### PR TITLE
Adds Mac GUI

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -47,3 +47,47 @@ jobs:
           name: czkawka_cli-${{ runner.os }}-${{ matrix.toolchain }}
           path: target/release/czkawka_cli
         if: ${{ matrix.type == 'release' }}
+
+  macos-gui:
+    strategy:
+      matrix:
+        toolchain: [ stable ]
+        type: [ release ]
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          override: true
+
+      - name: Install Homebrew
+        run: /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+      - name: Override link[WORKAROUND] # Looks that this is a bug with current homebrew or Github CI
+        run: rm '/usr/local/bin/2to3'
+
+      - name: Install GTK3
+        run: brew install rust gtk+3
+
+      - name: Build GUI Debug
+        run: cargo build --bin czkawka_gui
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: "-C debuginfo=0 -D warnings"
+        if: ${{ matrix.type == 'debug'}}
+
+      - name: Build GUI Release
+        run: cargo build --release --bin czkawka_gui
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: "-C debuginfo=0 -D warnings"
+        if: ${{ matrix.type == 'release'}}
+
+      - name: Store MacOS GUI
+        uses: actions/upload-artifact@v2
+        with:
+          name: czkawka_gui-${{ runner.os }}-${{ matrix.toolchain }}
+          path: target/release/czkawka_gui
+        if: ${{ matrix.type == 'release' }}

--- a/README.md
+++ b/README.md
@@ -50,7 +50,30 @@ After that the latest GTK 3 runtime must be installed from https://github.com/ts
 ## Usage
 ### Precompiled binaries
 Precompiled binaries are available here - https://github.com/qarmin/czkawka/releases/.  
-If the app does not run when clicking at a launcher, run it through a terminal.
+If the app does not run when clicking at a launcher, run it through a terminal.  
+You don't need to have any additional libraries for CLI Czkawka
+#### GUI Requirements
+##### Linux
+For Czkawka GUI you need to have at least GTK 3.22.  
+It should be installed by default on all the most popular distros.
+##### Windows
+`czkawka_gui.exe` extracted from zip file `windows_czkawka_gui.zip` needs to have all files inside around, because use them.
+If you want to move somewhere else exe binary and open it, you need to install GTK 3 runtime from site https://github.com/tschoonj/GTK-for-Windows-Runtime-Environment-Installer/releases
+##### MacOS
+For now you need to install manually GTK 3 libraries, because are dynamically loaded from OS(Help needed to use static linking).  
+To install it you need to type this commands in terminal
+```shell
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+brew install gtk+3
+```
+Next you need to go to place where you downloaded app and add executable bit
+```shell
+chmod +x mac_czkawka_gui
+```
+At the end you can open this app
+```shell
+./mac_czkawka_gui
+```
 
 ### Appimage
 Appimage files are available in release page - https://github.com/qarmin/czkawka/releases/
@@ -111,6 +134,12 @@ sudo apt install -y libgtk-3-dev
 ```shell
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh # Download the latest stable Rust
 sudo yum install gtk3-devel glib2-devel
+```
+#### MacOS
+You need to install Homebrew and GTK Libraries
+```shell
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+brew install rust gtk+3
 ```
 
 ### Compilation from source
@@ -228,3 +257,6 @@ Windows dark theme is used from AdMin repo - https://github.com/nrhodes91/AdMin 
 Program is completely free to use.
 
 "Gratis to uczciwa cena" - "Free is a fair price"
+
+## Dotations
+If you are using the app, I would appreciate a donation for its further development - https://github.com/sponsors/qarmin.

--- a/czkawka_core/src/common.rs
+++ b/czkawka_core/src/common.rs
@@ -63,7 +63,7 @@ impl Common {
         let temp_splits: Vec<&str> = expression.split('*').collect();
         let mut splits: Vec<&str> = Vec::new();
         for i in temp_splits {
-            if i != "" {
+            if !i.is_empty() {
                 splits.push(i);
             }
         }

--- a/czkawka_core/src/common_extensions.rs
+++ b/czkawka_core/src/common_extensions.rs
@@ -25,7 +25,7 @@ impl Extensions {
 
         let extensions: Vec<String> = allowed_extensions.split(',').map(String::from).collect();
         for mut extension in extensions {
-            if extension == "" || extension.replace('.', "").trim() == "" {
+            if extension.is_empty() || extension.replace('.', "").trim() == "" {
                 continue;
             }
 

--- a/czkawka_core/src/common_items.rs
+++ b/czkawka_core/src/common_items.rs
@@ -28,7 +28,7 @@ impl ExcludedItems {
         for expression in expressions {
             let expression: String = expression.trim().to_string();
 
-            if expression == "" {
+            if expression.is_empty() {
                 continue;
             }
             if expression == "DEFAULT" {

--- a/czkawka_core/src/same_music.rs
+++ b/czkawka_core/src/same_music.rs
@@ -395,10 +395,7 @@ impl SameMusic {
                     Some(t) => t.to_string(),
                     None => "".to_string(),
                 };
-                file_entry.year = match tag.year() {
-                    Some(t) => t,
-                    None => 0,
-                };
+                file_entry.year = tag.year().unwrap_or(0);
 
                 Some(Some(file_entry))
             })
@@ -474,7 +471,7 @@ impl SameMusic {
                 let mut hash_map: HashMap<String, Vec<FileEntry>> = Default::default();
                 for file_entry in vec_file_entry {
                     let title = file_entry.title.to_lowercase().trim().to_string();
-                    if title != "" {
+                    if !title.is_empty() {
                         hash_map.entry(title.clone()).or_insert_with(Vec::new);
                         hash_map.get_mut(title.as_str()).unwrap().push(file_entry);
                     }
@@ -501,7 +498,7 @@ impl SameMusic {
                 let mut hash_map: HashMap<String, Vec<FileEntry>> = Default::default();
                 for file_entry in vec_file_entry {
                     let artist = file_entry.artist.to_lowercase().trim().to_string();
-                    if artist != "" {
+                    if !artist.is_empty() {
                         hash_map.entry(artist.clone()).or_insert_with(Vec::new);
                         hash_map.get_mut(artist.as_str()).unwrap().push(file_entry);
                     }
@@ -528,7 +525,7 @@ impl SameMusic {
                 let mut hash_map: HashMap<String, Vec<FileEntry>> = Default::default();
                 for file_entry in vec_file_entry {
                     let album_title = file_entry.album_title.to_lowercase().trim().to_string();
-                    if album_title != "" {
+                    if !album_title.is_empty() {
                         hash_map.entry(album_title.clone()).or_insert_with(Vec::new);
                         hash_map.get_mut(album_title.as_str()).unwrap().push(file_entry);
                     }
@@ -555,7 +552,7 @@ impl SameMusic {
                 let mut hash_map: HashMap<String, Vec<FileEntry>> = Default::default();
                 for file_entry in vec_file_entry {
                     let album_artist = file_entry.album_artist.to_lowercase().trim().to_string();
-                    if album_artist != "" {
+                    if !album_artist.is_empty() {
                         hash_map.entry(album_artist.clone()).or_insert_with(Vec::new);
                         hash_map.get_mut(album_artist.as_str()).unwrap().push(file_entry);
                     }

--- a/czkawka_gui/src/connect_button_search.rs
+++ b/czkawka_gui/src/connect_button_search.rs
@@ -127,10 +127,7 @@ pub fn connect_button_search(
                 } else {
                     panic!("No radio button is pressed");
                 }
-                let minimal_file_size = match entry_duplicate_minimal_size.get_text().as_str().parse::<u64>() {
-                    Ok(t) => t,
-                    Err(_) => 1024, // By default
-                };
+                let minimal_file_size = entry_duplicate_minimal_size.get_text().as_str().parse::<u64>().unwrap_or(1024);
 
                 let glib_stop_sender = glib_stop_sender.clone();
                 let stop_receiver = stop_receiver.clone();
@@ -202,10 +199,7 @@ pub fn connect_button_search(
 
                 get_list_store(&scrolled_window_big_files_finder).clear();
 
-                let numbers_of_files_to_check = match entry_big_files_number.get_text().as_str().parse::<usize>() {
-                    Ok(t) => t,
-                    Err(_) => 50, // By default
-                };
+                let numbers_of_files_to_check = entry_big_files_number.get_text().as_str().parse::<usize>().unwrap_or(50);
 
                 let glib_stop_sender = glib_stop_sender.clone();
                 let stop_receiver = stop_receiver.clone();
@@ -258,10 +252,7 @@ pub fn connect_button_search(
                 let glib_stop_sender = glib_stop_sender.clone();
                 let stop_receiver = stop_receiver.clone();
 
-                let minimal_file_size = match entry_similar_images_minimal_size.get_text().as_str().parse::<u64>() {
-                    Ok(t) => t,
-                    Err(_) => 1024 * 16, // By default
-                };
+                let minimal_file_size = entry_similar_images_minimal_size.get_text().as_str().parse::<u64>().unwrap_or(1024 * 16);
 
                 let similarity;
                 if radio_button_similar_images_minimal.get_active() {
@@ -326,10 +317,8 @@ pub fn connect_button_search(
 
                 get_list_store(&scrolled_window_same_music_finder).clear();
 
-                let minimal_file_size = match entry_same_music_minimal_size.get_text().as_str().parse::<u64>() {
-                    Ok(t) => t,
-                    Err(_) => 1024, // By default
-                };
+                let minimal_file_size = entry_same_music_minimal_size.get_text().as_str().parse::<u64>().unwrap_or(1024);
+
                 let mut music_similarity: MusicSimilarity = MusicSimilarity::NONE;
 
                 if check_button_music_title.get_active() {


### PR DESCRIPTION
Fixes https://github.com/qarmin/czkawka/issues/11
Fixes https://github.com/qarmin/czkawka/issues/64

Thanks to ImplicitEmpiricism I have now basic instructions how to compile Czkawka on MacOS.
```
xcode-select --install
/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
brew install rust gtk+3 
curl -L https://github.com/qarmin/czkawka/archive/2.0.0.tar.gz | tar -zxvf -
cd czkawka-2.0.0
cargo run --bin czkawka_gui
```
Let's see if I can wrap it inside Github CI

Test binary - [czkawka_gui-macOS-stable.zip](https://github.com/qarmin/czkawka/files/5751893/czkawka_gui-macOS-stable.zip)

It should be able to run with help of terminal.
Probably after some changes it will be able to run when double clicking at it.

If you could open app, then please print here screenshot with OS info,