### PR TITLE
Only show preview when 1 image is selected

### DIFF
--- a/czkawka_gui/src/gui_data.rs
+++ b/czkawka_gui/src/gui_data.rs
@@ -371,6 +371,7 @@ impl GuiData {
 
         //// Dialog State - dialog with progress state, which allows to stop task
         let dialog_progress: gtk::Dialog = builder.get_object("dialog_progress").unwrap();
+        dialog_progress.set_title("Czkawka");
 
         let progress_bar_current_stage: gtk::ProgressBar = builder.get_object("progress_bar_current_stage").unwrap();
         let progress_bar_all_stages: gtk::ProgressBar = builder.get_object("progress_bar_all_stages").unwrap();

--- a/czkawka_gui/src/initialize_gui.rs
+++ b/czkawka_gui/src/initialize_gui.rs
@@ -228,7 +228,8 @@ pub fn initialize_gui(gui_data: &GuiData) {
 
                     let mut created_image = false;
 
-                    if !selected_rows.is_empty() && check_button_settings_show_preview_similar_images.get_active() {
+                    // Only show preview when selected is only one item, because there is no method to recognize current clicked item in multiselection
+                    if selected_rows.len() == 1 && check_button_settings_show_preview_similar_images.get_active() {
                         let tree_path = selected_rows[0].clone();
                         if let Some(proj_dirs) = ProjectDirs::from("pl", "Qarmin", "Czkawka") {
                             // TODO labels on {} are in testing stage, so we just ignore for now this warning until found better idea how to fix this


### PR DESCRIPTION
Fixes https://github.com/qarmin/czkawka/issues/173

For now I don't think that is any acceptable method(without too much complexity) to get current item when selecting more than 1 item