### PR TITLE
Move image cache to cache from config dir

### DIFF
--- a/czkawka_gui/src/saving_loading.rs
+++ b/czkawka_gui/src/saving_loading.rs
@@ -23,9 +23,9 @@ pub fn save_configuration(gui_data: &GuiData, manual_execution: bool) {
         return;
     }
     if let Some(proj_dirs) = ProjectDirs::from("pl", "Qarmin", "Czkawka") {
-        // Lin: /home/alice/.config/barapp
-        // Win: C:\Users\Alice\AppData\Roaming\Foo Corp\Bar App\config
-        // Mac: /Users/Alice/Library/Application Support/com.Foo-Corp.Bar-App
+        // Lin: /home/username/.config/czkawka
+        // Win: C:\Users\Username\AppData\Roaming\Qarmin\Czkawka\config
+        // Mac: /Users/Username/Library/Application Support/pl.Qarmin.Czkawka
 
         let config_dir = proj_dirs.config_dir();
         if config_dir.exists() {
@@ -166,9 +166,9 @@ pub fn load_configuration(gui_data: &GuiData, manual_execution: bool) {
     reset_text_view(&text_view_errors);
 
     if let Some(proj_dirs) = ProjectDirs::from("pl", "Qarmin", "Czkawka") {
-        // Lin: /home/alice/.config/barapp
-        // Win: C:\Users\Alice\AppData\Roaming\Foo Corp\Bar App\config
-        // Mac: /Users/Alice/Library/Application Support/com.Foo-Corp.Bar-App
+        // Lin: /home/username/.config/czkawka
+        // Win: C:\Users\Username\AppData\Roaming\Qarmin\Czkawka\config
+        // Mac: /Users/Username/Library/Application Support/pl.Qarmin.Czkawka
 
         let config_dir = proj_dirs.config_dir();
         let config_file = config_dir.join(Path::new(SAVE_FILE_NAME));

--- a/instructions/Instruction.md
+++ b/instructions/Instruction.md
@@ -130,12 +130,17 @@ For now Czkawka store only 2 files on disk:
 - `cache_similar_image.txt` - stores cache data and hashes which may be used later without needing to compute image hash again - DO NOT TRY TO EDIT THIS FILE MANUALLY! - editing this file may cause app crashes.
 
 
-This files are located in this path
+First file is located in this path
 
 Linux - `/home/username/.config/czkawka`  
 Mac - `/Users/username/Library/Application Support/pl.Qarmin.Czkawka`  
-Windows - `C:\Users\Alice\AppData\Roaming\Qarmin\Czkawka\config`
+Windows - `C:\Users\Username\AppData\Roaming\Qarmin\Czkawka\config`
 
+Second with cache here:
+
+Linux - `/home/username/.cache/czkawka`  
+Mac - `/Users/Username/Library/Caches/pl.Qarmin.Czkawka`  
+Windows - `C:\Users\Username\AppData\Local\Qarmin\Czkawka\cache`
   
 ## GUI GTK
 <img src="https://user-images.githubusercontent.com/41945903/103002387-14d1b800-452f-11eb-967e-9d5905dd6db5.png" width="800" />


### PR DESCRIPTION
Fixes https://github.com/qarmin/czkawka/issues/196

I was think before about putting image cache to cache dir, but I want to hav everything at one place.
Probably it is better to put it to special localization.

Only Czkawka 2.2 will have an option to move image cache from config dirs to cache dirs.   