### PR TITLE
Keep original file if replacing duplicate with hardlink fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,6 +580,7 @@ dependencies = [
  "img_hash",
  "rayon",
  "rodio",
+ "tempfile",
  "xxhash-rust",
  "zip",
 ]
@@ -1825,6 +1826,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
 name = "proc-macro-crate"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1910,6 +1917,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "rayon"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1973,6 +2020,15 @@ name = "regex-syntax"
 version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "ring"
@@ -2354,6 +2410,20 @@ dependencies = [
  "libc",
  "redox_syscall 0.1.57",
  "xattr",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "rand",
+ "redox_syscall 0.2.4",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]

--- a/czkawka_core/Cargo.toml
+++ b/czkawka_core/Cargo.toml
@@ -39,6 +39,8 @@ blake3 = "0.3"
 crc32fast = "1.2.1"
 xxhash-rust = { version = "0.8.1", features = ["xxh3"] }
 
+tempfile = "3.1"
+
 [features]
 default = []
 


### PR DESCRIPTION
If the user could not create a hard link (due to permissions or
different block devices) then czkawka lost the duplicate file.

```
$ mkdir hardlink
$ cd hardlink
$ echo a > a
$ cp a b
$ chown thetestuser:thetestuser a
$ ls -il .

25169246 -rw-rw-r-- 1 thetestuser thetestuser 2 Feb  7 11:18 a
25169641 -rw-rw-r-- 1 thomas      thomas      2 Feb  7 11:18 b

$ cargo run --bin czkawka_cli dup --directories $(pwd) -m 1 -f
test101.result --delete-method HARD

[...]
-------------------------------WARNINGS--------------------------------
Failed to link /home/thomas/Development/czkawka/hardlink/b ->
/home/thomas/Development/czkawka/hardlink/a
---------------------------END OF WARNINGS-----------------------------

$ ls -il .
25169246 -rw-rw-r-- 1 thetestuser thetestuser 2 Feb  7 11:18 a
```

Now czkawka keeps all files and the warning provides more information
why czkawka can't replace the duplicate with a hard link.

```
$ cargo run --bin czkawka_cli dup --directories $(pwd) -m 1 -f
test101.result --delete-method HARD

-------------------------------WARNINGS--------------------------------
Failed to link /home/thomas/Development/czkawka/hardlink/b ->
/home/thomas/Development/czkawka/hardlink/a (Operation not permitted (os
error 1))
---------------------------END OF WARNINGS-----------------------------
[...]

25169246 -rw-rw-r-- 1 thetestuser thetestuser 2 Feb  7 11:18 a
25169641 -rw-rw-r-- 1 thomas      thomas      2 Feb  7 11:18 b
```