### PR TITLE
Windows taskbar progress support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,6 +600,7 @@ dependencies = [
  "humansize",
  "image",
  "open",
+ "winapi",
 ]
 
 [[package]]

--- a/czkawka_gui/Cargo.toml
+++ b/czkawka_gui/Cargo.toml
@@ -32,7 +32,7 @@ open = "1.4.0"
 image = "0.23.12"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.9", features = ["combaseapi", "guiddef", "objbase", "shobjidl_core", "unknwnbase", "windef", "winerror", "wtypesbase", "winuser"] }
+winapi = { version = "0.3.9", features = ["combaseapi", "objbase", "shobjidl_core", "unknwnbase", "windef", "winerror", "wtypesbase", "winuser"] }
 
 [dependencies.gtk]
 version = "0.9.2"

--- a/czkawka_gui/Cargo.toml
+++ b/czkawka_gui/Cargo.toml
@@ -32,7 +32,7 @@ open = "1.4.0"
 image = "0.23.12"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.9", features = ["combaseapi", "objbase", "shobjidl_core", "unknwnbase", "windef", "winerror", "wtypesbase", "winuser"] }
+winapi = { version = "0.3.9", features = ["combaseapi", "objbase", "shobjidl_core", "windef", "winerror", "wtypesbase", "winuser"] }
 
 [dependencies.gtk]
 version = "0.9.2"

--- a/czkawka_gui/Cargo.toml
+++ b/czkawka_gui/Cargo.toml
@@ -31,6 +31,9 @@ open = "1.4.0"
 # To get image preview
 image = "0.23.12"
 
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3.9", features = ["combaseapi", "guiddef", "objbase", "shobjidl_core", "unknwnbase", "windef", "winerror", "wtypesbase", "winuser"] }
+
 [dependencies.gtk]
 version = "0.9.2"
 default-features = false # just in case

--- a/czkawka_gui/src/connect_button_search.rs
+++ b/czkawka_gui/src/connect_button_search.rs
@@ -113,8 +113,6 @@ pub fn connect_button_search(
         // Resets progress bars
         progress_bar_all_stages.set_fraction(0 as f64);
         progress_bar_current_stage.set_fraction(0 as f64);
-        taskbar_state.as_ref().set_progress_state(TBPF_NOPROGRESS);
-        taskbar_state.as_ref().set_progress_value(0, 1);
 
         reset_text_view(&text_view_errors);
 
@@ -410,6 +408,8 @@ pub fn connect_button_search(
         // Show progress dialog
         if show_dialog.load(Ordering::Relaxed) {
             window_progress.show();
+            taskbar_state.show();
+            taskbar_state.set_progress_state(TBPF_NOPROGRESS);
         }
     });
 }

--- a/czkawka_gui/src/connect_button_search.rs
+++ b/czkawka_gui/src/connect_button_search.rs
@@ -113,11 +113,8 @@ pub fn connect_button_search(
         // Resets progress bars
         progress_bar_all_stages.set_fraction(0 as f64);
         progress_bar_current_stage.set_fraction(0 as f64);
-        #[allow(unused_must_use)]
-        if let Some(taskbar_prog) = taskbar_state.as_ref() {
-            taskbar_prog.set_progress_state(TBPF_NOPROGRESS);
-            taskbar_prog.set_progress_value(0, 1);
-        }
+        taskbar_state.as_ref().set_progress_state(TBPF_NOPROGRESS);
+        taskbar_state.as_ref().set_progress_value(0, 1);
 
         reset_text_view(&text_view_errors);
 

--- a/czkawka_gui/src/connect_button_search.rs
+++ b/czkawka_gui/src/connect_button_search.rs
@@ -408,8 +408,8 @@ pub fn connect_button_search(
         // Show progress dialog
         if show_dialog.load(Ordering::Relaxed) {
             window_progress.show();
-            taskbar_state.show();
-            taskbar_state.set_progress_state(TBPF_NOPROGRESS);
+            taskbar_state.borrow().show();
+            taskbar_state.borrow().set_progress_state(TBPF_NOPROGRESS);
         }
     });
 }

--- a/czkawka_gui/src/connect_button_search.rs
+++ b/czkawka_gui/src/connect_button_search.rs
@@ -21,6 +21,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread;
 
+use crate::taskbar_progress::tbp_flags::TBPF_NOPROGRESS;
+
 #[allow(clippy::too_many_arguments)]
 pub fn connect_button_search(
     gui_data: &GuiData,
@@ -83,6 +85,7 @@ pub fn connect_button_search(
     let grid_progress_stages = gui_data.progress_window.grid_progress_stages.clone();
     let progress_bar_current_stage = gui_data.progress_window.progress_bar_current_stage.clone();
     let progress_bar_all_stages = gui_data.progress_window.progress_bar_all_stages.clone();
+    let taskbar_state = gui_data.taskbar_state.clone();
     let image_preview_similar_images = gui_data.main_notebook.image_preview_similar_images.clone();
     let radio_button_hash_type_blake3 = gui_data.main_notebook.radio_button_hash_type_blake3.clone();
     let radio_button_hash_type_crc32 = gui_data.main_notebook.radio_button_hash_type_crc32.clone();
@@ -110,6 +113,11 @@ pub fn connect_button_search(
         // Resets progress bars
         progress_bar_all_stages.set_fraction(0 as f64);
         progress_bar_current_stage.set_fraction(0 as f64);
+        #[allow(unused_must_use)]
+        if let Some(taskbar_prog) = taskbar_state.as_ref() {
+            taskbar_prog.set_progress_state(TBPF_NOPROGRESS);
+            taskbar_prog.set_progress_value(0, 1);
+        }
 
         reset_text_view(&text_view_errors);
 

--- a/czkawka_gui/src/connect_compute_results.rs
+++ b/czkawka_gui/src/connect_compute_results.rs
@@ -4,6 +4,7 @@ extern crate gtk;
 use crate::gui_data::GuiData;
 use crate::help_functions::*;
 use crate::notebook_enums::*;
+use crate::taskbar_progress::tbp_flags::TBPF_NOPROGRESS;
 use chrono::NaiveDateTime;
 use czkawka_core::duplicate::CheckingMethod;
 use czkawka_core::same_music::MusicSimilarity;
@@ -39,11 +40,17 @@ pub fn connect_compute_results(gui_data: &GuiData, glib_stop_receiver: Receiver<
     let shared_same_music_state = gui_data.shared_same_music_state.clone();
     let buttons_names = gui_data.bottom_buttons.buttons_names.clone();
     let window_progress = gui_data.progress_window.window_progress.clone();
+    let taskbar_state = gui_data.taskbar_state.clone();
 
     glib_stop_receiver.attach(None, move |msg| {
         buttons_search.show();
 
         window_progress.hide();
+
+        #[allow(unused_must_use)]
+        if let Some(taskbar_prog) = taskbar_state.as_ref() {
+            taskbar_prog.set_progress_state(TBPF_NOPROGRESS);
+        }
 
         // Restore clickability to main notebook
         notebook_main.set_sensitive(true);

--- a/czkawka_gui/src/connect_compute_results.rs
+++ b/czkawka_gui/src/connect_compute_results.rs
@@ -46,7 +46,7 @@ pub fn connect_compute_results(gui_data: &GuiData, glib_stop_receiver: Receiver<
 
         window_progress.hide();
 
-        taskbar_state.hide();
+        taskbar_state.borrow().hide();
 
         // Restore clickability to main notebook
         notebook_main.set_sensitive(true);

--- a/czkawka_gui/src/connect_compute_results.rs
+++ b/czkawka_gui/src/connect_compute_results.rs
@@ -4,7 +4,6 @@ extern crate gtk;
 use crate::gui_data::GuiData;
 use crate::help_functions::*;
 use crate::notebook_enums::*;
-use crate::taskbar_progress::tbp_flags::TBPF_NOPROGRESS;
 use chrono::NaiveDateTime;
 use czkawka_core::duplicate::CheckingMethod;
 use czkawka_core::same_music::MusicSimilarity;
@@ -47,7 +46,7 @@ pub fn connect_compute_results(gui_data: &GuiData, glib_stop_receiver: Receiver<
 
         window_progress.hide();
 
-        taskbar_state.as_ref().set_progress_state(TBPF_NOPROGRESS);
+        taskbar_state.hide();
 
         // Restore clickability to main notebook
         notebook_main.set_sensitive(true);

--- a/czkawka_gui/src/connect_compute_results.rs
+++ b/czkawka_gui/src/connect_compute_results.rs
@@ -47,10 +47,7 @@ pub fn connect_compute_results(gui_data: &GuiData, glib_stop_receiver: Receiver<
 
         window_progress.hide();
 
-        #[allow(unused_must_use)]
-        if let Some(taskbar_prog) = taskbar_state.as_ref() {
-            taskbar_prog.set_progress_state(TBPF_NOPROGRESS);
-        }
+        taskbar_state.as_ref().set_progress_state(TBPF_NOPROGRESS);
 
         // Restore clickability to main notebook
         notebook_main.set_sensitive(true);

--- a/czkawka_gui/src/connect_progress_window.rs
+++ b/czkawka_gui/src/connect_progress_window.rs
@@ -41,7 +41,7 @@ pub fn connect_progress_window(
                                 // progress_bar_all_stages.hide();
                                 progress_bar_all_stages.set_fraction(0 as f64);
                                 label_stage.set_text(format!("Scanned size of {} files", item.files_checked).as_str());
-                                taskbar_state.set_progress_state(TBPF_INDETERMINATE);
+                                taskbar_state.borrow().set_progress_state(TBPF_INDETERMINATE);
                             }
                             // Hash - first 1KB file
                             1 => {
@@ -50,13 +50,13 @@ pub fn connect_progress_window(
                                 if item.files_to_check != 0 {
                                     progress_bar_all_stages.set_fraction((1f64 + (item.files_checked) as f64 / item.files_to_check as f64) / (item.max_stage + 1) as f64);
                                     progress_bar_current_stage.set_fraction((item.files_checked) as f64 / item.files_to_check as f64);
-                                    taskbar_state.set_progress_value((item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
-                                    taskbar_state.set_progress_state(TBPF_NORMAL);
+                                    taskbar_state.borrow().set_progress_value((item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
+                                    taskbar_state.borrow().set_progress_state(TBPF_NORMAL);
                                 } else {
                                     progress_bar_all_stages.set_fraction((1f64) / (item.max_stage + 1) as f64);
                                     progress_bar_current_stage.set_fraction(0f64);
-                                    taskbar_state.set_progress_value(1, 1 + item.max_stage as u64);
-                                    taskbar_state.set_progress_state(TBPF_NORMAL);
+                                    taskbar_state.borrow().set_progress_value(1, 1 + item.max_stage as u64);
+                                    taskbar_state.borrow().set_progress_state(TBPF_NORMAL);
                                 }
                                 label_stage.set_text(format!("Analyzed partial hash of {}/{} files", item.files_checked, item.files_to_check).as_str());
                             }
@@ -65,11 +65,13 @@ pub fn connect_progress_window(
                                 if item.files_to_check != 0 {
                                     progress_bar_all_stages.set_fraction((2f64 + (item.files_checked) as f64 / item.files_to_check as f64) / (item.max_stage + 1) as f64);
                                     progress_bar_current_stage.set_fraction((item.files_checked) as f64 / item.files_to_check as f64);
-                                    taskbar_state.set_progress_value((2 * item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
+                                    taskbar_state
+                                        .borrow()
+                                        .set_progress_value((2 * item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
                                 } else {
                                     progress_bar_all_stages.set_fraction((2f64) / (item.max_stage + 1) as f64);
                                     progress_bar_current_stage.set_fraction(0f64);
-                                    taskbar_state.set_progress_value(2, 1 + item.max_stage as u64);
+                                    taskbar_state.borrow().set_progress_value(2, 1 + item.max_stage as u64);
                                 }
 
                                 if item.checking_method == duplicate::CheckingMethod::Hash {
@@ -88,14 +90,14 @@ pub fn connect_progress_window(
                         grid_progress_stages.hide();
 
                         label_stage.set_text(format!("Scanned name of {} files", item.files_checked).as_str());
-                        taskbar_state.set_progress_state(TBPF_INDETERMINATE);
+                        taskbar_state.borrow().set_progress_state(TBPF_INDETERMINATE);
                     }
                     duplicate::CheckingMethod::Size => {
                         label_stage.show();
                         grid_progress_stages.hide();
 
                         label_stage.set_text(format!("Scanned size {} files", item.files_checked).as_str());
-                        taskbar_state.set_progress_state(TBPF_INDETERMINATE);
+                        taskbar_state.borrow().set_progress_state(TBPF_INDETERMINATE);
                     }
                     duplicate::CheckingMethod::None => {
                         panic!();
@@ -112,7 +114,7 @@ pub fn connect_progress_window(
         let future = async move {
             while let Some(item) = futures_receiver_empty_files.next().await {
                 label_stage.set_text(format!("Scanned {} files", item.files_checked).as_str());
-                taskbar_state.set_progress_state(TBPF_INDETERMINATE);
+                taskbar_state.borrow().set_progress_state(TBPF_INDETERMINATE);
             }
         };
         main_context.spawn_local(future);
@@ -124,7 +126,7 @@ pub fn connect_progress_window(
         let future = async move {
             while let Some(item) = futures_receiver_empty_folder.next().await {
                 label_stage.set_text(format!("Scanned {} folders", item.folders_checked).as_str());
-                taskbar_state.set_progress_state(TBPF_INDETERMINATE);
+                taskbar_state.borrow().set_progress_state(TBPF_INDETERMINATE);
             }
         };
         main_context.spawn_local(future);
@@ -136,7 +138,7 @@ pub fn connect_progress_window(
         let future = async move {
             while let Some(item) = futures_receiver_big_files.next().await {
                 label_stage.set_text(format!("Scanned {} files", item.files_checked).as_str());
-                taskbar_state.set_progress_state(TBPF_INDETERMINATE);
+                taskbar_state.borrow().set_progress_state(TBPF_INDETERMINATE);
             }
         };
         main_context.spawn_local(future);
@@ -153,20 +155,20 @@ pub fn connect_progress_window(
                     0 => {
                         progress_bar_current_stage.hide();
                         label_stage.set_text(format!("Scanned {} files", item.music_checked).as_str());
-                        taskbar_state.set_progress_state(TBPF_INDETERMINATE);
+                        taskbar_state.borrow().set_progress_state(TBPF_INDETERMINATE);
                     }
                     1 => {
                         progress_bar_current_stage.show();
                         if item.music_to_check != 0 {
                             progress_bar_all_stages.set_fraction((1f64 + (item.music_checked) as f64 / item.music_to_check as f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction((item.music_checked) as f64 / item.music_to_check as f64);
-                            taskbar_state.set_progress_value((item.music_to_check + item.music_checked) as u64, item.music_to_check as u64 * (item.max_stage + 1) as u64);
-                            taskbar_state.set_progress_state(TBPF_NORMAL);
+                            taskbar_state.borrow().set_progress_value((item.music_to_check + item.music_checked) as u64, item.music_to_check as u64 * (item.max_stage + 1) as u64);
+                            taskbar_state.borrow().set_progress_state(TBPF_NORMAL);
                         } else {
                             progress_bar_all_stages.set_fraction((1f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction(0f64);
-                            taskbar_state.set_progress_value(1, (item.max_stage + 1) as u64);
-                            taskbar_state.set_progress_state(TBPF_NORMAL);
+                            taskbar_state.borrow().set_progress_value(1, (item.max_stage + 1) as u64);
+                            taskbar_state.borrow().set_progress_state(TBPF_NORMAL);
                         }
                         label_stage.set_text(format!("Reading tags of {}/{} music files", item.music_checked, item.music_to_check).as_str());
                     }
@@ -174,11 +176,13 @@ pub fn connect_progress_window(
                         if item.music_to_check != 0 {
                             progress_bar_all_stages.set_fraction((2f64 + (item.music_checked) as f64 / item.music_to_check as f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction((item.music_checked) as f64 / item.music_to_check as f64);
-                            taskbar_state.set_progress_value((2 * item.music_to_check + item.music_checked) as u64, item.music_to_check as u64 * (item.max_stage + 1) as u64);
+                            taskbar_state
+                                .borrow()
+                                .set_progress_value((2 * item.music_to_check + item.music_checked) as u64, item.music_to_check as u64 * (item.max_stage + 1) as u64);
                         } else {
                             progress_bar_all_stages.set_fraction((2f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction(0f64);
-                            taskbar_state.set_progress_value(2, (item.max_stage + 1) as u64);
+                            taskbar_state.borrow().set_progress_value(2, (item.max_stage + 1) as u64);
                         }
                         label_stage.set_text(format!("Checking for duplicates of {}/{} music files", item.music_checked, item.music_to_check).as_str());
                     }
@@ -202,20 +206,22 @@ pub fn connect_progress_window(
                     0 => {
                         progress_bar_current_stage.hide();
                         label_stage.set_text(format!("Scanned {} files", item.images_checked).as_str());
-                        taskbar_state.set_progress_state(TBPF_INDETERMINATE);
+                        taskbar_state.borrow().set_progress_state(TBPF_INDETERMINATE);
                     }
                     1 => {
                         progress_bar_current_stage.show();
                         if item.images_to_check != 0 {
                             progress_bar_all_stages.set_fraction((1f64 + (item.images_checked) as f64 / item.images_to_check as f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction((item.images_checked) as f64 / item.images_to_check as f64);
-                            taskbar_state.set_progress_value((item.images_to_check + item.images_checked) as u64, item.images_to_check as u64 * (item.max_stage + 1) as u64);
-                            taskbar_state.set_progress_state(TBPF_NORMAL);
+                            taskbar_state
+                                .borrow()
+                                .set_progress_value((item.images_to_check + item.images_checked) as u64, item.images_to_check as u64 * (item.max_stage + 1) as u64);
+                            taskbar_state.borrow().set_progress_state(TBPF_NORMAL);
                         } else {
                             progress_bar_all_stages.set_fraction((1f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction(0f64);
-                            taskbar_state.set_progress_value(1, (item.max_stage + 1) as u64);
-                            taskbar_state.set_progress_state(TBPF_NORMAL);
+                            taskbar_state.borrow().set_progress_value(1, (item.max_stage + 1) as u64);
+                            taskbar_state.borrow().set_progress_state(TBPF_NORMAL);
                         }
                         label_stage.set_text(format!("Hashing {}/{} image", item.images_checked, item.images_to_check).as_str());
                     }
@@ -234,7 +240,7 @@ pub fn connect_progress_window(
         let future = async move {
             while let Some(item) = futures_receiver_temporary.next().await {
                 label_stage.set_text(format!("Scanned {} files", item.files_checked).as_str());
-                taskbar_state.set_progress_state(TBPF_INDETERMINATE);
+                taskbar_state.borrow().set_progress_state(TBPF_INDETERMINATE);
             }
         };
         main_context.spawn_local(future);
@@ -251,20 +257,20 @@ pub fn connect_progress_window(
                     0 => {
                         progress_bar_current_stage.hide();
                         label_stage.set_text(format!("Scanned {} files", item.files_checked).as_str());
-                        taskbar_state.set_progress_state(TBPF_INDETERMINATE);
+                        taskbar_state.borrow().set_progress_state(TBPF_INDETERMINATE);
                     }
                     1 => {
                         progress_bar_current_stage.show();
                         if item.files_to_check != 0 {
                             progress_bar_all_stages.set_fraction((1f64 + (item.files_checked) as f64 / item.files_to_check as f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction((item.files_checked) as f64 / item.files_to_check as f64);
-                            taskbar_state.set_progress_value((item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
-                            taskbar_state.set_progress_state(TBPF_NORMAL);
+                            taskbar_state.borrow().set_progress_value((item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
+                            taskbar_state.borrow().set_progress_state(TBPF_NORMAL);
                         } else {
                             progress_bar_all_stages.set_fraction((1f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction(0f64);
-                            taskbar_state.set_progress_value(1, (item.max_stage + 1) as u64);
-                            taskbar_state.set_progress_state(TBPF_NORMAL);
+                            taskbar_state.borrow().set_progress_value(1, (item.max_stage + 1) as u64);
+                            taskbar_state.borrow().set_progress_state(TBPF_NORMAL);
                         }
                         label_stage.set_text(format!("Checking {}/{} file", item.files_checked, item.files_to_check).as_str());
                     }
@@ -283,7 +289,7 @@ pub fn connect_progress_window(
         let future = async move {
             while let Some(item) = futures_receiver_invalid_symlinks.next().await {
                 label_stage.set_text(format!("Scanned {} files", item.files_checked).as_str());
-                taskbar_state.set_progress_state(TBPF_INDETERMINATE);
+                taskbar_state.borrow().set_progress_state(TBPF_INDETERMINATE);
             }
         };
         main_context.spawn_local(future);
@@ -300,20 +306,20 @@ pub fn connect_progress_window(
                     0 => {
                         progress_bar_current_stage.hide();
                         label_stage.set_text(format!("Scanned {} files", item.files_checked).as_str());
-                        taskbar_state.set_progress_state(TBPF_INDETERMINATE);
+                        taskbar_state.borrow().set_progress_state(TBPF_INDETERMINATE);
                     }
                     1 => {
                         progress_bar_current_stage.show();
                         if item.files_to_check != 0 {
                             progress_bar_all_stages.set_fraction((1f64 + (item.files_checked) as f64 / item.files_to_check as f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction((item.files_checked) as f64 / item.files_to_check as f64);
-                            taskbar_state.set_progress_value((item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
-                            taskbar_state.set_progress_state(TBPF_NORMAL);
+                            taskbar_state.borrow().set_progress_value((item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
+                            taskbar_state.borrow().set_progress_state(TBPF_NORMAL);
                         } else {
                             progress_bar_all_stages.set_fraction((1f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction(0f64);
-                            taskbar_state.set_progress_value(1, (item.max_stage + 1) as u64);
-                            taskbar_state.set_progress_state(TBPF_NORMAL);
+                            taskbar_state.borrow().set_progress_value(1, (item.max_stage + 1) as u64);
+                            taskbar_state.borrow().set_progress_state(TBPF_NORMAL);
                         }
                         label_stage.set_text(format!("Checking {}/{} files", item.files_checked, item.files_to_check).as_str());
                     }

--- a/czkawka_gui/src/connect_progress_window.rs
+++ b/czkawka_gui/src/connect_progress_window.rs
@@ -41,7 +41,7 @@ pub fn connect_progress_window(
                                 // progress_bar_all_stages.hide();
                                 progress_bar_all_stages.set_fraction(0 as f64);
                                 label_stage.set_text(format!("Scanned size of {} files", item.files_checked).as_str());
-                                taskbar_state.as_ref().set_progress_state(TBPF_INDETERMINATE);
+                                taskbar_state.set_progress_state(TBPF_INDETERMINATE);
                             }
                             // Hash - first 1KB file
                             1 => {
@@ -50,13 +50,13 @@ pub fn connect_progress_window(
                                 if item.files_to_check != 0 {
                                     progress_bar_all_stages.set_fraction((1f64 + (item.files_checked) as f64 / item.files_to_check as f64) / (item.max_stage + 1) as f64);
                                     progress_bar_current_stage.set_fraction((item.files_checked) as f64 / item.files_to_check as f64);
-                                    taskbar_state.as_ref().set_progress_value((item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
-                                    taskbar_state.as_ref().set_progress_state(TBPF_NORMAL);
+                                    taskbar_state.set_progress_value((item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
+                                    taskbar_state.set_progress_state(TBPF_NORMAL);
                                 } else {
                                     progress_bar_all_stages.set_fraction((1f64) / (item.max_stage + 1) as f64);
                                     progress_bar_current_stage.set_fraction(0f64);
-                                    taskbar_state.as_ref().set_progress_value(1, 1 + item.max_stage as u64);
-                                    taskbar_state.as_ref().set_progress_state(TBPF_NORMAL);
+                                    taskbar_state.set_progress_value(1, 1 + item.max_stage as u64);
+                                    taskbar_state.set_progress_state(TBPF_NORMAL);
                                 }
                                 label_stage.set_text(format!("Analyzed partial hash of {}/{} files", item.files_checked, item.files_to_check).as_str());
                             }
@@ -65,13 +65,11 @@ pub fn connect_progress_window(
                                 if item.files_to_check != 0 {
                                     progress_bar_all_stages.set_fraction((2f64 + (item.files_checked) as f64 / item.files_to_check as f64) / (item.max_stage + 1) as f64);
                                     progress_bar_current_stage.set_fraction((item.files_checked) as f64 / item.files_to_check as f64);
-                                    taskbar_state
-                                        .as_ref()
-                                        .set_progress_value((2 * item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
+                                    taskbar_state.set_progress_value((2 * item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
                                 } else {
                                     progress_bar_all_stages.set_fraction((2f64) / (item.max_stage + 1) as f64);
                                     progress_bar_current_stage.set_fraction(0f64);
-                                    taskbar_state.as_ref().set_progress_value(2, 1 + item.max_stage as u64);
+                                    taskbar_state.set_progress_value(2, 1 + item.max_stage as u64);
                                 }
 
                                 if item.checking_method == duplicate::CheckingMethod::Hash {
@@ -90,14 +88,14 @@ pub fn connect_progress_window(
                         grid_progress_stages.hide();
 
                         label_stage.set_text(format!("Scanned name of {} files", item.files_checked).as_str());
-                        taskbar_state.as_ref().set_progress_state(TBPF_INDETERMINATE);
+                        taskbar_state.set_progress_state(TBPF_INDETERMINATE);
                     }
                     duplicate::CheckingMethod::Size => {
                         label_stage.show();
                         grid_progress_stages.hide();
 
                         label_stage.set_text(format!("Scanned size {} files", item.files_checked).as_str());
-                        taskbar_state.as_ref().set_progress_state(TBPF_INDETERMINATE);
+                        taskbar_state.set_progress_state(TBPF_INDETERMINATE);
                     }
                     duplicate::CheckingMethod::None => {
                         panic!();
@@ -114,7 +112,7 @@ pub fn connect_progress_window(
         let future = async move {
             while let Some(item) = futures_receiver_empty_files.next().await {
                 label_stage.set_text(format!("Scanned {} files", item.files_checked).as_str());
-                taskbar_state.as_ref().set_progress_state(TBPF_INDETERMINATE);
+                taskbar_state.set_progress_state(TBPF_INDETERMINATE);
             }
         };
         main_context.spawn_local(future);
@@ -126,7 +124,7 @@ pub fn connect_progress_window(
         let future = async move {
             while let Some(item) = futures_receiver_empty_folder.next().await {
                 label_stage.set_text(format!("Scanned {} folders", item.folders_checked).as_str());
-                taskbar_state.as_ref().set_progress_state(TBPF_INDETERMINATE);
+                taskbar_state.set_progress_state(TBPF_INDETERMINATE);
             }
         };
         main_context.spawn_local(future);
@@ -138,7 +136,7 @@ pub fn connect_progress_window(
         let future = async move {
             while let Some(item) = futures_receiver_big_files.next().await {
                 label_stage.set_text(format!("Scanned {} files", item.files_checked).as_str());
-                taskbar_state.as_ref().set_progress_state(TBPF_INDETERMINATE);
+                taskbar_state.set_progress_state(TBPF_INDETERMINATE);
             }
         };
         main_context.spawn_local(future);
@@ -155,20 +153,20 @@ pub fn connect_progress_window(
                     0 => {
                         progress_bar_current_stage.hide();
                         label_stage.set_text(format!("Scanned {} files", item.music_checked).as_str());
-                        taskbar_state.as_ref().set_progress_state(TBPF_INDETERMINATE);
+                        taskbar_state.set_progress_state(TBPF_INDETERMINATE);
                     }
                     1 => {
                         progress_bar_current_stage.show();
                         if item.music_to_check != 0 {
                             progress_bar_all_stages.set_fraction((1f64 + (item.music_checked) as f64 / item.music_to_check as f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction((item.music_checked) as f64 / item.music_to_check as f64);
-                            taskbar_state.as_ref().set_progress_value((item.music_to_check + item.music_checked) as u64, item.music_to_check as u64 * (item.max_stage + 1) as u64);
-                            taskbar_state.as_ref().set_progress_state(TBPF_NORMAL);
+                            taskbar_state.set_progress_value((item.music_to_check + item.music_checked) as u64, item.music_to_check as u64 * (item.max_stage + 1) as u64);
+                            taskbar_state.set_progress_state(TBPF_NORMAL);
                         } else {
                             progress_bar_all_stages.set_fraction((1f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction(0f64);
-                            taskbar_state.as_ref().set_progress_value(1, (item.max_stage + 1) as u64);
-                            taskbar_state.as_ref().set_progress_state(TBPF_NORMAL);
+                            taskbar_state.set_progress_value(1, (item.max_stage + 1) as u64);
+                            taskbar_state.set_progress_state(TBPF_NORMAL);
                         }
                         label_stage.set_text(format!("Reading tags of {}/{} music files", item.music_checked, item.music_to_check).as_str());
                     }
@@ -176,13 +174,11 @@ pub fn connect_progress_window(
                         if item.music_to_check != 0 {
                             progress_bar_all_stages.set_fraction((2f64 + (item.music_checked) as f64 / item.music_to_check as f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction((item.music_checked) as f64 / item.music_to_check as f64);
-                            taskbar_state
-                                .as_ref()
-                                .set_progress_value((2 * item.music_to_check + item.music_checked) as u64, item.music_to_check as u64 * (item.max_stage + 1) as u64);
+                            taskbar_state.set_progress_value((2 * item.music_to_check + item.music_checked) as u64, item.music_to_check as u64 * (item.max_stage + 1) as u64);
                         } else {
                             progress_bar_all_stages.set_fraction((2f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction(0f64);
-                            taskbar_state.as_ref().set_progress_value(2, (item.max_stage + 1) as u64);
+                            taskbar_state.set_progress_value(2, (item.max_stage + 1) as u64);
                         }
                         label_stage.set_text(format!("Checking for duplicates of {}/{} music files", item.music_checked, item.music_to_check).as_str());
                     }
@@ -206,22 +202,20 @@ pub fn connect_progress_window(
                     0 => {
                         progress_bar_current_stage.hide();
                         label_stage.set_text(format!("Scanned {} files", item.images_checked).as_str());
-                        taskbar_state.as_ref().set_progress_state(TBPF_INDETERMINATE);
+                        taskbar_state.set_progress_state(TBPF_INDETERMINATE);
                     }
                     1 => {
                         progress_bar_current_stage.show();
                         if item.images_to_check != 0 {
                             progress_bar_all_stages.set_fraction((1f64 + (item.images_checked) as f64 / item.images_to_check as f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction((item.images_checked) as f64 / item.images_to_check as f64);
-                            taskbar_state
-                                .as_ref()
-                                .set_progress_value((item.images_to_check + item.images_checked) as u64, item.images_to_check as u64 * (item.max_stage + 1) as u64);
-                            taskbar_state.as_ref().set_progress_state(TBPF_NORMAL);
+                            taskbar_state.set_progress_value((item.images_to_check + item.images_checked) as u64, item.images_to_check as u64 * (item.max_stage + 1) as u64);
+                            taskbar_state.set_progress_state(TBPF_NORMAL);
                         } else {
                             progress_bar_all_stages.set_fraction((1f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction(0f64);
-                            taskbar_state.as_ref().set_progress_value(1, (item.max_stage + 1) as u64);
-                            taskbar_state.as_ref().set_progress_state(TBPF_NORMAL);
+                            taskbar_state.set_progress_value(1, (item.max_stage + 1) as u64);
+                            taskbar_state.set_progress_state(TBPF_NORMAL);
                         }
                         label_stage.set_text(format!("Hashing {}/{} image", item.images_checked, item.images_to_check).as_str());
                     }
@@ -240,7 +234,7 @@ pub fn connect_progress_window(
         let future = async move {
             while let Some(item) = futures_receiver_temporary.next().await {
                 label_stage.set_text(format!("Scanned {} files", item.files_checked).as_str());
-                taskbar_state.as_ref().set_progress_state(TBPF_INDETERMINATE);
+                taskbar_state.set_progress_state(TBPF_INDETERMINATE);
             }
         };
         main_context.spawn_local(future);
@@ -257,20 +251,20 @@ pub fn connect_progress_window(
                     0 => {
                         progress_bar_current_stage.hide();
                         label_stage.set_text(format!("Scanned {} files", item.files_checked).as_str());
-                        taskbar_state.as_ref().set_progress_state(TBPF_INDETERMINATE);
+                        taskbar_state.set_progress_state(TBPF_INDETERMINATE);
                     }
                     1 => {
                         progress_bar_current_stage.show();
                         if item.files_to_check != 0 {
                             progress_bar_all_stages.set_fraction((1f64 + (item.files_checked) as f64 / item.files_to_check as f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction((item.files_checked) as f64 / item.files_to_check as f64);
-                            taskbar_state.as_ref().set_progress_value((item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
-                            taskbar_state.as_ref().set_progress_state(TBPF_NORMAL);
+                            taskbar_state.set_progress_value((item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
+                            taskbar_state.set_progress_state(TBPF_NORMAL);
                         } else {
                             progress_bar_all_stages.set_fraction((1f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction(0f64);
-                            taskbar_state.as_ref().set_progress_value(1, (item.max_stage + 1) as u64);
-                            taskbar_state.as_ref().set_progress_state(TBPF_NORMAL);
+                            taskbar_state.set_progress_value(1, (item.max_stage + 1) as u64);
+                            taskbar_state.set_progress_state(TBPF_NORMAL);
                         }
                         label_stage.set_text(format!("Checking {}/{} file", item.files_checked, item.files_to_check).as_str());
                     }
@@ -289,7 +283,7 @@ pub fn connect_progress_window(
         let future = async move {
             while let Some(item) = futures_receiver_invalid_symlinks.next().await {
                 label_stage.set_text(format!("Scanned {} files", item.files_checked).as_str());
-                taskbar_state.as_ref().set_progress_state(TBPF_INDETERMINATE);
+                taskbar_state.set_progress_state(TBPF_INDETERMINATE);
             }
         };
         main_context.spawn_local(future);
@@ -306,20 +300,20 @@ pub fn connect_progress_window(
                     0 => {
                         progress_bar_current_stage.hide();
                         label_stage.set_text(format!("Scanned {} files", item.files_checked).as_str());
-                        taskbar_state.as_ref().set_progress_state(TBPF_INDETERMINATE);
+                        taskbar_state.set_progress_state(TBPF_INDETERMINATE);
                     }
                     1 => {
                         progress_bar_current_stage.show();
                         if item.files_to_check != 0 {
                             progress_bar_all_stages.set_fraction((1f64 + (item.files_checked) as f64 / item.files_to_check as f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction((item.files_checked) as f64 / item.files_to_check as f64);
-                            taskbar_state.as_ref().set_progress_value((item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
-                            taskbar_state.as_ref().set_progress_state(TBPF_NORMAL);
+                            taskbar_state.set_progress_value((item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
+                            taskbar_state.set_progress_state(TBPF_NORMAL);
                         } else {
                             progress_bar_all_stages.set_fraction((1f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction(0f64);
-                            taskbar_state.as_ref().set_progress_value(1, (item.max_stage + 1) as u64);
-                            taskbar_state.as_ref().set_progress_state(TBPF_NORMAL);
+                            taskbar_state.set_progress_value(1, (item.max_stage + 1) as u64);
+                            taskbar_state.set_progress_state(TBPF_NORMAL);
                         }
                         label_stage.set_text(format!("Checking {}/{} files", item.files_checked, item.files_to_check).as_str());
                     }

--- a/czkawka_gui/src/connect_progress_window.rs
+++ b/czkawka_gui/src/connect_progress_window.rs
@@ -1,4 +1,5 @@
 use crate::gui_data::GuiData;
+use crate::taskbar_progress::tbp_flags::{TBPF_INDETERMINATE, TBPF_NORMAL};
 
 use czkawka_core::{big_file, broken_files, duplicate, empty_files, empty_folder, invalid_symlinks, same_music, similar_images, temporary, zeroed};
 
@@ -27,6 +28,7 @@ pub fn connect_progress_window(
         let progress_bar_current_stage = gui_data.progress_window.progress_bar_current_stage.clone();
         let progress_bar_all_stages = gui_data.progress_window.progress_bar_all_stages.clone();
         let grid_progress_stages = gui_data.progress_window.grid_progress_stages.clone();
+        let taskbar_state = gui_data.taskbar_state.clone();
         let future = async move {
             while let Some(item) = futures_receiver_duplicate_files.next().await {
                 match item.checking_method {
@@ -39,6 +41,10 @@ pub fn connect_progress_window(
                                 // progress_bar_all_stages.hide();
                                 progress_bar_all_stages.set_fraction(0 as f64);
                                 label_stage.set_text(format!("Scanned size of {} files", item.files_checked).as_str());
+                                #[allow(unused_must_use)]
+                                if let Some(taskbar_prog) = taskbar_state.as_ref() {
+                                    taskbar_prog.set_progress_state(TBPF_INDETERMINATE);
+                                }
                             }
                             // Hash - first 1KB file
                             1 => {
@@ -47,9 +53,19 @@ pub fn connect_progress_window(
                                 if item.files_to_check != 0 {
                                     progress_bar_all_stages.set_fraction((1f64 + (item.files_checked) as f64 / item.files_to_check as f64) / (item.max_stage + 1) as f64);
                                     progress_bar_current_stage.set_fraction((item.files_checked) as f64 / item.files_to_check as f64);
+                                    #[allow(unused_must_use)]
+                                    if let Some(taskbar_prog) = taskbar_state.as_ref() {
+                                        taskbar_prog.set_progress_value((item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
+                                        taskbar_prog.set_progress_state(TBPF_NORMAL);
+                                    }
                                 } else {
                                     progress_bar_all_stages.set_fraction((1f64) / (item.max_stage + 1) as f64);
                                     progress_bar_current_stage.set_fraction(0f64);
+                                    #[allow(unused_must_use)]
+                                    if let Some(taskbar_prog) = taskbar_state.as_ref() {
+                                        taskbar_prog.set_progress_value(1, 1 + item.max_stage as u64);
+                                        taskbar_prog.set_progress_state(TBPF_NORMAL);
+                                    }
                                 }
                                 label_stage.set_text(format!("Analyzed partial hash of {}/{} files", item.files_checked, item.files_to_check).as_str());
                             }
@@ -58,9 +74,19 @@ pub fn connect_progress_window(
                                 if item.files_to_check != 0 {
                                     progress_bar_all_stages.set_fraction((2f64 + (item.files_checked) as f64 / item.files_to_check as f64) / (item.max_stage + 1) as f64);
                                     progress_bar_current_stage.set_fraction((item.files_checked) as f64 / item.files_to_check as f64);
+                                    #[allow(unused_must_use)]
+                                    if let Some(taskbar_prog) = taskbar_state.as_ref() {
+                                        taskbar_prog.set_progress_value((2 * item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
+                                        // taskbar_prog.set_progress_state(TBPF_NORMAL);
+                                    }
                                 } else {
                                     progress_bar_all_stages.set_fraction((2f64) / (item.max_stage + 1) as f64);
                                     progress_bar_current_stage.set_fraction(0f64);
+                                    #[allow(unused_must_use)]
+                                    if let Some(taskbar_prog) = taskbar_state.as_ref() {
+                                        taskbar_prog.set_progress_value(2, 1 + item.max_stage as u64);
+                                        // taskbar_prog.set_progress_state(TBPF_NORMAL);
+                                    }
                                 }
 
                                 if item.checking_method == duplicate::CheckingMethod::Hash {
@@ -79,12 +105,20 @@ pub fn connect_progress_window(
                         grid_progress_stages.hide();
 
                         label_stage.set_text(format!("Scanned name of {} files", item.files_checked).as_str());
+                        #[allow(unused_must_use)]
+                        if let Some(taskbar_prog) = taskbar_state.as_ref() {
+                            taskbar_prog.set_progress_state(TBPF_INDETERMINATE);
+                        }
                     }
                     duplicate::CheckingMethod::Size => {
                         label_stage.show();
                         grid_progress_stages.hide();
 
                         label_stage.set_text(format!("Scanned size {} files", item.files_checked).as_str());
+                        #[allow(unused_must_use)]
+                        if let Some(taskbar_prog) = taskbar_state.as_ref() {
+                            taskbar_prog.set_progress_state(TBPF_INDETERMINATE);
+                        }
                     }
                     duplicate::CheckingMethod::None => {
                         panic!();
@@ -97,9 +131,14 @@ pub fn connect_progress_window(
     {
         // Empty Files
         let label_stage = gui_data.progress_window.label_stage.clone();
+        let taskbar_state = gui_data.taskbar_state.clone();
         let future = async move {
             while let Some(item) = futures_receiver_empty_files.next().await {
                 label_stage.set_text(format!("Scanned {} files", item.files_checked).as_str());
+                #[allow(unused_must_use)]
+                if let Some(taskbar_prog) = taskbar_state.as_ref() {
+                    taskbar_prog.set_progress_state(TBPF_INDETERMINATE);
+                }
             }
         };
         main_context.spawn_local(future);
@@ -107,9 +146,14 @@ pub fn connect_progress_window(
     {
         // Empty Folder
         let label_stage = gui_data.progress_window.label_stage.clone();
+        let taskbar_state = gui_data.taskbar_state.clone();
         let future = async move {
             while let Some(item) = futures_receiver_empty_folder.next().await {
                 label_stage.set_text(format!("Scanned {} folders", item.folders_checked).as_str());
+                #[allow(unused_must_use)]
+                if let Some(taskbar_prog) = taskbar_state.as_ref() {
+                    taskbar_prog.set_progress_state(TBPF_INDETERMINATE);
+                }
             }
         };
         main_context.spawn_local(future);
@@ -117,9 +161,14 @@ pub fn connect_progress_window(
     {
         // Big Files
         let label_stage = gui_data.progress_window.label_stage.clone();
+        let taskbar_state = gui_data.taskbar_state.clone();
         let future = async move {
             while let Some(item) = futures_receiver_big_files.next().await {
                 label_stage.set_text(format!("Scanned {} files", item.files_checked).as_str());
+                #[allow(unused_must_use)]
+                if let Some(taskbar_prog) = taskbar_state.as_ref() {
+                    taskbar_prog.set_progress_state(TBPF_INDETERMINATE);
+                }
             }
         };
         main_context.spawn_local(future);
@@ -129,21 +178,36 @@ pub fn connect_progress_window(
         let label_stage = gui_data.progress_window.label_stage.clone();
         let progress_bar_current_stage = gui_data.progress_window.progress_bar_current_stage.clone();
         let progress_bar_all_stages = gui_data.progress_window.progress_bar_all_stages.clone();
+        let taskbar_state = gui_data.taskbar_state.clone();
         let future = async move {
             while let Some(item) = futures_receiver_same_music.next().await {
                 match item.current_stage {
                     0 => {
                         progress_bar_current_stage.hide();
                         label_stage.set_text(format!("Scanned {} files", item.music_checked).as_str());
+                        #[allow(unused_must_use)]
+                        if let Some(taskbar_prog) = taskbar_state.as_ref() {
+                            taskbar_prog.set_progress_state(TBPF_INDETERMINATE);
+                        }
                     }
                     1 => {
                         progress_bar_current_stage.show();
                         if item.music_to_check != 0 {
                             progress_bar_all_stages.set_fraction((1f64 + (item.music_checked) as f64 / item.music_to_check as f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction((item.music_checked) as f64 / item.music_to_check as f64);
+                            #[allow(unused_must_use)]
+                            if let Some(taskbar_prog) = taskbar_state.as_ref() {
+                                taskbar_prog.set_progress_value((item.music_to_check + item.music_checked) as u64, item.music_to_check as u64 * (item.max_stage + 1) as u64);
+                                taskbar_prog.set_progress_state(TBPF_NORMAL);
+                            }
                         } else {
                             progress_bar_all_stages.set_fraction((1f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction(0f64);
+                            #[allow(unused_must_use)]
+                            if let Some(taskbar_prog) = taskbar_state.as_ref() {
+                                taskbar_prog.set_progress_value(1, (item.max_stage + 1) as u64);
+                                taskbar_prog.set_progress_state(TBPF_NORMAL);
+                            }
                         }
                         label_stage.set_text(format!("Reading tags of {}/{} music files", item.music_checked, item.music_to_check).as_str());
                     }
@@ -151,9 +215,19 @@ pub fn connect_progress_window(
                         if item.music_to_check != 0 {
                             progress_bar_all_stages.set_fraction((2f64 + (item.music_checked) as f64 / item.music_to_check as f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction((item.music_checked) as f64 / item.music_to_check as f64);
+                            #[allow(unused_must_use)]
+                            if let Some(taskbar_prog) = taskbar_state.as_ref() {
+                                taskbar_prog.set_progress_value((2 * item.music_to_check + item.music_checked) as u64, item.music_to_check as u64 * (item.max_stage + 1) as u64);
+                                taskbar_prog.set_progress_state(TBPF_NORMAL);
+                            }
                         } else {
                             progress_bar_all_stages.set_fraction((2f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction(0f64);
+                            #[allow(unused_must_use)]
+                            if let Some(taskbar_prog) = taskbar_state.as_ref() {
+                                taskbar_prog.set_progress_value(2, (item.max_stage + 1) as u64);
+                                taskbar_prog.set_progress_state(TBPF_NORMAL);
+                            }
                         }
                         label_stage.set_text(format!("Checking for duplicates of {}/{} music files", item.music_checked, item.music_to_check).as_str());
                     }
@@ -170,21 +244,36 @@ pub fn connect_progress_window(
         let label_stage = gui_data.progress_window.label_stage.clone();
         let progress_bar_current_stage = gui_data.progress_window.progress_bar_current_stage.clone();
         let progress_bar_all_stages = gui_data.progress_window.progress_bar_all_stages.clone();
+        let taskbar_state = gui_data.taskbar_state.clone();
         let future = async move {
             while let Some(item) = futures_receiver_similar_images.next().await {
                 match item.current_stage {
                     0 => {
                         progress_bar_current_stage.hide();
                         label_stage.set_text(format!("Scanned {} files", item.images_checked).as_str());
+                        #[allow(unused_must_use)]
+                        if let Some(taskbar_prog) = taskbar_state.as_ref() {
+                            taskbar_prog.set_progress_state(TBPF_INDETERMINATE);
+                        }
                     }
                     1 => {
                         progress_bar_current_stage.show();
                         if item.images_to_check != 0 {
                             progress_bar_all_stages.set_fraction((1f64 + (item.images_checked) as f64 / item.images_to_check as f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction((item.images_checked) as f64 / item.images_to_check as f64);
+                            #[allow(unused_must_use)]
+                            if let Some(taskbar_prog) = taskbar_state.as_ref() {
+                                taskbar_prog.set_progress_value((item.images_to_check + item.images_checked) as u64, item.images_to_check as u64 * (item.max_stage + 1) as u64);
+                                taskbar_prog.set_progress_state(TBPF_NORMAL);
+                            }
                         } else {
                             progress_bar_all_stages.set_fraction((1f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction(0f64);
+                            #[allow(unused_must_use)]
+                            if let Some(taskbar_prog) = taskbar_state.as_ref() {
+                                taskbar_prog.set_progress_value(1, (item.max_stage + 1) as u64);
+                                taskbar_prog.set_progress_state(TBPF_NORMAL);
+                            }
                         }
                         label_stage.set_text(format!("Hashing {}/{} image", item.images_checked, item.images_to_check).as_str());
                     }
@@ -199,9 +288,14 @@ pub fn connect_progress_window(
     {
         // Temporary
         let label_stage = gui_data.progress_window.label_stage.clone();
+        let taskbar_state = gui_data.taskbar_state.clone();
         let future = async move {
             while let Some(item) = futures_receiver_temporary.next().await {
                 label_stage.set_text(format!("Scanned {} files", item.files_checked).as_str());
+                #[allow(unused_must_use)]
+                if let Some(taskbar_prog) = taskbar_state.as_ref() {
+                    taskbar_prog.set_progress_state(TBPF_INDETERMINATE);
+                }
             }
         };
         main_context.spawn_local(future);
@@ -211,21 +305,36 @@ pub fn connect_progress_window(
         let label_stage = gui_data.progress_window.label_stage.clone();
         let progress_bar_current_stage = gui_data.progress_window.progress_bar_current_stage.clone();
         let progress_bar_all_stages = gui_data.progress_window.progress_bar_all_stages.clone();
+        let taskbar_state = gui_data.taskbar_state.clone();
         let future = async move {
             while let Some(item) = futures_receiver_zeroed.next().await {
                 match item.current_stage {
                     0 => {
                         progress_bar_current_stage.hide();
                         label_stage.set_text(format!("Scanned {} files", item.files_checked).as_str());
+                        #[allow(unused_must_use)]
+                        if let Some(taskbar_prog) = taskbar_state.as_ref() {
+                            taskbar_prog.set_progress_state(TBPF_INDETERMINATE);
+                        }
                     }
                     1 => {
                         progress_bar_current_stage.show();
                         if item.files_to_check != 0 {
                             progress_bar_all_stages.set_fraction((1f64 + (item.files_checked) as f64 / item.files_to_check as f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction((item.files_checked) as f64 / item.files_to_check as f64);
+                            #[allow(unused_must_use)]
+                            if let Some(taskbar_prog) = taskbar_state.as_ref() {
+                                taskbar_prog.set_progress_value((item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
+                                taskbar_prog.set_progress_state(TBPF_NORMAL);
+                            }
                         } else {
                             progress_bar_all_stages.set_fraction((1f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction(0f64);
+                            #[allow(unused_must_use)]
+                            if let Some(taskbar_prog) = taskbar_state.as_ref() {
+                                taskbar_prog.set_progress_value(1, (item.max_stage + 1) as u64);
+                                taskbar_prog.set_progress_state(TBPF_NORMAL);
+                            }
                         }
                         label_stage.set_text(format!("Checking {}/{} file", item.files_checked, item.files_to_check).as_str());
                     }
@@ -240,9 +349,14 @@ pub fn connect_progress_window(
     {
         // Invalid Symlinks
         let label_stage = gui_data.progress_window.label_stage.clone();
+        let taskbar_state = gui_data.taskbar_state.clone();
         let future = async move {
             while let Some(item) = futures_receiver_invalid_symlinks.next().await {
                 label_stage.set_text(format!("Scanned {} files", item.files_checked).as_str());
+                #[allow(unused_must_use)]
+                if let Some(taskbar_prog) = taskbar_state.as_ref() {
+                    taskbar_prog.set_progress_state(TBPF_INDETERMINATE);
+                }
             }
         };
         main_context.spawn_local(future);
@@ -252,21 +366,36 @@ pub fn connect_progress_window(
         let label_stage = gui_data.progress_window.label_stage.clone();
         let progress_bar_current_stage = gui_data.progress_window.progress_bar_current_stage.clone();
         let progress_bar_all_stages = gui_data.progress_window.progress_bar_all_stages.clone();
+        let taskbar_state = gui_data.taskbar_state.clone();
         let future = async move {
             while let Some(item) = futures_receiver_broken_files.next().await {
                 match item.current_stage {
                     0 => {
                         progress_bar_current_stage.hide();
                         label_stage.set_text(format!("Scanned {} files", item.files_checked).as_str());
+                        #[allow(unused_must_use)]
+                        if let Some(taskbar_prog) = taskbar_state.as_ref() {
+                            taskbar_prog.set_progress_state(TBPF_INDETERMINATE);
+                        }
                     }
                     1 => {
                         progress_bar_current_stage.show();
                         if item.files_to_check != 0 {
                             progress_bar_all_stages.set_fraction((1f64 + (item.files_checked) as f64 / item.files_to_check as f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction((item.files_checked) as f64 / item.files_to_check as f64);
+                            #[allow(unused_must_use)]
+                            if let Some(taskbar_prog) = taskbar_state.as_ref() {
+                                taskbar_prog.set_progress_value((item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
+                                taskbar_prog.set_progress_state(TBPF_NORMAL);
+                            }
                         } else {
                             progress_bar_all_stages.set_fraction((1f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction(0f64);
+                            #[allow(unused_must_use)]
+                            if let Some(taskbar_prog) = taskbar_state.as_ref() {
+                                taskbar_prog.set_progress_value(1, (item.max_stage + 1) as u64);
+                                taskbar_prog.set_progress_state(TBPF_NORMAL);
+                            }
                         }
                         label_stage.set_text(format!("Checking {}/{} files", item.files_checked, item.files_to_check).as_str());
                     }

--- a/czkawka_gui/src/connect_progress_window.rs
+++ b/czkawka_gui/src/connect_progress_window.rs
@@ -41,10 +41,7 @@ pub fn connect_progress_window(
                                 // progress_bar_all_stages.hide();
                                 progress_bar_all_stages.set_fraction(0 as f64);
                                 label_stage.set_text(format!("Scanned size of {} files", item.files_checked).as_str());
-                                #[allow(unused_must_use)]
-                                if let Some(taskbar_prog) = taskbar_state.as_ref() {
-                                    taskbar_prog.set_progress_state(TBPF_INDETERMINATE);
-                                }
+                                taskbar_state.as_ref().set_progress_state(TBPF_INDETERMINATE);
                             }
                             // Hash - first 1KB file
                             1 => {
@@ -53,19 +50,13 @@ pub fn connect_progress_window(
                                 if item.files_to_check != 0 {
                                     progress_bar_all_stages.set_fraction((1f64 + (item.files_checked) as f64 / item.files_to_check as f64) / (item.max_stage + 1) as f64);
                                     progress_bar_current_stage.set_fraction((item.files_checked) as f64 / item.files_to_check as f64);
-                                    #[allow(unused_must_use)]
-                                    if let Some(taskbar_prog) = taskbar_state.as_ref() {
-                                        taskbar_prog.set_progress_value((item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
-                                        taskbar_prog.set_progress_state(TBPF_NORMAL);
-                                    }
+                                    taskbar_state.as_ref().set_progress_value((item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
+                                    taskbar_state.as_ref().set_progress_state(TBPF_NORMAL);
                                 } else {
                                     progress_bar_all_stages.set_fraction((1f64) / (item.max_stage + 1) as f64);
                                     progress_bar_current_stage.set_fraction(0f64);
-                                    #[allow(unused_must_use)]
-                                    if let Some(taskbar_prog) = taskbar_state.as_ref() {
-                                        taskbar_prog.set_progress_value(1, 1 + item.max_stage as u64);
-                                        taskbar_prog.set_progress_state(TBPF_NORMAL);
-                                    }
+                                    taskbar_state.as_ref().set_progress_value(1, 1 + item.max_stage as u64);
+                                    taskbar_state.as_ref().set_progress_state(TBPF_NORMAL);
                                 }
                                 label_stage.set_text(format!("Analyzed partial hash of {}/{} files", item.files_checked, item.files_to_check).as_str());
                             }
@@ -74,19 +65,13 @@ pub fn connect_progress_window(
                                 if item.files_to_check != 0 {
                                     progress_bar_all_stages.set_fraction((2f64 + (item.files_checked) as f64 / item.files_to_check as f64) / (item.max_stage + 1) as f64);
                                     progress_bar_current_stage.set_fraction((item.files_checked) as f64 / item.files_to_check as f64);
-                                    #[allow(unused_must_use)]
-                                    if let Some(taskbar_prog) = taskbar_state.as_ref() {
-                                        taskbar_prog.set_progress_value((2 * item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
-                                        // taskbar_prog.set_progress_state(TBPF_NORMAL);
-                                    }
+                                    taskbar_state
+                                        .as_ref()
+                                        .set_progress_value((2 * item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
                                 } else {
                                     progress_bar_all_stages.set_fraction((2f64) / (item.max_stage + 1) as f64);
                                     progress_bar_current_stage.set_fraction(0f64);
-                                    #[allow(unused_must_use)]
-                                    if let Some(taskbar_prog) = taskbar_state.as_ref() {
-                                        taskbar_prog.set_progress_value(2, 1 + item.max_stage as u64);
-                                        // taskbar_prog.set_progress_state(TBPF_NORMAL);
-                                    }
+                                    taskbar_state.as_ref().set_progress_value(2, 1 + item.max_stage as u64);
                                 }
 
                                 if item.checking_method == duplicate::CheckingMethod::Hash {
@@ -105,20 +90,14 @@ pub fn connect_progress_window(
                         grid_progress_stages.hide();
 
                         label_stage.set_text(format!("Scanned name of {} files", item.files_checked).as_str());
-                        #[allow(unused_must_use)]
-                        if let Some(taskbar_prog) = taskbar_state.as_ref() {
-                            taskbar_prog.set_progress_state(TBPF_INDETERMINATE);
-                        }
+                        taskbar_state.as_ref().set_progress_state(TBPF_INDETERMINATE);
                     }
                     duplicate::CheckingMethod::Size => {
                         label_stage.show();
                         grid_progress_stages.hide();
 
                         label_stage.set_text(format!("Scanned size {} files", item.files_checked).as_str());
-                        #[allow(unused_must_use)]
-                        if let Some(taskbar_prog) = taskbar_state.as_ref() {
-                            taskbar_prog.set_progress_state(TBPF_INDETERMINATE);
-                        }
+                        taskbar_state.as_ref().set_progress_state(TBPF_INDETERMINATE);
                     }
                     duplicate::CheckingMethod::None => {
                         panic!();
@@ -135,10 +114,7 @@ pub fn connect_progress_window(
         let future = async move {
             while let Some(item) = futures_receiver_empty_files.next().await {
                 label_stage.set_text(format!("Scanned {} files", item.files_checked).as_str());
-                #[allow(unused_must_use)]
-                if let Some(taskbar_prog) = taskbar_state.as_ref() {
-                    taskbar_prog.set_progress_state(TBPF_INDETERMINATE);
-                }
+                taskbar_state.as_ref().set_progress_state(TBPF_INDETERMINATE);
             }
         };
         main_context.spawn_local(future);
@@ -150,10 +126,7 @@ pub fn connect_progress_window(
         let future = async move {
             while let Some(item) = futures_receiver_empty_folder.next().await {
                 label_stage.set_text(format!("Scanned {} folders", item.folders_checked).as_str());
-                #[allow(unused_must_use)]
-                if let Some(taskbar_prog) = taskbar_state.as_ref() {
-                    taskbar_prog.set_progress_state(TBPF_INDETERMINATE);
-                }
+                taskbar_state.as_ref().set_progress_state(TBPF_INDETERMINATE);
             }
         };
         main_context.spawn_local(future);
@@ -165,10 +138,7 @@ pub fn connect_progress_window(
         let future = async move {
             while let Some(item) = futures_receiver_big_files.next().await {
                 label_stage.set_text(format!("Scanned {} files", item.files_checked).as_str());
-                #[allow(unused_must_use)]
-                if let Some(taskbar_prog) = taskbar_state.as_ref() {
-                    taskbar_prog.set_progress_state(TBPF_INDETERMINATE);
-                }
+                taskbar_state.as_ref().set_progress_state(TBPF_INDETERMINATE);
             }
         };
         main_context.spawn_local(future);
@@ -185,29 +155,20 @@ pub fn connect_progress_window(
                     0 => {
                         progress_bar_current_stage.hide();
                         label_stage.set_text(format!("Scanned {} files", item.music_checked).as_str());
-                        #[allow(unused_must_use)]
-                        if let Some(taskbar_prog) = taskbar_state.as_ref() {
-                            taskbar_prog.set_progress_state(TBPF_INDETERMINATE);
-                        }
+                        taskbar_state.as_ref().set_progress_state(TBPF_INDETERMINATE);
                     }
                     1 => {
                         progress_bar_current_stage.show();
                         if item.music_to_check != 0 {
                             progress_bar_all_stages.set_fraction((1f64 + (item.music_checked) as f64 / item.music_to_check as f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction((item.music_checked) as f64 / item.music_to_check as f64);
-                            #[allow(unused_must_use)]
-                            if let Some(taskbar_prog) = taskbar_state.as_ref() {
-                                taskbar_prog.set_progress_value((item.music_to_check + item.music_checked) as u64, item.music_to_check as u64 * (item.max_stage + 1) as u64);
-                                taskbar_prog.set_progress_state(TBPF_NORMAL);
-                            }
+                            taskbar_state.as_ref().set_progress_value((item.music_to_check + item.music_checked) as u64, item.music_to_check as u64 * (item.max_stage + 1) as u64);
+                            taskbar_state.as_ref().set_progress_state(TBPF_NORMAL);
                         } else {
                             progress_bar_all_stages.set_fraction((1f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction(0f64);
-                            #[allow(unused_must_use)]
-                            if let Some(taskbar_prog) = taskbar_state.as_ref() {
-                                taskbar_prog.set_progress_value(1, (item.max_stage + 1) as u64);
-                                taskbar_prog.set_progress_state(TBPF_NORMAL);
-                            }
+                            taskbar_state.as_ref().set_progress_value(1, (item.max_stage + 1) as u64);
+                            taskbar_state.as_ref().set_progress_state(TBPF_NORMAL);
                         }
                         label_stage.set_text(format!("Reading tags of {}/{} music files", item.music_checked, item.music_to_check).as_str());
                     }
@@ -215,19 +176,13 @@ pub fn connect_progress_window(
                         if item.music_to_check != 0 {
                             progress_bar_all_stages.set_fraction((2f64 + (item.music_checked) as f64 / item.music_to_check as f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction((item.music_checked) as f64 / item.music_to_check as f64);
-                            #[allow(unused_must_use)]
-                            if let Some(taskbar_prog) = taskbar_state.as_ref() {
-                                taskbar_prog.set_progress_value((2 * item.music_to_check + item.music_checked) as u64, item.music_to_check as u64 * (item.max_stage + 1) as u64);
-                                // taskbar_prog.set_progress_state(TBPF_NORMAL);
-                            }
+                            taskbar_state
+                                .as_ref()
+                                .set_progress_value((2 * item.music_to_check + item.music_checked) as u64, item.music_to_check as u64 * (item.max_stage + 1) as u64);
                         } else {
                             progress_bar_all_stages.set_fraction((2f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction(0f64);
-                            #[allow(unused_must_use)]
-                            if let Some(taskbar_prog) = taskbar_state.as_ref() {
-                                taskbar_prog.set_progress_value(2, (item.max_stage + 1) as u64);
-                                // taskbar_prog.set_progress_state(TBPF_NORMAL);
-                            }
+                            taskbar_state.as_ref().set_progress_value(2, (item.max_stage + 1) as u64);
                         }
                         label_stage.set_text(format!("Checking for duplicates of {}/{} music files", item.music_checked, item.music_to_check).as_str());
                     }
@@ -251,29 +206,22 @@ pub fn connect_progress_window(
                     0 => {
                         progress_bar_current_stage.hide();
                         label_stage.set_text(format!("Scanned {} files", item.images_checked).as_str());
-                        #[allow(unused_must_use)]
-                        if let Some(taskbar_prog) = taskbar_state.as_ref() {
-                            taskbar_prog.set_progress_state(TBPF_INDETERMINATE);
-                        }
+                        taskbar_state.as_ref().set_progress_state(TBPF_INDETERMINATE);
                     }
                     1 => {
                         progress_bar_current_stage.show();
                         if item.images_to_check != 0 {
                             progress_bar_all_stages.set_fraction((1f64 + (item.images_checked) as f64 / item.images_to_check as f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction((item.images_checked) as f64 / item.images_to_check as f64);
-                            #[allow(unused_must_use)]
-                            if let Some(taskbar_prog) = taskbar_state.as_ref() {
-                                taskbar_prog.set_progress_value((item.images_to_check + item.images_checked) as u64, item.images_to_check as u64 * (item.max_stage + 1) as u64);
-                                taskbar_prog.set_progress_state(TBPF_NORMAL);
-                            }
+                            taskbar_state
+                                .as_ref()
+                                .set_progress_value((item.images_to_check + item.images_checked) as u64, item.images_to_check as u64 * (item.max_stage + 1) as u64);
+                            taskbar_state.as_ref().set_progress_state(TBPF_NORMAL);
                         } else {
                             progress_bar_all_stages.set_fraction((1f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction(0f64);
-                            #[allow(unused_must_use)]
-                            if let Some(taskbar_prog) = taskbar_state.as_ref() {
-                                taskbar_prog.set_progress_value(1, (item.max_stage + 1) as u64);
-                                taskbar_prog.set_progress_state(TBPF_NORMAL);
-                            }
+                            taskbar_state.as_ref().set_progress_value(1, (item.max_stage + 1) as u64);
+                            taskbar_state.as_ref().set_progress_state(TBPF_NORMAL);
                         }
                         label_stage.set_text(format!("Hashing {}/{} image", item.images_checked, item.images_to_check).as_str());
                     }
@@ -292,10 +240,7 @@ pub fn connect_progress_window(
         let future = async move {
             while let Some(item) = futures_receiver_temporary.next().await {
                 label_stage.set_text(format!("Scanned {} files", item.files_checked).as_str());
-                #[allow(unused_must_use)]
-                if let Some(taskbar_prog) = taskbar_state.as_ref() {
-                    taskbar_prog.set_progress_state(TBPF_INDETERMINATE);
-                }
+                taskbar_state.as_ref().set_progress_state(TBPF_INDETERMINATE);
             }
         };
         main_context.spawn_local(future);
@@ -312,29 +257,20 @@ pub fn connect_progress_window(
                     0 => {
                         progress_bar_current_stage.hide();
                         label_stage.set_text(format!("Scanned {} files", item.files_checked).as_str());
-                        #[allow(unused_must_use)]
-                        if let Some(taskbar_prog) = taskbar_state.as_ref() {
-                            taskbar_prog.set_progress_state(TBPF_INDETERMINATE);
-                        }
+                        taskbar_state.as_ref().set_progress_state(TBPF_INDETERMINATE);
                     }
                     1 => {
                         progress_bar_current_stage.show();
                         if item.files_to_check != 0 {
                             progress_bar_all_stages.set_fraction((1f64 + (item.files_checked) as f64 / item.files_to_check as f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction((item.files_checked) as f64 / item.files_to_check as f64);
-                            #[allow(unused_must_use)]
-                            if let Some(taskbar_prog) = taskbar_state.as_ref() {
-                                taskbar_prog.set_progress_value((item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
-                                taskbar_prog.set_progress_state(TBPF_NORMAL);
-                            }
+                            taskbar_state.as_ref().set_progress_value((item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
+                            taskbar_state.as_ref().set_progress_state(TBPF_NORMAL);
                         } else {
                             progress_bar_all_stages.set_fraction((1f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction(0f64);
-                            #[allow(unused_must_use)]
-                            if let Some(taskbar_prog) = taskbar_state.as_ref() {
-                                taskbar_prog.set_progress_value(1, (item.max_stage + 1) as u64);
-                                taskbar_prog.set_progress_state(TBPF_NORMAL);
-                            }
+                            taskbar_state.as_ref().set_progress_value(1, (item.max_stage + 1) as u64);
+                            taskbar_state.as_ref().set_progress_state(TBPF_NORMAL);
                         }
                         label_stage.set_text(format!("Checking {}/{} file", item.files_checked, item.files_to_check).as_str());
                     }
@@ -353,10 +289,7 @@ pub fn connect_progress_window(
         let future = async move {
             while let Some(item) = futures_receiver_invalid_symlinks.next().await {
                 label_stage.set_text(format!("Scanned {} files", item.files_checked).as_str());
-                #[allow(unused_must_use)]
-                if let Some(taskbar_prog) = taskbar_state.as_ref() {
-                    taskbar_prog.set_progress_state(TBPF_INDETERMINATE);
-                }
+                taskbar_state.as_ref().set_progress_state(TBPF_INDETERMINATE);
             }
         };
         main_context.spawn_local(future);
@@ -373,29 +306,20 @@ pub fn connect_progress_window(
                     0 => {
                         progress_bar_current_stage.hide();
                         label_stage.set_text(format!("Scanned {} files", item.files_checked).as_str());
-                        #[allow(unused_must_use)]
-                        if let Some(taskbar_prog) = taskbar_state.as_ref() {
-                            taskbar_prog.set_progress_state(TBPF_INDETERMINATE);
-                        }
+                        taskbar_state.as_ref().set_progress_state(TBPF_INDETERMINATE);
                     }
                     1 => {
                         progress_bar_current_stage.show();
                         if item.files_to_check != 0 {
                             progress_bar_all_stages.set_fraction((1f64 + (item.files_checked) as f64 / item.files_to_check as f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction((item.files_checked) as f64 / item.files_to_check as f64);
-                            #[allow(unused_must_use)]
-                            if let Some(taskbar_prog) = taskbar_state.as_ref() {
-                                taskbar_prog.set_progress_value((item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
-                                taskbar_prog.set_progress_state(TBPF_NORMAL);
-                            }
+                            taskbar_state.as_ref().set_progress_value((item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
+                            taskbar_state.as_ref().set_progress_state(TBPF_NORMAL);
                         } else {
                             progress_bar_all_stages.set_fraction((1f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction(0f64);
-                            #[allow(unused_must_use)]
-                            if let Some(taskbar_prog) = taskbar_state.as_ref() {
-                                taskbar_prog.set_progress_value(1, (item.max_stage + 1) as u64);
-                                taskbar_prog.set_progress_state(TBPF_NORMAL);
-                            }
+                            taskbar_state.as_ref().set_progress_value(1, (item.max_stage + 1) as u64);
+                            taskbar_state.as_ref().set_progress_state(TBPF_NORMAL);
                         }
                         label_stage.set_text(format!("Checking {}/{} files", item.files_checked, item.files_to_check).as_str());
                     }

--- a/czkawka_gui/src/connect_progress_window.rs
+++ b/czkawka_gui/src/connect_progress_window.rs
@@ -1,5 +1,5 @@
 use crate::gui_data::GuiData;
-use crate::taskbar_progress::tbp_flags::{TBPF_INDETERMINATE, TBPF_NORMAL};
+use crate::taskbar_progress::tbp_flags::TBPF_INDETERMINATE;
 
 use czkawka_core::{big_file, broken_files, duplicate, empty_files, empty_folder, invalid_symlinks, same_music, similar_images, temporary, zeroed};
 
@@ -51,12 +51,10 @@ pub fn connect_progress_window(
                                     progress_bar_all_stages.set_fraction((1f64 + (item.files_checked) as f64 / item.files_to_check as f64) / (item.max_stage + 1) as f64);
                                     progress_bar_current_stage.set_fraction((item.files_checked) as f64 / item.files_to_check as f64);
                                     taskbar_state.borrow().set_progress_value((item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
-                                    taskbar_state.borrow().set_progress_state(TBPF_NORMAL);
                                 } else {
                                     progress_bar_all_stages.set_fraction((1f64) / (item.max_stage + 1) as f64);
                                     progress_bar_current_stage.set_fraction(0f64);
                                     taskbar_state.borrow().set_progress_value(1, 1 + item.max_stage as u64);
-                                    taskbar_state.borrow().set_progress_state(TBPF_NORMAL);
                                 }
                                 label_stage.set_text(format!("Analyzed partial hash of {}/{} files", item.files_checked, item.files_to_check).as_str());
                             }
@@ -163,12 +161,10 @@ pub fn connect_progress_window(
                             progress_bar_all_stages.set_fraction((1f64 + (item.music_checked) as f64 / item.music_to_check as f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction((item.music_checked) as f64 / item.music_to_check as f64);
                             taskbar_state.borrow().set_progress_value((item.music_to_check + item.music_checked) as u64, item.music_to_check as u64 * (item.max_stage + 1) as u64);
-                            taskbar_state.borrow().set_progress_state(TBPF_NORMAL);
                         } else {
                             progress_bar_all_stages.set_fraction((1f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction(0f64);
                             taskbar_state.borrow().set_progress_value(1, (item.max_stage + 1) as u64);
-                            taskbar_state.borrow().set_progress_state(TBPF_NORMAL);
                         }
                         label_stage.set_text(format!("Reading tags of {}/{} music files", item.music_checked, item.music_to_check).as_str());
                     }
@@ -216,12 +212,10 @@ pub fn connect_progress_window(
                             taskbar_state
                                 .borrow()
                                 .set_progress_value((item.images_to_check + item.images_checked) as u64, item.images_to_check as u64 * (item.max_stage + 1) as u64);
-                            taskbar_state.borrow().set_progress_state(TBPF_NORMAL);
                         } else {
                             progress_bar_all_stages.set_fraction((1f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction(0f64);
                             taskbar_state.borrow().set_progress_value(1, (item.max_stage + 1) as u64);
-                            taskbar_state.borrow().set_progress_state(TBPF_NORMAL);
                         }
                         label_stage.set_text(format!("Hashing {}/{} image", item.images_checked, item.images_to_check).as_str());
                     }
@@ -265,12 +259,10 @@ pub fn connect_progress_window(
                             progress_bar_all_stages.set_fraction((1f64 + (item.files_checked) as f64 / item.files_to_check as f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction((item.files_checked) as f64 / item.files_to_check as f64);
                             taskbar_state.borrow().set_progress_value((item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
-                            taskbar_state.borrow().set_progress_state(TBPF_NORMAL);
                         } else {
                             progress_bar_all_stages.set_fraction((1f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction(0f64);
                             taskbar_state.borrow().set_progress_value(1, (item.max_stage + 1) as u64);
-                            taskbar_state.borrow().set_progress_state(TBPF_NORMAL);
                         }
                         label_stage.set_text(format!("Checking {}/{} file", item.files_checked, item.files_to_check).as_str());
                     }
@@ -314,12 +306,10 @@ pub fn connect_progress_window(
                             progress_bar_all_stages.set_fraction((1f64 + (item.files_checked) as f64 / item.files_to_check as f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction((item.files_checked) as f64 / item.files_to_check as f64);
                             taskbar_state.borrow().set_progress_value((item.files_to_check + item.files_checked) as u64, item.files_to_check as u64 * (item.max_stage + 1) as u64);
-                            taskbar_state.borrow().set_progress_state(TBPF_NORMAL);
                         } else {
                             progress_bar_all_stages.set_fraction((1f64) / (item.max_stage + 1) as f64);
                             progress_bar_current_stage.set_fraction(0f64);
                             taskbar_state.borrow().set_progress_value(1, (item.max_stage + 1) as u64);
-                            taskbar_state.borrow().set_progress_state(TBPF_NORMAL);
                         }
                         label_stage.set_text(format!("Checking {}/{} files", item.files_checked, item.files_to_check).as_str());
                     }

--- a/czkawka_gui/src/connect_progress_window.rs
+++ b/czkawka_gui/src/connect_progress_window.rs
@@ -218,7 +218,7 @@ pub fn connect_progress_window(
                             #[allow(unused_must_use)]
                             if let Some(taskbar_prog) = taskbar_state.as_ref() {
                                 taskbar_prog.set_progress_value((2 * item.music_to_check + item.music_checked) as u64, item.music_to_check as u64 * (item.max_stage + 1) as u64);
-                                taskbar_prog.set_progress_state(TBPF_NORMAL);
+                                // taskbar_prog.set_progress_state(TBPF_NORMAL);
                             }
                         } else {
                             progress_bar_all_stages.set_fraction((2f64) / (item.max_stage + 1) as f64);
@@ -226,7 +226,7 @@ pub fn connect_progress_window(
                             #[allow(unused_must_use)]
                             if let Some(taskbar_prog) = taskbar_state.as_ref() {
                                 taskbar_prog.set_progress_value(2, (item.max_stage + 1) as u64);
-                                taskbar_prog.set_progress_state(TBPF_NORMAL);
+                                // taskbar_prog.set_progress_state(TBPF_NORMAL);
                             }
                         }
                         label_stage.set_text(format!("Checking for duplicates of {}/{} music files", item.music_checked, item.music_to_check).as_str());

--- a/czkawka_gui/src/gui_data.rs
+++ b/czkawka_gui/src/gui_data.rs
@@ -45,7 +45,7 @@ pub struct GuiData {
     pub header: GUIHeader,
 
     // Taskbar state
-    pub taskbar_state: Rc<TaskbarProgress>,
+    pub taskbar_state: Rc<RefCell<TaskbarProgress>>,
 
     // Buttons state
     pub shared_buttons: Rc<RefCell<HashMap<NotebookMainEnum, HashMap<String, bool>>>>,
@@ -100,7 +100,7 @@ impl GuiData {
         ////////////////////////////////////////////////////////////////////////////////////////////////
 
         // Taskbar state
-        let taskbar_state = Rc::new(TaskbarProgress::new());
+        let taskbar_state = Rc::new(RefCell::new(TaskbarProgress::new()));
 
         // Buttons State - to remember existence of different buttons on pages
         let shared_buttons: Rc<RefCell<_>> = Rc::new(RefCell::new(HashMap::<NotebookMainEnum, HashMap<String, bool>>::new()));

--- a/czkawka_gui/src/gui_data.rs
+++ b/czkawka_gui/src/gui_data.rs
@@ -8,6 +8,7 @@ use crate::gui_popovers::GUIPopovers;
 use crate::gui_progress_dialog::GUIProgressDialog;
 use crate::gui_upper_notepad::GUIUpperNotebook;
 use crate::notebook_enums::*;
+use crate::taskbar_progress::TaskbarProgress;
 use crossbeam_channel::unbounded;
 use czkawka_core::big_file::BigFile;
 use czkawka_core::broken_files::BrokenFiles;
@@ -42,6 +43,9 @@ pub struct GuiData {
     pub about: GUIAbout,
     pub options: GUIOptions,
     pub header: GUIHeader,
+
+    // Taskbar state
+    pub taskbar_state: Rc<Option<TaskbarProgress>>,
 
     // Buttons state
     pub shared_buttons: Rc<RefCell<HashMap<NotebookMainEnum, HashMap<String, bool>>>>,
@@ -94,6 +98,9 @@ impl GuiData {
         let header = GUIHeader::create_from_builder(&builder);
 
         ////////////////////////////////////////////////////////////////////////////////////////////////
+
+        // Taskbar state
+        let taskbar_state = Rc::new(TaskbarProgress::new().ok());
 
         // Buttons State - to remember existence of different buttons on pages
         let shared_buttons: Rc<RefCell<_>> = Rc::new(RefCell::new(HashMap::<NotebookMainEnum, HashMap<String, bool>>::new()));
@@ -160,6 +167,7 @@ impl GuiData {
             about,
             options,
             header,
+            taskbar_state,
             shared_buttons,
             shared_upper_notebooks,
             shared_duplication_state,

--- a/czkawka_gui/src/gui_data.rs
+++ b/czkawka_gui/src/gui_data.rs
@@ -45,7 +45,7 @@ pub struct GuiData {
     pub header: GUIHeader,
 
     // Taskbar state
-    pub taskbar_state: Rc<Option<TaskbarProgress>>,
+    pub taskbar_state: Rc<TaskbarProgress>,
 
     // Buttons state
     pub shared_buttons: Rc<RefCell<HashMap<NotebookMainEnum, HashMap<String, bool>>>>,
@@ -100,7 +100,7 @@ impl GuiData {
         ////////////////////////////////////////////////////////////////////////////////////////////////
 
         // Taskbar state
-        let taskbar_state = Rc::new(TaskbarProgress::new().ok());
+        let taskbar_state = Rc::new(TaskbarProgress::new());
 
         // Buttons State - to remember existence of different buttons on pages
         let shared_buttons: Rc<RefCell<_>> = Rc::new(RefCell::new(HashMap::<NotebookMainEnum, HashMap<String, bool>>::new()));

--- a/czkawka_gui/src/initialize_gui.rs
+++ b/czkawka_gui/src/initialize_gui.rs
@@ -3,6 +3,7 @@ use crate::create_tree_view::*;
 use crate::double_click_opening::*;
 use crate::gui_data::*;
 use crate::help_functions::*;
+use crate::taskbar_progress::tbp_flags::TBPF_NOPROGRESS;
 use directories_next::ProjectDirs;
 use gtk::prelude::*;
 use gtk::{CheckButton, Image, SelectionMode, TextView, TreeView};
@@ -462,10 +463,16 @@ pub fn initialize_gui(gui_data: &mut GuiData) {
     {
         let window_progress = gui_data.progress_window.window_progress.clone();
         let stop_sender = gui_data.stop_sender.clone();
+        let taskbar_state = gui_data.taskbar_state.clone();
 
         window_progress.hide_on_delete();
 
         window_progress.connect_delete_event(move |_e, _y| {
+            #[allow(unused_must_use)]
+            if let Some(taskbar_prog) = taskbar_state.as_ref() {
+                taskbar_prog.set_progress_state(TBPF_NOPROGRESS);
+            }
+
             stop_sender.send(()).unwrap();
             gtk::Inhibit(true)
         });

--- a/czkawka_gui/src/initialize_gui.rs
+++ b/czkawka_gui/src/initialize_gui.rs
@@ -468,10 +468,7 @@ pub fn initialize_gui(gui_data: &mut GuiData) {
         window_progress.hide_on_delete();
 
         window_progress.connect_delete_event(move |_e, _y| {
-            #[allow(unused_must_use)]
-            if let Some(taskbar_prog) = taskbar_state.as_ref() {
-                taskbar_prog.set_progress_state(TBPF_NOPROGRESS);
-            }
+            taskbar_state.as_ref().set_progress_state(TBPF_NOPROGRESS);
 
             stop_sender.send(()).unwrap();
             gtk::Inhibit(true)

--- a/czkawka_gui/src/initialize_gui.rs
+++ b/czkawka_gui/src/initialize_gui.rs
@@ -3,7 +3,6 @@ use crate::create_tree_view::*;
 use crate::double_click_opening::*;
 use crate::gui_data::*;
 use crate::help_functions::*;
-use crate::taskbar_progress::tbp_flags::TBPF_NOPROGRESS;
 use directories_next::ProjectDirs;
 use gtk::prelude::*;
 use gtk::{CheckButton, Image, SelectionMode, TextView, TreeView};
@@ -468,7 +467,7 @@ pub fn initialize_gui(gui_data: &mut GuiData) {
         window_progress.hide_on_delete();
 
         window_progress.connect_delete_event(move |_e, _y| {
-            taskbar_state.as_ref().set_progress_state(TBPF_NOPROGRESS);
+            taskbar_state.hide();
 
             stop_sender.send(()).unwrap();
             gtk::Inhibit(true)

--- a/czkawka_gui/src/initialize_gui.rs
+++ b/czkawka_gui/src/initialize_gui.rs
@@ -462,13 +462,10 @@ pub fn initialize_gui(gui_data: &mut GuiData) {
     {
         let window_progress = gui_data.progress_window.window_progress.clone();
         let stop_sender = gui_data.stop_sender.clone();
-        let taskbar_state = gui_data.taskbar_state.clone();
 
         window_progress.hide_on_delete();
 
         window_progress.connect_delete_event(move |_e, _y| {
-            taskbar_state.hide();
-
             stop_sender.send(()).unwrap();
             gtk::Inhibit(true)
         });

--- a/czkawka_gui/src/main.rs
+++ b/czkawka_gui/src/main.rs
@@ -32,10 +32,10 @@ mod initialize_gui;
 mod notebook_enums;
 mod saving_loading;
 mod taskbar_progress;
-#[cfg(target_os = "windows")]
-mod taskbar_progress_win;
 #[cfg(not(target_os = "windows"))]
 mod taskbar_progress_dummy;
+#[cfg(target_os = "windows")]
+mod taskbar_progress_win;
 
 use czkawka_core::*;
 

--- a/czkawka_gui/src/main.rs
+++ b/czkawka_gui/src/main.rs
@@ -145,9 +145,11 @@ fn main() {
     // Quit the program when X in main window was clicked
     {
         let window_main = gui_data.window_main.clone();
+        let taskbar_state = gui_data.taskbar_state.clone();
         window_main.connect_delete_event(move |_, _| {
             save_configuration(&gui_data, false); // Save configuration at exit
             gtk::main_quit();
+            taskbar_state.borrow_mut().release();
             Inhibit(false)
         });
     }

--- a/czkawka_gui/src/main.rs
+++ b/czkawka_gui/src/main.rs
@@ -31,6 +31,11 @@ mod help_functions;
 mod initialize_gui;
 mod notebook_enums;
 mod saving_loading;
+mod taskbar_progress;
+#[cfg(target_os = "windows")]
+mod taskbar_progress_win;
+#[cfg(not(target_os = "windows"))]
+mod taskbar_progress_dummy;
 
 use czkawka_core::*;
 

--- a/czkawka_gui/src/taskbar_progress.rs
+++ b/czkawka_gui/src/taskbar_progress.rs
@@ -1,0 +1,5 @@
+#[cfg(target_os = "windows")]
+pub use crate::taskbar_progress_win::{TaskbarProgress, tbp_flags};
+
+#[cfg(not(target_os = "windows"))]
+pub use crate::taskbar_progress_dummy::{TaskbarProgress, tbp_flags};

--- a/czkawka_gui/src/taskbar_progress.rs
+++ b/czkawka_gui/src/taskbar_progress.rs
@@ -1,5 +1,5 @@
 #[cfg(target_os = "windows")]
-pub use crate::taskbar_progress_win::{TaskbarProgress, tbp_flags};
+pub use crate::taskbar_progress_win::{tbp_flags, TaskbarProgress};
 
 #[cfg(not(target_os = "windows"))]
-pub use crate::taskbar_progress_dummy::{TaskbarProgress, tbp_flags};
+pub use crate::taskbar_progress_dummy::{tbp_flags, TaskbarProgress};

--- a/czkawka_gui/src/taskbar_progress_dummy.rs
+++ b/czkawka_gui/src/taskbar_progress_dummy.rs
@@ -6,35 +6,35 @@ type HWND = *mut HWND__;
 
 #[allow(non_camel_case_types, dead_code)]
 pub enum TBPFLAG {
-	TBPF_NOPROGRESS = 0,
-	TBPF_INDETERMINATE = 0x1,
-	TBPF_NORMAL = 0x2,
-	TBPF_ERROR = 0x4,
-	TBPF_PAUSED = 0x8,
+    TBPF_NOPROGRESS = 0,
+    TBPF_INDETERMINATE = 0x1,
+    TBPF_NORMAL = 0x2,
+    TBPF_ERROR = 0x4,
+    TBPF_PAUSED = 0x8,
 }
 
 pub mod tbp_flags {
-	pub use super::TBPFLAG::*;
+    pub use super::TBPFLAG::*;
 }
 
 pub struct TaskbarProgress {}
 
 impl TaskbarProgress {
-	pub fn new() -> TaskbarProgress {
-		TaskbarProgress {}
-	}
+    pub fn new() -> TaskbarProgress {
+        TaskbarProgress {}
+    }
 
-	pub fn set_progress_state(&self, _tbp_flags: TBPFLAG) {}
+    pub fn set_progress_state(&self, _tbp_flags: TBPFLAG) {}
 
-	pub fn set_progress_value(&self, _completed: u64, _total: u64) {}
+    pub fn set_progress_value(&self, _completed: u64, _total: u64) {}
 }
 
 impl From<HWND> for TaskbarProgress {
-	fn from(_hwnd: HWND) -> Self {
-		TaskbarProgress {}
-	}
+    fn from(_hwnd: HWND) -> Self {
+        TaskbarProgress {}
+    }
 }
 
 impl Drop for TaskbarProgress {
-	fn drop(&mut self) {}
+    fn drop(&mut self) {}
 }

--- a/czkawka_gui/src/taskbar_progress_dummy.rs
+++ b/czkawka_gui/src/taskbar_progress_dummy.rs
@@ -4,7 +4,8 @@ use std::convert::From;
 enum HWND__ {}
 type HWND = *mut HWND__;
 
-enum TBPFLAG {
+#[allow(non_camel_case_types, dead_code)]
+pub enum TBPFLAG {
 	TBPF_NOPROGRESS = 0,
 	TBPF_INDETERMINATE = 0x1,
 	TBPF_NORMAL = 0x2,
@@ -13,7 +14,7 @@ enum TBPFLAG {
 }
 
 pub mod tbp_flags {
-	use TBPFLAG::*;
+	pub use super::TBPFLAG::*;
 }
 
 pub struct TaskbarProgress {}
@@ -23,14 +24,13 @@ impl TaskbarProgress {
 		TaskbarProgress {}
 	}
 
-	pub fn set_progress_state(&self, tbp_flags: TBPFLAG) {}
+	pub fn set_progress_state(&self, _tbp_flags: TBPFLAG) {}
 
-	pub fn set_progress_value(&self, completed: u64, total: u64) {}
+	pub fn set_progress_value(&self, _completed: u64, _total: u64) {}
 }
 
 impl From<HWND> for TaskbarProgress {
-
-	fn from(hwnd: HWND) -> Self {
+	fn from(_hwnd: HWND) -> Self {
 		TaskbarProgress {}
 	}
 }

--- a/czkawka_gui/src/taskbar_progress_dummy.rs
+++ b/czkawka_gui/src/taskbar_progress_dummy.rs
@@ -1,0 +1,41 @@
+#![cfg(not(target_os = "windows"))]
+
+type HRESULT = i32;
+enum HWND__ {}
+type HWND = *mut HWND__;
+
+enum TBPFLAG {
+	TBPF_NOPROGRESS = 0,
+	TBPF_INDETERMINATE = 0x1,
+	TBPF_NORMAL = 0x2,
+	TBPF_ERROR = 0x4,
+	TBPF_PAUSED = 0x8,
+}
+
+pub mod tbp_flags {
+	use TBPFLAG::*;
+}
+
+pub struct TaskbarProgress {}
+
+impl TaskbarProgress {
+	pub fn new() -> Result<TaskbarProgress, HRESULT> {
+		TaskbarProgress {}
+	}
+
+	pub fn set_progress_state(&self, tbp_flags: TBPFLAG) -> Result<(), HRESULT> {}
+
+	pub fn set_progress_value(&self, completed: u64, total: u64) -> Result<(), HRESULT> {}
+}
+
+impl TryFrom<HWND> for TaskbarProgress {
+	type Error = HRESULT;
+
+	fn try_from(hwnd: HWND) -> Result<Self, Self::Error> {
+		Ok(TaskbarProgress {})
+	}
+}
+
+impl Drop for TaskbarProgress {
+	fn drop(&mut self) {}
+}

--- a/czkawka_gui/src/taskbar_progress_dummy.rs
+++ b/czkawka_gui/src/taskbar_progress_dummy.rs
@@ -1,6 +1,6 @@
 #![cfg(not(target_os = "windows"))]
+use std::convert::From;
 
-type HRESULT = i32;
 enum HWND__ {}
 type HWND = *mut HWND__;
 
@@ -19,20 +19,19 @@ pub mod tbp_flags {
 pub struct TaskbarProgress {}
 
 impl TaskbarProgress {
-	pub fn new() -> Result<TaskbarProgress, HRESULT> {
+	pub fn new() -> TaskbarProgress {
 		TaskbarProgress {}
 	}
 
-	pub fn set_progress_state(&self, tbp_flags: TBPFLAG) -> Result<(), HRESULT> {}
+	pub fn set_progress_state(&self, tbp_flags: TBPFLAG) {}
 
-	pub fn set_progress_value(&self, completed: u64, total: u64) -> Result<(), HRESULT> {}
+	pub fn set_progress_value(&self, completed: u64, total: u64) {}
 }
 
-impl TryFrom<HWND> for TaskbarProgress {
-	type Error = HRESULT;
+impl From<HWND> for TaskbarProgress {
 
-	fn try_from(hwnd: HWND) -> Result<Self, Self::Error> {
-		Ok(TaskbarProgress {})
+	fn from(hwnd: HWND) -> Self {
+		TaskbarProgress {}
 	}
 }
 

--- a/czkawka_gui/src/taskbar_progress_dummy.rs
+++ b/czkawka_gui/src/taskbar_progress_dummy.rs
@@ -31,6 +31,8 @@ impl TaskbarProgress {
     pub fn hide(&self) {}
 
     pub fn show(&self) {}
+
+    pub fn release(&mut self) {}
 }
 
 impl From<HWND> for TaskbarProgress {

--- a/czkawka_gui/src/taskbar_progress_dummy.rs
+++ b/czkawka_gui/src/taskbar_progress_dummy.rs
@@ -27,6 +27,10 @@ impl TaskbarProgress {
     pub fn set_progress_state(&self, _tbp_flags: TBPFLAG) {}
 
     pub fn set_progress_value(&self, _completed: u64, _total: u64) {}
+
+    pub fn hide(&self) {}
+
+    pub fn show(&self) {}
 }
 
 impl From<HWND> for TaskbarProgress {

--- a/czkawka_gui/src/taskbar_progress_win.rs
+++ b/czkawka_gui/src/taskbar_progress_win.rs
@@ -12,107 +12,107 @@ use winapi::um::{combaseapi, objbase, winuser};
 use winapi::Interface;
 
 pub mod tbp_flags {
-	pub use winapi::um::shobjidl_core::{TBPF_ERROR, TBPF_INDETERMINATE, TBPF_NOPROGRESS, TBPF_NORMAL, TBPF_PAUSED};
+    pub use winapi::um::shobjidl_core::{TBPF_ERROR, TBPF_INDETERMINATE, TBPF_NOPROGRESS, TBPF_NORMAL, TBPF_PAUSED};
 }
 
 pub struct TaskbarProgress {
-	hwnd: HWND,
-	taskbar_list: *mut ITaskbarList3,
-	current_state: RefCell<TBPFLAG>,
-	current_progress: RefCell<(u64, u64)>,
-	must_uninit_com: bool,
+    hwnd: HWND,
+    taskbar_list: *mut ITaskbarList3,
+    current_state: RefCell<TBPFLAG>,
+    current_progress: RefCell<(u64, u64)>,
+    must_uninit_com: bool,
 }
 
 impl TaskbarProgress {
-	pub fn new() -> TaskbarProgress {
-		let hwnd = unsafe { winuser::GetActiveWindow() };
-		TaskbarProgress::from(hwnd)
-	}
+    pub fn new() -> TaskbarProgress {
+        let hwnd = unsafe { winuser::GetActiveWindow() };
+        TaskbarProgress::from(hwnd)
+    }
 
-	pub fn set_progress_state(&self, tbp_flags: TBPFLAG) {
-		if tbp_flags == *self.current_state.borrow() {
-			return ();
-		}
-		let result = unsafe {
-			if let Some(list) = self.taskbar_list.as_ref() {
-				list.SetProgressState(self.hwnd, tbp_flags)
-			} else {
-				E_POINTER
-			}
-		};
-		if result == S_OK {
-			self.current_state.replace(tbp_flags);
-		}
-	}
+    pub fn set_progress_state(&self, tbp_flags: TBPFLAG) {
+        if tbp_flags == *self.current_state.borrow() {
+            return ();
+        }
+        let result = unsafe {
+            if let Some(list) = self.taskbar_list.as_ref() {
+                list.SetProgressState(self.hwnd, tbp_flags)
+            } else {
+                E_POINTER
+            }
+        };
+        if result == S_OK {
+            self.current_state.replace(tbp_flags);
+        }
+    }
 
-	pub fn set_progress_value(&self, completed: u64, total: u64) {
-		if (completed, total) == *self.current_progress.borrow() {
-			return ();
-		}
-		let result = unsafe {
-			if let Some(list) = self.taskbar_list.as_ref() {
-				list.SetProgressValue(self.hwnd, completed, total)
-			} else {
-				E_POINTER
-			}
-		};
-		if result == S_OK {
-			self.current_progress.replace((completed, total));
-		}
-	}
+    pub fn set_progress_value(&self, completed: u64, total: u64) {
+        if (completed, total) == *self.current_progress.borrow() {
+            return ();
+        }
+        let result = unsafe {
+            if let Some(list) = self.taskbar_list.as_ref() {
+                list.SetProgressValue(self.hwnd, completed, total)
+            } else {
+                E_POINTER
+            }
+        };
+        if result == S_OK {
+            self.current_progress.replace((completed, total));
+        }
+    }
 }
 
 impl From<HWND> for TaskbarProgress {
-	fn from(hwnd: HWND) -> Self {
-		if hwnd.is_null() {
-			return TaskbarProgress {
-				hwnd,
-				taskbar_list: ptr::null_mut(),
-				current_state: RefCell::new(tbp_flags::TBPF_NOPROGRESS),
-				current_progress: RefCell::new((0, 0)),
-				must_uninit_com: false,
-			};
-		}
+    fn from(hwnd: HWND) -> Self {
+        if hwnd.is_null() {
+            return TaskbarProgress {
+                hwnd,
+                taskbar_list: ptr::null_mut(),
+                current_state: RefCell::new(tbp_flags::TBPF_NOPROGRESS),
+                current_progress: RefCell::new((0, 0)),
+                must_uninit_com: false,
+            };
+        }
 
-		let init_result = unsafe { combaseapi::CoInitializeEx(ptr::null_mut(), objbase::COINIT_APARTMENTTHREADED) };
-		// S_FALSE means that COM library is already initialised for this thread
-		// Success codes are not negative, RPC_E_CHANGED_MODE should not be possible and is treated as an error
-		if init_result < 0 {
-			return TaskbarProgress {
-				hwnd: ptr::null_mut(),
-				taskbar_list: ptr::null_mut(),
-				current_state: RefCell::new(tbp_flags::TBPF_NOPROGRESS),
-				current_progress: RefCell::new((0, 0)),
-				must_uninit_com: false,
-			};
-		}
+        let init_result = unsafe { combaseapi::CoInitializeEx(ptr::null_mut(), objbase::COINIT_APARTMENTTHREADED) };
+        // S_FALSE means that COM library is already initialised for this thread
+        // Success codes are not negative, RPC_E_CHANGED_MODE should not be possible and is treated as an error
+        if init_result < 0 {
+            return TaskbarProgress {
+                hwnd: ptr::null_mut(),
+                taskbar_list: ptr::null_mut(),
+                current_state: RefCell::new(tbp_flags::TBPF_NOPROGRESS),
+                current_progress: RefCell::new((0, 0)),
+                must_uninit_com: false,
+            };
+        }
 
-		let mut taskbar_list: *mut ITaskbarList3 = ptr::null_mut();
-		let taskbar_list_ptr: *mut *mut ITaskbarList3 = &mut taskbar_list;
+        let mut taskbar_list: *mut ITaskbarList3 = ptr::null_mut();
+        let taskbar_list_ptr: *mut *mut ITaskbarList3 = &mut taskbar_list;
 
-		unsafe { combaseapi::CoCreateInstance(&CLSID_TaskbarList, ptr::null_mut(), CLSCTX_INPROC_SERVER, &ITaskbarList3::uuidof(), taskbar_list_ptr as *mut *mut c_void) };
+        unsafe { combaseapi::CoCreateInstance(&CLSID_TaskbarList, ptr::null_mut(), CLSCTX_INPROC_SERVER, &ITaskbarList3::uuidof(), taskbar_list_ptr as *mut *mut c_void) };
 
-		TaskbarProgress {
-			hwnd: if taskbar_list.is_null() { ptr::null_mut() } else { hwnd },
-			taskbar_list,
-			current_state: RefCell::new(tbp_flags::TBPF_NOPROGRESS), // Assume no progress
-			current_progress: RefCell::new((0, 0)),
-			must_uninit_com: true,
-		}
-	}
+        TaskbarProgress {
+            hwnd: if taskbar_list.is_null() { ptr::null_mut() } else { hwnd },
+            taskbar_list,
+            current_state: RefCell::new(tbp_flags::TBPF_NOPROGRESS), // Assume no progress
+            current_progress: RefCell::new((0, 0)),
+            must_uninit_com: true,
+        }
+    }
 }
 
 impl Drop for TaskbarProgress {
-	fn drop(&mut self) {
-		unsafe {
-			if let Some(list) = self.taskbar_list.as_ref() {
-				list.Release();
-			}
-			// A thread must call CoUninitialize once for each successful call it has made to
-			// the CoInitialize or CoInitializeEx function, including any call that returns S_FALSE.
-			if self.must_uninit_com {
-				combaseapi::CoUninitialize();
-			}
-		}
-	}
+    fn drop(&mut self) {
+        unsafe {
+            if let Some(list) = self.taskbar_list.as_ref() {
+                list.Release();
+            }
+            // A thread must call CoUninitialize once for each successful call it has made to
+            // the CoInitialize or CoInitializeEx function, including any call that returns S_FALSE.
+            if self.must_uninit_com {
+                combaseapi::CoUninitialize();
+            }
+        }
+    }
 }

--- a/czkawka_gui/src/taskbar_progress_win.rs
+++ b/czkawka_gui/src/taskbar_progress_win.rs
@@ -1,0 +1,126 @@
+#![cfg(target_os = "windows")]
+extern crate winapi;
+use std::{cell::RefCell, convert::TryFrom, ptr};
+use winapi::ctypes::c_void;
+use winapi::shared::guiddef::GUID;
+use winapi::shared::windef::HWND;
+use winapi::shared::winerror::{E_POINTER, HRESULT, RPC_E_CHANGED_MODE, S_FALSE, S_OK};
+use winapi::shared::wtypesbase::CLSCTX_INPROC_SERVER;
+use winapi::um::shobjidl_core::{CLSID_TaskbarList, ITaskbarList3, TBPFLAG};
+use winapi::um::unknwnbase::IUnknown;
+use winapi::um::{combaseapi, objbase, winuser};
+
+pub mod tbp_flags {
+	pub use winapi::um::shobjidl_core::{TBPF_ERROR, TBPF_INDETERMINATE, TBPF_NOPROGRESS, TBPF_NORMAL, TBPF_PAUSED};
+}
+
+pub struct TaskbarProgress {
+	hwnd: HWND,
+	taskbar_list: *mut ITaskbarList3,
+	com_was_init: bool,
+	current_state: RefCell<TBPFLAG>,
+	current_progress: RefCell<(u64, u64)>,
+}
+
+impl TaskbarProgress {
+	pub fn new() -> Result<TaskbarProgress, HRESULT> {
+		let hwnd = unsafe { winuser::GetActiveWindow() };
+		TaskbarProgress::try_from(hwnd)
+	}
+
+	pub fn set_progress_state(&self, tbp_flags: TBPFLAG) -> Result<(), HRESULT> {
+		if tbp_flags == *self.current_state.borrow() {
+			return Ok(());
+		}
+		let result = unsafe {
+			if let Some(list) = self.taskbar_list.as_ref() {
+				list.SetProgressState(self.hwnd, tbp_flags)
+			} else {
+				E_POINTER
+			}
+		};
+		if result == S_OK {
+			self.current_state.replace(tbp_flags);
+			Ok(())
+		} else {
+			Err(result)
+		}
+	}
+
+	pub fn set_progress_value(&self, completed: u64, total: u64) -> Result<(), HRESULT> {
+		if (completed, total) == *self.current_progress.borrow() {
+			return Ok(());
+		}
+		let result = unsafe {
+			if let Some(list) = self.taskbar_list.as_ref() {
+				list.SetProgressValue(self.hwnd, completed, total)
+			} else {
+				E_POINTER
+			}
+		};
+		if result == S_OK {
+			self.current_progress.replace((completed, total));
+			Ok(())
+		} else {
+			Err(result)
+		}
+	}
+}
+
+impl TryFrom<HWND> for TaskbarProgress {
+	type Error = HRESULT;
+
+	fn try_from(hwnd: HWND) -> Result<Self, Self::Error> {
+		if hwnd.is_null() {
+			return Err(E_POINTER);
+		}
+
+		// IIDs are not listed in winapi, but I found them here:
+		// https://referencesource.microsoft.com/#PresentationFramework/src/Framework/System/Windows/Standard/ComGuids.cs,44
+		// IID_ITaskbarList3 "ea1afb91-9e28-4b86-90e9-9e9f8a5eefaf"
+		#[allow(non_upper_case_globals)]
+		const IID_ITaskbarList3: GUID = GUID {
+			Data1: 0xea1afb91,
+			Data2: 0x9e28,
+			Data3: 0x4b86,
+			Data4: [0x90, 0xe9, 0x9e, 0x9f, 0x8a, 0x5e, 0xef, 0xaf],
+		};
+
+		let init_result = unsafe { combaseapi::CoInitializeEx(ptr::null_mut::<c_void>(), objbase::COINIT_APARTMENTTHREADED) };
+		// S_FALSE means that COM library is already initialised for this thread
+		// RPC_E_CHANGED_MODE means that COM was initialised in multithreaded mode, this call may have changed it
+		if init_result != S_OK && init_result != S_FALSE && init_result != RPC_E_CHANGED_MODE {
+			return Err(init_result);
+		}
+
+		let com_was_init = init_result != S_OK;
+		let mut taskbar_list: *mut ITaskbarList3 = ptr::null_mut();
+		let taskbar_list_ptr: *mut *mut ITaskbarList3 = &mut taskbar_list;
+
+		let create_result = unsafe { combaseapi::CoCreateInstance(&CLSID_TaskbarList, ptr::null_mut::<IUnknown>(), CLSCTX_INPROC_SERVER, &IID_ITaskbarList3, taskbar_list_ptr as *mut *mut c_void) };
+		if taskbar_list.is_null() {
+			return Err(create_result);
+		}
+
+		Ok(TaskbarProgress {
+			hwnd,
+			taskbar_list,
+			com_was_init,
+			current_state: RefCell::new(tbp_flags::TBPF_NOPROGRESS), // Assume no progress
+			current_progress: RefCell::new((0, 0)),
+		})
+	}
+}
+
+impl Drop for TaskbarProgress {
+	fn drop(&mut self) {
+		unsafe {
+			if let Some(list) = self.taskbar_list.as_ref() {
+				list.Release();
+			}
+			if !self.com_was_init {
+				combaseapi::CoUninitialize();
+			}
+		}
+	}
+}

--- a/czkawka_gui/src/taskbar_progress_win.rs
+++ b/czkawka_gui/src/taskbar_progress_win.rs
@@ -1,14 +1,16 @@
 #![cfg(target_os = "windows")]
 extern crate winapi;
-use std::{cell::RefCell, convert::TryFrom, ptr};
+use std::cell::RefCell;
+use std::convert::TryFrom;
+use std::ptr;
 use winapi::ctypes::c_void;
-use winapi::shared::guiddef::GUID;
 use winapi::shared::windef::HWND;
-use winapi::shared::winerror::{E_POINTER, HRESULT, RPC_E_CHANGED_MODE, S_FALSE, S_OK};
+use winapi::shared::winerror::{E_POINTER, HRESULT, S_OK};
 use winapi::shared::wtypesbase::CLSCTX_INPROC_SERVER;
 use winapi::um::shobjidl_core::{CLSID_TaskbarList, ITaskbarList3, TBPFLAG};
 use winapi::um::unknwnbase::IUnknown;
 use winapi::um::{combaseapi, objbase, winuser};
+use winapi::Interface;
 
 pub mod tbp_flags {
 	pub use winapi::um::shobjidl_core::{TBPF_ERROR, TBPF_INDETERMINATE, TBPF_NOPROGRESS, TBPF_NORMAL, TBPF_PAUSED};
@@ -17,7 +19,6 @@ pub mod tbp_flags {
 pub struct TaskbarProgress {
 	hwnd: HWND,
 	taskbar_list: *mut ITaskbarList3,
-	com_was_init: bool,
 	current_state: RefCell<TBPFLAG>,
 	current_progress: RefCell<(u64, u64)>,
 }
@@ -75,29 +76,17 @@ impl TryFrom<HWND> for TaskbarProgress {
 			return Err(E_POINTER);
 		}
 
-		// IIDs are not listed in winapi, but I found them here:
-		// https://referencesource.microsoft.com/#PresentationFramework/src/Framework/System/Windows/Standard/ComGuids.cs,44
-		// IID_ITaskbarList3 "ea1afb91-9e28-4b86-90e9-9e9f8a5eefaf"
-		#[allow(non_upper_case_globals)]
-		const IID_ITaskbarList3: GUID = GUID {
-			Data1: 0xea1afb91,
-			Data2: 0x9e28,
-			Data3: 0x4b86,
-			Data4: [0x90, 0xe9, 0x9e, 0x9f, 0x8a, 0x5e, 0xef, 0xaf],
-		};
-
 		let init_result = unsafe { combaseapi::CoInitializeEx(ptr::null_mut::<c_void>(), objbase::COINIT_APARTMENTTHREADED) };
 		// S_FALSE means that COM library is already initialised for this thread
-		// RPC_E_CHANGED_MODE means that COM was initialised in multithreaded mode, this call may have changed it
-		if init_result != S_OK && init_result != S_FALSE && init_result != RPC_E_CHANGED_MODE {
+		// Success codes are not negative, RPC_E_CHANGED_MODE should not be possible and is treated as an error
+		if init_result < 0 {
 			return Err(init_result);
 		}
 
-		let com_was_init = init_result != S_OK;
 		let mut taskbar_list: *mut ITaskbarList3 = ptr::null_mut();
 		let taskbar_list_ptr: *mut *mut ITaskbarList3 = &mut taskbar_list;
 
-		let create_result = unsafe { combaseapi::CoCreateInstance(&CLSID_TaskbarList, ptr::null_mut::<IUnknown>(), CLSCTX_INPROC_SERVER, &IID_ITaskbarList3, taskbar_list_ptr as *mut *mut c_void) };
+		let create_result = unsafe { combaseapi::CoCreateInstance(&CLSID_TaskbarList, ptr::null_mut::<IUnknown>(), CLSCTX_INPROC_SERVER, &ITaskbarList3::uuidof(), taskbar_list_ptr as *mut *mut c_void) };
 		if taskbar_list.is_null() {
 			return Err(create_result);
 		}
@@ -105,7 +94,6 @@ impl TryFrom<HWND> for TaskbarProgress {
 		Ok(TaskbarProgress {
 			hwnd,
 			taskbar_list,
-			com_was_init,
 			current_state: RefCell::new(tbp_flags::TBPF_NOPROGRESS), // Assume no progress
 			current_progress: RefCell::new((0, 0)),
 		})
@@ -118,9 +106,9 @@ impl Drop for TaskbarProgress {
 			if let Some(list) = self.taskbar_list.as_ref() {
 				list.Release();
 			}
-			if !self.com_was_init {
-				combaseapi::CoUninitialize();
-			}
+			// A thread must call CoUninitialize once for each successful call it has made to
+			// the CoInitialize or CoInitializeEx function, including any call that returns S_FALSE.
+			combaseapi::CoUninitialize();
 		}
 	}
 }

--- a/czkawka_gui/src/taskbar_progress_win.rs
+++ b/czkawka_gui/src/taskbar_progress_win.rs
@@ -1,14 +1,13 @@
 #![cfg(target_os = "windows")]
 extern crate winapi;
 use std::cell::RefCell;
-use std::convert::TryFrom;
+use std::convert::From;
 use std::ptr;
 use winapi::ctypes::c_void;
 use winapi::shared::windef::HWND;
-use winapi::shared::winerror::{E_POINTER, HRESULT, S_OK};
+use winapi::shared::winerror::{E_POINTER, S_OK};
 use winapi::shared::wtypesbase::CLSCTX_INPROC_SERVER;
 use winapi::um::shobjidl_core::{CLSID_TaskbarList, ITaskbarList3, TBPFLAG};
-use winapi::um::unknwnbase::IUnknown;
 use winapi::um::{combaseapi, objbase, winuser};
 use winapi::Interface;
 
@@ -21,17 +20,18 @@ pub struct TaskbarProgress {
 	taskbar_list: *mut ITaskbarList3,
 	current_state: RefCell<TBPFLAG>,
 	current_progress: RefCell<(u64, u64)>,
+	must_uninit_com: bool,
 }
 
 impl TaskbarProgress {
-	pub fn new() -> Result<TaskbarProgress, HRESULT> {
+	pub fn new() -> TaskbarProgress {
 		let hwnd = unsafe { winuser::GetActiveWindow() };
-		TaskbarProgress::try_from(hwnd)
+		TaskbarProgress::from(hwnd)
 	}
 
-	pub fn set_progress_state(&self, tbp_flags: TBPFLAG) -> Result<(), HRESULT> {
+	pub fn set_progress_state(&self, tbp_flags: TBPFLAG) {
 		if tbp_flags == *self.current_state.borrow() {
-			return Ok(());
+			return ();
 		}
 		let result = unsafe {
 			if let Some(list) = self.taskbar_list.as_ref() {
@@ -42,15 +42,12 @@ impl TaskbarProgress {
 		};
 		if result == S_OK {
 			self.current_state.replace(tbp_flags);
-			Ok(())
-		} else {
-			Err(result)
 		}
 	}
 
-	pub fn set_progress_value(&self, completed: u64, total: u64) -> Result<(), HRESULT> {
+	pub fn set_progress_value(&self, completed: u64, total: u64) {
 		if (completed, total) == *self.current_progress.borrow() {
-			return Ok(());
+			return ();
 		}
 		let result = unsafe {
 			if let Some(list) = self.taskbar_list.as_ref() {
@@ -61,42 +58,47 @@ impl TaskbarProgress {
 		};
 		if result == S_OK {
 			self.current_progress.replace((completed, total));
-			Ok(())
-		} else {
-			Err(result)
 		}
 	}
 }
 
-impl TryFrom<HWND> for TaskbarProgress {
-	type Error = HRESULT;
-
-	fn try_from(hwnd: HWND) -> Result<Self, Self::Error> {
+impl From<HWND> for TaskbarProgress {
+	fn from(hwnd: HWND) -> Self {
 		if hwnd.is_null() {
-			return Err(E_POINTER);
+			return TaskbarProgress {
+				hwnd,
+				taskbar_list: ptr::null_mut(),
+				current_state: RefCell::new(tbp_flags::TBPF_NOPROGRESS),
+				current_progress: RefCell::new((0, 0)),
+				must_uninit_com: false,
+			};
 		}
 
-		let init_result = unsafe { combaseapi::CoInitializeEx(ptr::null_mut::<c_void>(), objbase::COINIT_APARTMENTTHREADED) };
+		let init_result = unsafe { combaseapi::CoInitializeEx(ptr::null_mut(), objbase::COINIT_APARTMENTTHREADED) };
 		// S_FALSE means that COM library is already initialised for this thread
 		// Success codes are not negative, RPC_E_CHANGED_MODE should not be possible and is treated as an error
 		if init_result < 0 {
-			return Err(init_result);
+			return TaskbarProgress {
+				hwnd: ptr::null_mut(),
+				taskbar_list: ptr::null_mut(),
+				current_state: RefCell::new(tbp_flags::TBPF_NOPROGRESS),
+				current_progress: RefCell::new((0, 0)),
+				must_uninit_com: false,
+			};
 		}
 
 		let mut taskbar_list: *mut ITaskbarList3 = ptr::null_mut();
 		let taskbar_list_ptr: *mut *mut ITaskbarList3 = &mut taskbar_list;
 
-		let create_result = unsafe { combaseapi::CoCreateInstance(&CLSID_TaskbarList, ptr::null_mut::<IUnknown>(), CLSCTX_INPROC_SERVER, &ITaskbarList3::uuidof(), taskbar_list_ptr as *mut *mut c_void) };
-		if taskbar_list.is_null() {
-			return Err(create_result);
-		}
+		unsafe { combaseapi::CoCreateInstance(&CLSID_TaskbarList, ptr::null_mut(), CLSCTX_INPROC_SERVER, &ITaskbarList3::uuidof(), taskbar_list_ptr as *mut *mut c_void) };
 
-		Ok(TaskbarProgress {
-			hwnd,
+		TaskbarProgress {
+			hwnd: if taskbar_list.is_null() { ptr::null_mut() } else { hwnd },
 			taskbar_list,
 			current_state: RefCell::new(tbp_flags::TBPF_NOPROGRESS), // Assume no progress
 			current_progress: RefCell::new((0, 0)),
-		})
+			must_uninit_com: true,
+		}
 	}
 }
 
@@ -108,7 +110,9 @@ impl Drop for TaskbarProgress {
 			}
 			// A thread must call CoUninitialize once for each successful call it has made to
 			// the CoInitialize or CoInitializeEx function, including any call that returns S_FALSE.
-			combaseapi::CoUninitialize();
+			if self.must_uninit_com {
+				combaseapi::CoUninitialize();
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR adds support for taskbar progress (#176) on Windows (7+). It should be also possible to implement it for some Linux systems using [libxapp](https://github.com/linuxmint/xapp), but I did not find Rust bindings for it.

However, there are some problems to solve and things to improve:

- [ ] Taskbar progress is not available before Windows 7 and I have no idea what will happen on earlier versions. Runtime version checks could be added (using [VerifyVersionInfoA](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-verifyversioninfoa)) if the GUI is supposed to run on older Windows versions.
- [x] If error and pause states will not be used (not supported in XApp anyway), setting the normal progress state is not necessary (setting value changes the state to normal from indeterminate and no progress).
- [x] **IMPORTANT:** The struct is never dropped and COM is not uninitialised properly. It looks like the clones of `GuiData` and `Rc<TaskbarProgress>` moved to closures used as signal handlers or spawned in the main context [are not dropped](https://gist.github.com/krzysdz/6f28f7938b33a0e7210b7a09dcd7a4f9#file-not_dropped-txt).

Comments and suggestions are welcome.