### PR TITLE
Fix Winows theme in CI builds

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -241,7 +241,7 @@ jobs:
           echo "gtk-theme-name = admin-gtk3-dark-osx" >> $GTK_APP/share/gtk-3.0/settings.ini
           echo "gtk-font-name = Segoe UI 10" >> $GTK_APP/share/gtk-3.0/settings.ini
           echo "gtk-xft-rgba = rgb" >> $GTK_APP/share/gtk-3.0/settings.ini
-          cp $GTK_THEME/AdMin-master/admin-gtk3-dark-osx $GTK_APP/share/themes -r
+          cp $GTK_THEME/AdMin-master/admin-gtk3-dark-osx $GTK_APP/share/themes -r -L
 
           zip -r gtk_app.zip $GTK_APP
         env:


### PR DESCRIPTION
The `admin-gtk3-dark-osx` theme contains relative symlinks, which after copying only this theme are no longer valid.\
The **-L** (**--dereference**) option makes `cp` always follow symbolic links, so that all of them are replaced with files they pointed to.

The `zip` command ignored these invalid symlinks (`zip warning: name not matched` in [logs](https://github.com/qarmin/czkawka/pull/264/checks?check_run_id=1915425586#step:7:44482)) and the CI builds didn't contain the `assets/`, `windows-assets/` directories and `assets.svg`, `assets.txt` files.

This fixes nrhodes91/AdMin#11.