### PR TITLE
Disable for now checking tga and gif files

### DIFF
--- a/czkawka_core/src/broken_files.rs
+++ b/czkawka_core/src/broken_files.rs
@@ -665,7 +665,7 @@ fn load_cache_from_file(text_messages: &mut Messages) -> Option<HashMap<String, 
 
 fn check_extension_avaibility(file_name_lowercase: &str) -> TypeOfFile {
     // Checking allowed image extensions
-    let allowed_image_extensions = [".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".tif", ".pnm", ".tga", ".ff", ".gif", ".jif", ".jfi", ".ico", ".webp", ".avif"];
+    let allowed_image_extensions = [".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".tif", ".pnm", ".ff", ".jif", ".jfi", ".ico", ".webp", ".avif"]; // TODO Re-enable broken files checking after image-rs update // tga, gif
     let allowed_archive_zip_extensions = [".zip"]; // Probably also should work [".xz", ".bz2"], but from my tests they not working
     let allowed_audio_extensions = [".mp3", ".flac", ".wav", ".ogg"]; // Probably also should work [".xz", ".bz2"], but from my tests they not working
     if allowed_image_extensions.iter().any(|e| file_name_lowercase.ends_with(e)) {

--- a/czkawka_core/src/similar_images.rs
+++ b/czkawka_core/src/similar_images.rs
@@ -265,7 +265,7 @@ impl SimilarImages {
                     .to_lowercase();
 
                     // Checking allowed image extensions
-                    let allowed_image_extensions = [".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".tif", ".pnm", ".tga", ".ff", ".gif", ".jif", ".jfi"];
+                    let allowed_image_extensions = [".jpg", ".jpeg", ".png", ".bmp", ".tiff", ".tif", ".pnm", ".ff", ".jif", ".jfi"];
                     if !allowed_image_extensions.iter().any(|e| file_name_lowercase.ends_with(e)) {
                         continue 'dir;
                     }


### PR DESCRIPTION
The latest fixes for `tga` and `gif` files are available in git of `image-rs` library but we must to use stable version due some dependencies, so it is better to disable for now checking this files.