### PR TITLE
Use xxhash-rust >=0.8.2 to avoid bug in stateful implementation

### DIFF
--- a/czkawka_core/Cargo.toml
+++ b/czkawka_core/Cargo.toml
@@ -37,7 +37,7 @@ rodio = { version = "0.13.0", optional = true }
 # Hashes
 blake3 = "0.3"
 crc32fast = "1.2.1"
-xxhash-rust = { version = "0.8.1", features = ["xxh3"] }
+xxhash-rust = { version = "0.8.2", features = ["xxh3"] }
 
 tempfile = "3.1"
 


### PR DESCRIPTION
Unfortunately stateful `Xxh3` had bug which resulted in it producing invalid hashes for total length of 1025 and more.
0.8.1 is not a valid version to use now