### PR TITLE
Update to Rust 1.51

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55f82cfe485775d02112886f4169bde0c5894d75e79ead7eafe7e40a25e45f7"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,9 +16,9 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "alsa"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb213f6b3e4b1480a60931ca2035794aa67b73103d254715b1db7b70dcb3c934"
+checksum = "75c4da790adcb2ce5e758c064b4f3ec17a30349f9961d3e5e6c9688b052a9e18"
 dependencies = [
  "alsa-sys",
  "bitflags",
@@ -56,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
+checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
 name = "arrayref"
@@ -71,12 +62,6 @@ name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
-name = "ascii"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
 name = "atk"
@@ -141,36 +126,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "backtrace"
-version = "0.3.56"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d117600f438b1707d4e4ae15d3595657288f8235a0eb593e80ecc98ab34e1bc"
-dependencies = [
- "addr2line",
- "cfg-if 1.0.0",
- "libc",
- "miniz_oxide 0.4.4",
- "object",
- "rustc-demangle",
-]
-
-[[package]]
-name = "base-x"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
-
-[[package]]
 name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
-
-[[package]]
-name = "base64"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bindgen"
@@ -294,6 +253,9 @@ name = "cc"
 version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cesu8"
@@ -331,15 +293,9 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time 0.1.43",
+ "time",
  "winapi",
 ]
-
-[[package]]
-name = "chunked_transfer"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff857943da45f546682664a79488be82e69e43c1a7a2307679ab9afb3a66d2e"
 
 [[package]]
 name = "clang-sys"
@@ -381,19 +337,6 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "combine"
-version = "3.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
-dependencies = [
- "ascii",
- "byteorder",
- "either",
- "memchr",
- "unreachable",
-]
-
-[[package]]
-name = "combine"
 version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc4369b5e4c0cddf64ad8981c0111e7df4f7078f4d6ba98fb31f2e17c4c57b7e"
@@ -403,43 +346,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_fn"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
-
-[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
-name = "cookie"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
-dependencies = [
- "percent-encoding",
- "time 0.2.25",
- "version_check",
-]
-
-[[package]]
-name = "cookie_store"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3818dfca4b0cb5211a659bbcbb94225b7127407b2b135e650d717bfb78ab10d3"
-dependencies = [
- "cookie",
- "idna",
- "log",
- "publicsuffix",
- "serde",
- "serde_json",
- "time 0.2.25",
- "url",
-]
 
 [[package]]
 name = "core-foundation-sys"
@@ -449,9 +359,9 @@ checksum = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 
 [[package]]
 name = "coreaudio-rs"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f229761965dad3e9b11081668a6ea00f1def7aa46062321b5ec245b834f6e491"
+checksum = "11894b20ebfe1ff903cbdc52259693389eea03b94918a2def2c30c3bf227ad88"
 dependencies = [
  "bitflags",
  "coreaudio-sys",
@@ -468,14 +378,14 @@ dependencies = [
 
 [[package]]
 name = "cpal"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05631e2089dfa5d3b6ea1cfbbfd092e2ee5deeb69698911bc976b28b746d3657"
+checksum = "840981d3f30230d9120328d64be72319dbbedabb61bcd4c370a54cdd051238ac"
 dependencies = [
  "alsa",
  "core-foundation-sys",
  "coreaudio-rs",
- "jni 0.17.0",
+ "jni",
  "js-sys",
  "lazy_static",
  "libc",
@@ -485,7 +395,7 @@ dependencies = [
  "nix",
  "oboe",
  "parking_lot",
- "stdweb 0.1.3",
+ "stdweb",
  "thiserror",
  "web-sys",
  "winapi",
@@ -692,49 +602,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "discard"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
-
-[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
-
-[[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "backtrace",
- "version_check",
-]
-
-[[package]]
-name = "fetch_unroll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d44807d562d137f063cbfe209da1c3f9f2fa8375e11166ef495daab7b847f9"
-dependencies = [
- "libflate",
- "tar",
- "ureq",
-]
-
-[[package]]
-name = "filetime"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "redox_syscall",
- "winapi",
-]
 
 [[package]]
 name = "flate2"
@@ -753,16 +624,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "form_urlencoded"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
-dependencies = [
- "matches",
- "percent-encoding",
-]
 
 [[package]]
 name = "futures"
@@ -944,19 +805,13 @@ dependencies = [
 
 [[package]]
 name = "gif"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02efba560f227847cb41463a7395c514d127d4f74fff12ef0137fff1b84b96c4"
+checksum = "5a668f699973d0f573d15749b7002a9ac9e1f9c6b220e7b165601334c173d8de"
 dependencies = [
  "color_quant",
  "weezl",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "gio"
@@ -1160,17 +1015,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
-name = "idna"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
 name = "image"
 version = "0.23.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1191,11 +1035,11 @@ dependencies = [
 
 [[package]]
 name = "img_hash"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df6c5bc88f37a165c63143e38924f691246fc77f12de0cbd126fe0c8ca3527b"
+checksum = "52057a4b155b3cc36b9cd5b20faaa60f506e39727efcffad7d090f0163fe0c6d"
 dependencies = [
- "base64 0.11.0",
+ "base64",
  "image",
  "rustdct",
  "serde",
@@ -1221,36 +1065,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
-
-[[package]]
 name = "jni"
-version = "0.14.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1981310da491a4f0f815238097d0d43d8072732b5ae5f8bd0d8eadf5bf245402"
+checksum = "24967112a1e4301ca5342ea339763613a37592b8a6ce6cf2e4494537c7a42faf"
 dependencies = [
  "cesu8",
- "combine 3.8.1",
- "error-chain",
+ "combine",
  "jni-sys",
  "log",
- "walkdir",
-]
-
-[[package]]
-name = "jni"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36bcc950632e48b86da402c5c077590583da5ac0d480103611d5374e7c967a3c"
-dependencies = [
- "cesu8",
- "combine 4.5.2",
- "error-chain",
- "jni-sys",
- "log",
+ "thiserror",
  "walkdir",
 ]
 
@@ -1259,6 +1083,15 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jobserver"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "jpeg-decoder"
@@ -1271,9 +1104,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.48"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc9f84f9b115ce7843d60706df1422a916680bfdfcbdb0447c5614ff9d7e4d78"
+checksum = "dc15e39392125075f60c95ba416f5381ff6c3a948ff02ab12464715adf56c821"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1303,27 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.88"
+version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a"
-
-[[package]]
-name = "libflate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389de7875e06476365974da3e7ff85d55f1972188ccd9f6020dd7c8156e17914"
-dependencies = [
- "adler32",
- "crc32fast",
- "libflate_lz77",
- "rle-decode-fast",
-]
-
-[[package]]
-name = "libflate_lz77"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3286f09f7d4926fc486334f28d8d2e6ebe4f7f9994494b6dab27ddfad2c9b11b"
+checksum = "8916b1f6ca17130ec6568feccee27c156ad12037880833a3b842a823236502e7"
 
 [[package]]
 name = "libloading"
@@ -1363,12 +1178,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matches"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
-
-[[package]]
 name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1376,9 +1185,9 @@ checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memoffset"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
+checksum = "cc14fc54a812b4472b4113facc3e44d099fbc0ea2ce0551fa5c703f8edfbfd38"
 dependencies = [
  "autocfg",
 ]
@@ -1451,9 +1260,9 @@ checksum = "64ae83441f6b67e3b7f009295618e90f03228b0f1a149f56ee8cd0f6bb5602c5"
 
 [[package]]
 name = "ndk"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb167c1febed0a496639034d0c76b3b74263636045db5489eee52143c246e73"
+checksum = "8794322172319b972f528bf90c6b467be0079f1fa82780ffb431088e741a73ab"
 dependencies = [
  "jni-sys",
  "ndk-sys",
@@ -1463,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "ndk-glue"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf399b8b7a39c6fb153c4ec32c72fd5fe789df24a647f229c239aa7adb15241"
+checksum = "c5caf0c24d51ac1c905c27d4eda4fa0635bbe0de596b8f79235e0b17a4d29385"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1496,15 +1305,14 @@ checksum = "c44922cb3dbb1c70b5e5f443d63b64363a898564d739ba5198e3a9138442868d"
 
 [[package]]
 name = "nix"
-version = "0.15.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2e0b4f3320ed72aaedb9a5ac838690a8047c7b275da22711fddff4f8a14229"
+checksum = "fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "void",
 ]
 
 [[package]]
@@ -1591,9 +1399,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca565a7df06f3d4b485494f25ba05da1435950f4dc263440eda7a6fa9b8e36e4"
+checksum = "226b45a5c2ac4dd696ed30fa6b94b057ad909c7b7fc2e0d0808192bced894066"
 dependencies = [
  "derivative",
  "num_enum_derive",
@@ -1601,9 +1409,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa5a33ddddfee04c0283a7653987d634e880347e96b5b2ed64de07efb59db9d"
+checksum = "1c0fd9eba1d5db0994a239e09c1be402d35622277e35468ba891aa5e3188ce7e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1612,18 +1420,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
-
-[[package]]
 name = "oboe"
-version = "0.3.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aadc2b0867bdbb9a81c4d99b9b682958f49dbea1295a81d2f646cca2afdd9fc"
+checksum = "4cfb2390bddb9546c0f7448fd1d2abdd39e6075206f960991eb28c7fa7f126c4"
 dependencies = [
- "jni 0.14.0",
+ "jni",
  "ndk",
  "ndk-glue",
  "num-derive",
@@ -1633,11 +1435,11 @@ dependencies = [
 
 [[package]]
 name = "oboe-sys"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ff7a51600eabe34e189eec5c995a62f151d8d97e5fbca39e87ca738bb99b82"
+checksum = "fe069264d082fc820dfa172f79be3f2e088ecfece9b1c47b0c9fd838d2bef103"
 dependencies = [
- "fetch_unroll",
+ "cc",
 ]
 
 [[package]]
@@ -1722,12 +1524,6 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
-name = "percent-encoding"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project-lite"
@@ -1817,25 +1613,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid",
-]
-
-[[package]]
-name = "publicsuffix"
-version = "1.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b4ce31ff0a27d93c8de1849cf58162283752f065a90d508f1105fa6c9a213f"
-dependencies = [
- "idna",
- "url",
-]
-
-[[package]]
-name = "qstring"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
-dependencies = [
- "percent-encoding",
 ]
 
 [[package]]
@@ -1933,18 +1710,18 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.3"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.22"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
 
 [[package]]
 name = "remove_dir_all"
@@ -1954,27 +1731,6 @@ checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin",
- "untrusted",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "rle-decode-fast"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 
 [[package]]
 name = "rodio"
@@ -1990,25 +1746,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver",
-]
 
 [[package]]
 name = "rustdct"
@@ -2033,25 +1774,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064fd21ff87c6e87ed4506e68beb42459caa4a0e2eb144932e6776768556980b"
-dependencies = [
- "base64 0.13.0",
- "log",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "ryu"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2073,66 +1795,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "sct"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
 name = "serde"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
+checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
+checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "serde_json"
-version = "1.0.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "sha1"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "shlex"
@@ -2164,74 +1844,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "standback"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2beb4d1860a61f571530b3f855a1b538d0200f7871c63331ecd6f17b1f014f8"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "stdweb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef5430c8e36b713e13b48a9f709cc21e046723fe44ce34587b73a830203b533e"
-
-[[package]]
-name = "stdweb"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
-dependencies = [
- "discard",
- "rustc_version",
- "stdweb-derive",
- "stdweb-internal-macros",
- "stdweb-internal-runtime",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "stdweb-derive"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-macros"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
-dependencies = [
- "base-x",
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "serde_json",
- "sha1",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-runtime"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "strength_reduce"
@@ -2301,9 +1917,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.63"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd9bc7ccc2688b3344c2f48b9b546648b25ce0b20fc717ee7fa7981a8ca9717"
+checksum = "f3a1d708c221c5a612956ef9f75b37e454e88d1f7b899fbd3a18d4252012d663"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2323,17 +1939,6 @@ dependencies = [
  "thiserror",
  "toml",
  "version-compare",
-]
-
-[[package]]
-name = "tar"
-version = "0.4.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0bcfbd6a598361fda270d82469fff3d65089dc33e175c9a131f7b4cd395f228"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
 ]
 
 [[package]]
@@ -2401,44 +2006,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1195b046942c221454c2539395f85413b33383a067449d78aab2b7b052a142f7"
-dependencies = [
- "const_fn",
- "libc",
- "standback",
- "stdweb 0.4.20",
- "time-macros",
- "version_check",
- "winapi",
-]
-
-[[package]]
-name = "time-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
-dependencies = [
- "proc-macro-hack",
- "time-macros-impl",
-]
-
-[[package]]
-name = "time-macros-impl"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "standback",
- "syn",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2489,27 +2056,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
-
-[[package]]
-name = "unicode-bidi"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
-dependencies = [
- "matches",
-]
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
-dependencies = [
- "tinyvec",
-]
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
 name = "unicode-segmentation"
@@ -2530,52 +2079,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
-name = "unreachable"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-dependencies = [
- "void",
-]
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "ureq"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "294b85ef5dbc3670a72e82a89971608a1fcc4ed5c7c5a2895230d31a95f0569b"
-dependencies = [
- "base64 0.13.0",
- "chunked_transfer",
- "cookie",
- "cookie_store",
- "log",
- "once_cell",
- "qstring",
- "rustls",
- "url",
- "webpki",
- "webpki-roots",
-]
-
-[[package]]
-name = "url"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
-dependencies = [
- "form_urlencoded",
- "idna",
- "matches",
- "percent-encoding",
-]
-
-[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2589,21 +2092,15 @@ checksum = "d63556a25bae6ea31b52e640d7c41d1ab27faba4ccb600013837a3d0b3994ca1"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "walkdir"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
 dependencies = [
  "same-file",
  "winapi",
@@ -2618,9 +2115,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee1280240b7c461d6a0071313e08f34a60b0365f14260362e5a2b17d1d31aa7"
+checksum = "8fe8f61dba8e5d645a4d8132dc7a0a66861ed5e1045d2c0ed940fab33bac0fbe"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -2628,9 +2125,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b7d8b6942b8bb3a9b0e73fc79b98095a27de6fa247615e59d096754a3bc2aa8"
+checksum = "046ceba58ff062da072c7cb4ba5b22a37f00a302483f7e2a6cdc18fedbdc1fd3"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2643,9 +2140,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ac38da8ef716661f0f36c0d8320b89028efe10c7c0afde65baffb496ce0d3b"
+checksum = "0ef9aa01d36cda046f797c57959ff5f3c615c9cc63997a8d545831ec7976819b"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2653,9 +2150,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
+checksum = "96eb45c1b2ee33545a813a92dbb53856418bf7eb54ab34f7f7ff1448a5b3735d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2666,37 +2163,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6f8ec44822dd71f5f221a5847fb34acd9060535c1211b70a05844c0f6383b1"
+checksum = "b7148f4696fb4960a346eaa60bbfb42a1ac4ebba21f750f75fc1375b098d5ffa"
 
 [[package]]
 name = "web-sys"
-version = "0.3.48"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec600b26223b2948cedfde2a0aa6756dcf1fef616f43d7b3097aaf53a6c4d92b"
+checksum = "59fe19d70f5dacc03f6e46777213facae5ac3801575d56ca6cbd4c93dcd12310"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82015b7e0b8bad8185994674a13a93306bea76cf5a16c5a181382fd3a5ec2376"
-dependencies = [
- "webpki",
 ]
 
 [[package]]
@@ -2747,15 +2225,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "xattr"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "xxhash-rust"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2772,5 +2241,5 @@ dependencies = [
  "crc32fast",
  "flate2",
  "thiserror",
- "time 0.1.43",
+ "time",
 ]

--- a/czkawka_cli/src/commands.rs
+++ b/czkawka_cli/src/commands.rs
@@ -256,8 +256,8 @@ impl FileToSave {
 fn parse_hash_type(src: &str) -> Result<HashType, &'static str> {
     match src.to_ascii_lowercase().as_str() {
         "blake3" => Ok(HashType::Blake3),
-        "crc32" => Ok(HashType::CRC32),
-        "xxh3" => Ok(HashType::XXH3),
+        "crc32" => Ok(HashType::Crc32),
+        "xxh3" => Ok(HashType::Xxh3),
         _ => Err("Couldn't parse the hash type (allowed: BLAKE3, CRC32, XXH3)"),
     }
 }
@@ -267,7 +267,7 @@ fn parse_checking_method(src: &str) -> Result<CheckingMethod, &'static str> {
         "name" => Ok(CheckingMethod::Name),
         "size" => Ok(CheckingMethod::Size),
         "hash" => Ok(CheckingMethod::Hash),
-        "hashmb" => Ok(CheckingMethod::HashMB),
+        "hashmb" => Ok(CheckingMethod::HashMb),
         _ => Err("Couldn't parse the search method (allowed: NAME, SIZE, HASH, HASHMB)"),
     }
 }

--- a/czkawka_core/src/broken_files.rs
+++ b/czkawka_core/src/broken_files.rs
@@ -48,7 +48,7 @@ pub struct FileEntry {
 pub enum TypeOfFile {
     Unknown = -1,
     Image = 0,
-    ArchiveZIP,
+    ArchiveZip,
     #[cfg(feature = "broken_audio")]
     Audio,
 }
@@ -315,18 +315,16 @@ impl BrokenFiles {
             };
 
             for (name, file_entry) in &self.files_to_check {
-                #[allow(clippy::collapsible_if)]
+                #[allow(clippy::if_same_then_else)]
                 if !loaded_hash_map.contains_key(name) {
                     // If loaded data doesn't contains current image info
                     non_cached_files_to_check.insert(name.clone(), file_entry.clone());
+                } else if file_entry.size != loaded_hash_map.get(name).unwrap().size || file_entry.modified_date != loaded_hash_map.get(name).unwrap().modified_date {
+                    // When size or modification date of image changed, then it is clear that is different image
+                    non_cached_files_to_check.insert(name.clone(), file_entry.clone());
                 } else {
-                    if file_entry.size != loaded_hash_map.get(name).unwrap().size || file_entry.modified_date != loaded_hash_map.get(name).unwrap().modified_date {
-                        // When size or modification date of image changed, then it is clear that is different image
-                        non_cached_files_to_check.insert(name.clone(), file_entry.clone());
-                    } else {
-                        // Checking may be omitted when already there is entry with same size and modification date
-                        records_already_cached.insert(name.clone(), loaded_hash_map.get(name).unwrap().clone());
-                    }
+                    // Checking may be omitted when already there is entry with same size and modification date
+                    records_already_cached.insert(name.clone(), loaded_hash_map.get(name).unwrap().clone());
                 }
             }
         } else {
@@ -392,7 +390,7 @@ impl BrokenFiles {
                             } // Something is wrong with image
                         }
                     }
-                    TypeOfFile::ArchiveZIP => match fs::File::open(&file_entry.path) {
+                    TypeOfFile::ArchiveZip => match fs::File::open(&file_entry.path) {
                         Ok(file) => match zip::ZipArchive::new(file) {
                             Ok(_) => Some(None),
                             Err(e) => {
@@ -687,7 +685,7 @@ fn check_extension_avaibility(file_name_lowercase: &str) -> TypeOfFile {
     if allowed_image_extensions.iter().any(|e| file_name_lowercase.ends_with(e)) {
         TypeOfFile::Image
     } else if allowed_archive_zip_extensions.iter().any(|e| file_name_lowercase.ends_with(e)) {
-        TypeOfFile::ArchiveZIP
+        TypeOfFile::ArchiveZip
     } else if allowed_audio_extensions.iter().any(|e| file_name_lowercase.ends_with(e)) {
         #[cfg(feature = "broken_audio")]
         {

--- a/czkawka_core/src/duplicate.rs
+++ b/czkawka_core/src/duplicate.rs
@@ -45,7 +45,7 @@ pub enum CheckingMethod {
     Name,
     Size,
     Hash,
-    HashMB,
+    HashMb,
 }
 
 impl MyHasher for blake3::Hasher {
@@ -78,16 +78,16 @@ impl MyHasher for xxhash_rust::xxh3::Xxh3 {
 #[derive(PartialEq, Eq, Clone, Debug, Copy)]
 pub enum HashType {
     Blake3,
-    CRC32,
-    XXH3,
+    Crc32,
+    Xxh3,
 }
 
 impl HashType {
     fn hasher(self: &HashType) -> Box<dyn MyHasher> {
         match self {
             HashType::Blake3 => Box::new(blake3::Hasher::new()),
-            HashType::CRC32 => Box::new(crc32fast::Hasher::new()),
-            HashType::XXH3 => Box::new(xxhash_rust::xxh3::Xxh3::new()),
+            HashType::Crc32 => Box::new(crc32fast::Hasher::new()),
+            HashType::Xxh3 => Box::new(xxhash_rust::xxh3::Xxh3::new()),
         }
     }
 }
@@ -193,7 +193,7 @@ impl DuplicateFinder {
                     return;
                 }
             }
-            CheckingMethod::HashMB | CheckingMethod::Hash => {
+            CheckingMethod::HashMb | CheckingMethod::Hash => {
                 if !self.check_files_size(stop_receiver, progress_sender) {
                     self.stopped_search = true;
                     return;
@@ -477,7 +477,7 @@ impl DuplicateFinder {
             let checking_method = self.check_method.clone();
             let max_stage = match self.check_method {
                 CheckingMethod::Size => 0,
-                CheckingMethod::HashMB | CheckingMethod::Hash => 2,
+                CheckingMethod::HashMb | CheckingMethod::Hash => 2,
                 _ => 255,
             };
             progress_thread_handle = thread::spawn(move || loop {
@@ -771,7 +771,7 @@ impl DuplicateFinder {
         let mut full_hash_results: Vec<(u64, HashMap<String, Vec<FileEntry>>, Vec<String>, u64)>;
 
         match self.check_method {
-            CheckingMethod::HashMB => {
+            CheckingMethod::HashMb => {
                 full_hash_results = pre_checked_map
                     .par_iter()
                     .map(|(size, vec_file_entry)| {
@@ -970,7 +970,7 @@ impl DuplicateFinder {
                     self.information.number_of_failed_to_remove_files += tuple.2;
                 }
             }
-            CheckingMethod::Hash | CheckingMethod::HashMB => {
+            CheckingMethod::Hash | CheckingMethod::HashMb => {
                 for vector_vectors in self.files_with_identical_hashes.values() {
                     for vector in vector_vectors.iter() {
                         let tuple: (u64, usize, usize) = delete_files(vector, &self.delete_method, &mut self.text_messages, self.dryrun);
@@ -1129,7 +1129,7 @@ impl SaveResults for DuplicateFinder {
                     write!(writer, "Not found any duplicates.").unwrap();
                 }
             }
-            CheckingMethod::Hash | CheckingMethod::HashMB => {
+            CheckingMethod::Hash | CheckingMethod::HashMb => {
                 if !self.files_with_identical_hashes.is_empty() {
                     writeln!(writer, "-------------------------------------------------Files with same hashes-------------------------------------------------").unwrap();
                     writeln!(
@@ -1183,7 +1183,7 @@ impl PrintResults for DuplicateFinder {
                     println!();
                 }
             }
-            CheckingMethod::Hash | CheckingMethod::HashMB => {
+            CheckingMethod::Hash | CheckingMethod::HashMb => {
                 for (_size, vector) in self.files_with_identical_hashes.iter() {
                     for j in vector {
                         number_of_files += j.len() as u64;
@@ -1317,7 +1317,7 @@ fn filter_hard_links(vec_file_entry: &[FileEntry]) -> Vec<FileEntry> {
     identical
 }
 
-pub fn make_hard_link(src: &PathBuf, dst: &PathBuf) -> io::Result<()> {
+pub fn make_hard_link(src: &Path, dst: &Path) -> io::Result<()> {
     let dst_dir = dst.parent().ok_or_else(|| Error::new(ErrorKind::Other, "No parent"))?;
     let temp = tempfile::Builder::new().tempfile_in(dst_dir)?;
     fs::rename(dst, temp.path())?;

--- a/czkawka_core/src/empty_folder.rs
+++ b/czkawka_core/src/empty_folder.rs
@@ -7,7 +7,7 @@ use crossbeam_channel::Receiver;
 use std::collections::BTreeMap;
 use std::fs::{File, Metadata};
 use std::io::{BufWriter, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::thread::sleep;
@@ -288,7 +288,7 @@ impl EmptyFolder {
     }
 }
 
-fn set_as_not_empty_folder(folders_checked: &mut BTreeMap<PathBuf, FolderEntry>, current_folder: &PathBuf) {
+fn set_as_not_empty_folder(folders_checked: &mut BTreeMap<PathBuf, FolderEntry>, current_folder: &Path) {
     // Not folder so it may be a file or symbolic link so it isn't empty
     folders_checked.get_mut(current_folder).unwrap().is_empty = FolderEmptiness::No;
     let mut d = folders_checked.get_mut(current_folder).unwrap();

--- a/czkawka_core/src/similar_images.rs
+++ b/czkawka_core/src/similar_images.rs
@@ -339,18 +339,16 @@ impl SimilarImages {
             };
 
             for (name, file_entry) in &self.images_to_check {
-                #[allow(clippy::collapsible_if)]
+                #[allow(clippy::if_same_then_else)]
                 if !loaded_hash_map.contains_key(name) {
                     // If loaded data doesn't contains current image info
                     non_cached_files_to_check.insert(name.clone(), file_entry.clone());
+                } else if file_entry.size != loaded_hash_map.get(name).unwrap().size || file_entry.modified_date != loaded_hash_map.get(name).unwrap().modified_date {
+                    // When size or modification date of image changed, then it is clear that is different image
+                    non_cached_files_to_check.insert(name.clone(), file_entry.clone());
                 } else {
-                    if file_entry.size != loaded_hash_map.get(name).unwrap().size || file_entry.modified_date != loaded_hash_map.get(name).unwrap().modified_date {
-                        // When size or modification date of image changed, then it is clear that is different image
-                        non_cached_files_to_check.insert(name.clone(), file_entry.clone());
-                    } else {
-                        // Checking may be omitted when already there is entry with same size and modification date
-                        records_already_cached.insert(name.clone(), loaded_hash_map.get(name).unwrap().clone());
-                    }
+                    // Checking may be omitted when already there is entry with same size and modification date
+                    records_already_cached.insert(name.clone(), loaded_hash_map.get(name).unwrap().clone());
                 }
             }
         } else {

--- a/czkawka_gui/src/connect_button_search.rs
+++ b/czkawka_gui/src/connect_button_search.rs
@@ -137,7 +137,7 @@ pub fn connect_button_search(
                 } else if radio_button_duplicates_size.get_active() {
                     check_method = duplicate::CheckingMethod::Size;
                 } else if radio_button_duplicates_hashmb.get_active() {
-                    check_method = duplicate::CheckingMethod::HashMB;
+                    check_method = duplicate::CheckingMethod::HashMb;
                 } else if radio_button_duplicates_hash.get_active() {
                     check_method = duplicate::CheckingMethod::Hash;
                 } else {
@@ -149,9 +149,9 @@ pub fn connect_button_search(
                 if radio_button_hash_type_blake3.get_active() {
                     hash_type = duplicate::HashType::Blake3;
                 } else if radio_button_hash_type_crc32.get_active() {
-                    hash_type = duplicate::HashType::CRC32;
+                    hash_type = duplicate::HashType::Crc32;
                 } else if radio_button_hash_type_xxh3.get_active() {
-                    hash_type = duplicate::HashType::XXH3;
+                    hash_type = duplicate::HashType::Xxh3;
                 } else {
                     panic!("No radio button is pressed");
                 }

--- a/czkawka_gui/src/connect_compute_results.rs
+++ b/czkawka_gui/src/connect_compute_results.rs
@@ -70,7 +70,7 @@ pub fn connect_compute_results(gui_data: &GuiData, glib_stop_receiver: Receiver<
                             duplicates_group = information.number_of_groups_by_name;
                             entry_info.set_text(format!("Found {} files in {} groups which have same names.", duplicates_number, duplicates_group).as_str());
                         }
-                        CheckingMethod::Hash | CheckingMethod::HashMB => {
+                        CheckingMethod::Hash | CheckingMethod::HashMb => {
                             duplicates_number = information.number_of_duplicated_files_by_hash;
                             duplicates_size = information.lost_space_by_hash;
                             duplicates_group = information.number_of_groups_by_hash;
@@ -132,7 +132,7 @@ pub fn connect_compute_results(gui_data: &GuiData, glib_stop_receiver: Receiver<
                                     }
                                 }
                             }
-                            CheckingMethod::Hash | CheckingMethod::HashMB => {
+                            CheckingMethod::Hash | CheckingMethod::HashMb => {
                                 let btreemap = df.get_files_sorted_by_hash();
 
                                 for (size, vectors_vector) in btreemap.iter().rev() {

--- a/czkawka_gui/src/connect_popovers.rs
+++ b/czkawka_gui/src/connect_popovers.rs
@@ -66,7 +66,7 @@ fn popover_all_except_oldest(popover: &gtk::Popover, tree_view: &gtk::TreeView, 
         let mut tree_iter_array: Vec<TreeIter> = Vec::new();
         let mut oldest_index: Option<usize> = None;
         let mut current_index: usize = 0;
-        let mut oldest_modification_time: u64 = u64::max_value();
+        let mut oldest_modification_time: u64 = u64::MAX;
 
         let mut file_length: usize = 0;
 
@@ -182,7 +182,7 @@ fn popover_one_oldest(popover: &gtk::Popover, tree_view: &gtk::TreeView, column_
         let mut tree_iter_array: Vec<TreeIter> = Vec::new();
         let mut oldest_index: Option<usize> = None;
         let mut current_index: usize = 0;
-        let mut oldest_modification_time: u64 = u64::max_value();
+        let mut oldest_modification_time: u64 = u64::MAX;
 
         let mut file_length: usize = 0;
 
@@ -294,7 +294,7 @@ fn popover_select_custom(popover: &gtk::Popover, gui_data: &GuiData, tree_view: 
         Path,
         Name,
         PathName,
-    };
+    }
     let wildcard_type: WildcardType;
 
     // Accept Dialog
@@ -410,7 +410,7 @@ fn popover_unselect_custom(popover: &gtk::Popover, gui_data: &GuiData, tree_view
         Path,
         Name,
         PathName,
-    };
+    }
     let wildcard_type: WildcardType;
 
     // Accept Dialog
@@ -590,8 +590,8 @@ fn popover_all_except_smallest(popover: &gtk::Popover, tree_view: &gtk::TreeView
         let mut tree_iter_array: Vec<TreeIter> = Vec::new();
         let mut smallest_index: Option<usize> = None;
         let mut current_index: usize = 0;
-        let mut smallest_size_as_bytes: u64 = u64::max_value();
-        let mut smallest_number_of_pixels: u64 = u64::max_value();
+        let mut smallest_size_as_bytes: u64 = u64::MAX;
+        let mut smallest_number_of_pixels: u64 = u64::MAX;
 
         loop {
             let color = tree_model.get_value(&tree_iter_all, column_color).get::<String>().unwrap().unwrap();

--- a/czkawka_gui/src/connect_progress_window.rs
+++ b/czkawka_gui/src/connect_progress_window.rs
@@ -32,7 +32,7 @@ pub fn connect_progress_window(
         let future = async move {
             while let Some(item) = futures_receiver_duplicate_files.next().await {
                 match item.checking_method {
-                    duplicate::CheckingMethod::Hash | duplicate::CheckingMethod::HashMB => {
+                    duplicate::CheckingMethod::Hash | duplicate::CheckingMethod::HashMb => {
                         label_stage.show();
                         match item.current_stage {
                             // Checking Size

--- a/czkawka_gui/src/gui_about.rs
+++ b/czkawka_gui/src/gui_about.rs
@@ -1,7 +1,7 @@
 use gtk::prelude::*;
 
 #[derive(Clone)]
-pub struct GUIAbout {
+pub struct GuiAbout {
     pub about_dialog: gtk::AboutDialog,
 
     pub button_repository: gtk::Button,
@@ -9,7 +9,7 @@ pub struct GUIAbout {
     pub button_instruction: gtk::Button,
 }
 
-impl GUIAbout {
+impl GuiAbout {
     pub fn create_from_builder(builder: &gtk::Builder) -> Self {
         let about_dialog: gtk::AboutDialog = builder.get_object("about_dialog").unwrap();
 

--- a/czkawka_gui/src/gui_bottom_buttons.rs
+++ b/czkawka_gui/src/gui_bottom_buttons.rs
@@ -2,7 +2,7 @@ use gtk::prelude::*;
 use gtk::Button;
 
 #[derive(Clone)]
-pub struct GUIBottomButtons {
+pub struct GuiBottomButtons {
     pub buttons_search: gtk::Button,
     pub buttons_select: gtk::Button,
     pub buttons_delete: gtk::Button,
@@ -14,7 +14,7 @@ pub struct GUIBottomButtons {
     pub buttons_array: [Button; 6],
 }
 
-impl GUIBottomButtons {
+impl GuiBottomButtons {
     pub fn create_from_builder(builder: &gtk::Builder) -> Self {
         let buttons_search: gtk::Button = builder.get_object("buttons_search").unwrap();
         let buttons_select: gtk::Button = builder.get_object("buttons_select").unwrap();

--- a/czkawka_gui/src/gui_data.rs
+++ b/czkawka_gui/src/gui_data.rs
@@ -1,12 +1,12 @@
 extern crate gtk;
-use crate::gui_about::GUIAbout;
-use crate::gui_bottom_buttons::GUIBottomButtons;
-use crate::gui_header::GUIHeader;
-use crate::gui_main_notebook::GUIMainNotebook;
-use crate::gui_popovers::GUIPopovers;
-use crate::gui_progress_dialog::GUIProgressDialog;
-use crate::gui_settings::GUISettings;
-use crate::gui_upper_notepad::GUIUpperNotebook;
+use crate::gui_about::GuiAbout;
+use crate::gui_bottom_buttons::GuiBottomButtons;
+use crate::gui_header::GuiHeader;
+use crate::gui_main_notebook::GuiMainNotebook;
+use crate::gui_popovers::GuiPopovers;
+use crate::gui_progress_dialog::GuiProgressDialog;
+use crate::gui_settings::GuiSettings;
+use crate::gui_upper_notepad::GuiUpperNotebook;
 use crate::notebook_enums::*;
 use crate::taskbar_progress::TaskbarProgress;
 use crossbeam_channel::unbounded;
@@ -35,14 +35,14 @@ pub struct GuiData {
     // Windows
     pub window_main: gtk::Window,
 
-    pub main_notebook: GUIMainNotebook,
-    pub upper_notebook: GUIUpperNotebook,
-    pub popovers: GUIPopovers,
-    pub bottom_buttons: GUIBottomButtons,
-    pub progress_window: GUIProgressDialog,
-    pub about: GUIAbout,
-    pub settings: GUISettings,
-    pub header: GUIHeader,
+    pub main_notebook: GuiMainNotebook,
+    pub upper_notebook: GuiUpperNotebook,
+    pub popovers: GuiPopovers,
+    pub bottom_buttons: GuiBottomButtons,
+    pub progress_window: GuiProgressDialog,
+    pub about: GuiAbout,
+    pub settings: GuiSettings,
+    pub header: GuiHeader,
 
     // Taskbar state
     pub taskbar_state: Rc<RefCell<TaskbarProgress>>,
@@ -88,14 +88,14 @@ impl GuiData {
         window_main.show_all();
         window_main.set_title("Czkawka");
 
-        let main_notebook = GUIMainNotebook::create_from_builder(&builder);
-        let upper_notebook = GUIUpperNotebook::create_from_builder(&builder);
-        let popovers = GUIPopovers::create_from_builder(&builder);
-        let bottom_buttons = GUIBottomButtons::create_from_builder(&builder);
-        let progress_window = GUIProgressDialog::create_from_builder(&builder);
-        let about = GUIAbout::create_from_builder(&builder);
-        let header = GUIHeader::create_from_builder(&builder);
-        let settings = GUISettings::create_from_builder(&builder);
+        let main_notebook = GuiMainNotebook::create_from_builder(&builder);
+        let upper_notebook = GuiUpperNotebook::create_from_builder(&builder);
+        let popovers = GuiPopovers::create_from_builder(&builder);
+        let bottom_buttons = GuiBottomButtons::create_from_builder(&builder);
+        let progress_window = GuiProgressDialog::create_from_builder(&builder);
+        let about = GuiAbout::create_from_builder(&builder);
+        let header = GuiHeader::create_from_builder(&builder);
+        let settings = GuiSettings::create_from_builder(&builder);
 
         ////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/czkawka_gui/src/gui_header.rs
+++ b/czkawka_gui/src/gui_header.rs
@@ -1,12 +1,12 @@
 use gtk::prelude::*;
 
 #[derive(Clone)]
-pub struct GUIHeader {
+pub struct GuiHeader {
     pub button_settings: gtk::Button,
     pub button_app_info: gtk::Button,
 }
 
-impl GUIHeader {
+impl GuiHeader {
     pub fn create_from_builder(builder: &gtk::Builder) -> Self {
         let button_settings: gtk::Button = builder.get_object("button_settings").unwrap();
         let button_app_info: gtk::Button = builder.get_object("button_app_info").unwrap();

--- a/czkawka_gui/src/gui_main_notebook.rs
+++ b/czkawka_gui/src/gui_main_notebook.rs
@@ -2,7 +2,7 @@ use gtk::prelude::*;
 use gtk::TreeView;
 
 #[derive(Clone)]
-pub struct GUIMainNotebook {
+pub struct GuiMainNotebook {
     pub notebook_main: gtk::Notebook,
 
     pub scrolled_window_duplicate_finder: gtk::ScrolledWindow,
@@ -60,7 +60,7 @@ pub struct GUIMainNotebook {
     pub image_preview_similar_images: gtk::Image,
 }
 
-impl GUIMainNotebook {
+impl GuiMainNotebook {
     pub fn create_from_builder(builder: &gtk::Builder) -> Self {
         let notebook_main: gtk::Notebook = builder.get_object("notebook_main").unwrap();
 

--- a/czkawka_gui/src/gui_popovers.rs
+++ b/czkawka_gui/src/gui_popovers.rs
@@ -1,7 +1,7 @@
 use gtk::prelude::*;
 
 #[derive(Clone)]
-pub struct GUIPopovers {
+pub struct GuiPopovers {
     pub buttons_popover_select_all: gtk::Button,
     pub buttons_popover_unselect_all: gtk::Button,
     pub buttons_popover_reverse: gtk::Button,
@@ -26,7 +26,7 @@ pub struct GUIPopovers {
     pub popover_right_click: gtk::Popover,
 }
 
-impl GUIPopovers {
+impl GuiPopovers {
     pub fn create_from_builder(builder: &gtk::Builder) -> Self {
         let buttons_popover_select_all: gtk::Button = builder.get_object("buttons_popover_select_all").unwrap();
         let buttons_popover_unselect_all: gtk::Button = builder.get_object("buttons_popover_unselect_all").unwrap();

--- a/czkawka_gui/src/gui_progress_dialog.rs
+++ b/czkawka_gui/src/gui_progress_dialog.rs
@@ -1,7 +1,7 @@
 use gtk::prelude::*;
 
 #[derive(Clone)]
-pub struct GUIProgressDialog {
+pub struct GuiProgressDialog {
     pub window_progress: gtk::Window,
 
     pub progress_bar_current_stage: gtk::ProgressBar,
@@ -14,7 +14,7 @@ pub struct GUIProgressDialog {
     pub button_stop_in_dialog: gtk::Button,
 }
 
-impl GUIProgressDialog {
+impl GuiProgressDialog {
     pub fn create_from_builder(builder: &gtk::Builder) -> Self {
         let window_progress: gtk::Window = builder.get_object("window_progress").unwrap();
 

--- a/czkawka_gui/src/gui_settings.rs
+++ b/czkawka_gui/src/gui_settings.rs
@@ -1,7 +1,7 @@
 use gtk::prelude::*;
 
 #[derive(Clone)]
-pub struct GUISettings {
+pub struct GuiSettings {
     pub window_settings: gtk::Window,
 
     // General
@@ -25,7 +25,7 @@ pub struct GUISettings {
     pub button_settings_reset_configuration: gtk::Button,
 }
 
-impl GUISettings {
+impl GuiSettings {
     pub fn create_from_builder(builder: &gtk::Builder) -> Self {
         let window_settings: gtk::Window = builder.get_object("window_settings").unwrap();
 
@@ -56,13 +56,13 @@ impl GUISettings {
             check_button_settings_confirm_deletion,
             check_button_settings_confirm_group_deletion,
             check_button_settings_show_text_view,
+            check_button_settings_use_cache,
+            check_button_settings_use_trash,
+            check_button_settings_hide_hard_links,
+            check_button_settings_show_preview_similar_images,
             button_settings_save_configuration,
             button_settings_load_configuration,
             button_settings_reset_configuration,
-            check_button_settings_show_preview_similar_images,
-            check_button_settings_hide_hard_links,
-            check_button_settings_use_cache,
-            check_button_settings_use_trash,
         }
     }
 }

--- a/czkawka_gui/src/gui_upper_notepad.rs
+++ b/czkawka_gui/src/gui_upper_notepad.rs
@@ -2,7 +2,7 @@ use gtk::prelude::*;
 use gtk::TreeView;
 
 #[derive(Clone)]
-pub struct GUIUpperNotebook {
+pub struct GuiUpperNotebook {
     pub notebook_upper: gtk::Notebook,
 
     pub scrolled_window_included_directories: gtk::ScrolledWindow,
@@ -24,7 +24,7 @@ pub struct GUIUpperNotebook {
     pub buttons_remove_excluded_directory: gtk::Button,
 }
 
-impl GUIUpperNotebook {
+impl GuiUpperNotebook {
     pub fn create_from_builder(builder: &gtk::Builder) -> Self {
         let notebook_upper: gtk::Notebook = builder.get_object("notebook_upper").unwrap();
 

--- a/czkawka_gui/src/saving_loading.rs
+++ b/czkawka_gui/src/saving_loading.rs
@@ -37,8 +37,7 @@ pub fn save_configuration(gui_data: &GuiData, manual_execution: bool) {
             add_text_to_text_view(&text_view_errors, format!("Failed configuration to create configuration folder {}", config_dir.display()).as_str());
             return;
         }
-
-        let mut data_to_save: Vec<String> = Vec::new();
+        let mut data_to_save: Vec<String> = Vec::with_capacity(16);
 
         //// Included Directories
         data_to_save.push("--included_directories:".to_string());

--- a/czkawka_gui/src/taskbar_progress_dummy.rs
+++ b/czkawka_gui/src/taskbar_progress_dummy.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::upper_case_acronyms)]
 #![cfg(not(target_os = "windows"))]
 use std::convert::From;
 


### PR DESCRIPTION
Update delete a lot of dependencies.
Also fixes some Clippy warnings which comes with Rust 1.51