### PR TITLE
Add adwaita-icon-theme as required dependency on macOS

### DIFF
--- a/instructions/Installation.md
+++ b/instructions/Installation.md
@@ -19,11 +19,11 @@ sudo xbps-install gcc pkg-config alsa-lib-devel
 ```
 
 ### macOS
-Currently, you need to manually install `GTK 3` libraries, because they are dynamically loaded from the OS (*we need
+Currently, you need to manually install `GTK 3` libraries and the Adwaita theme, because they are dynamically loaded from the OS (*we need
 help in using static linking*). One very straight-forward way to do this is by using [Homebrew](https://brew.sh/). Installation in the terminal:
 ```shell
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-brew install gtk+3
+brew install gtk+3 adwaita-icon-theme
 ```
 After that, go to the location where you downloaded Czkawka and add the `executable` permission to this file.
 ```shell


### PR DESCRIPTION
Apparently, it's not enough to install the `gtk+3` package on macOS — the icons won't show up. One needs to install the `adwaita-icon-theme` as a separate package. Using the app without icons is possible, but not the greatest experience.

----

If one doesn't install it, the following message will appear in Terminal:

```
(<unknown>:****): Gtk-WARNING **: 12:34:56.789: Could not load a pixbuf from /org/gtk/libgtk/theme/Adwaita/assets/check-symbolic.svg.
This may indicate that pixbuf loaders or the mime database could not be found.
```