### PR TITLE
Update all dependencies except trash which don't crosscompile on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2079,9 +2079,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
+checksum = "4ac2e1d4bd0f75279cfd5a076e0d578bbf02c22b7c39e766c437dd49b3ec43e0"
 dependencies = [
  "tinyvec_macros",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,9 +156,13 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bk-tree"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5488039ea2c6de8668351415e39a0218a8955bffadcff0cf01d1293a20854584"
+checksum = "6121f6e107e94d717b5ca2631d56e7c2ed1542a21b2eb87b4bda1d6c1420ef3f"
+dependencies = [
+ "fnv",
+ "triple_accel",
+]
 
 [[package]]
 name = "blake3"
@@ -1473,11 +1477,11 @@ checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "open"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1711eb4b31ce4ad35b0f316d8dfba4fe5c7ad601c448446d84aae7a896627b20"
+checksum = "dcea7a30d6b81a2423cc59c43554880feff7b57d12916f231a79f8d6d9470201"
 dependencies = [
- "which",
+ "pathdiff",
  "winapi",
 ]
 
@@ -1530,6 +1534,12 @@ dependencies = [
  "smallvec",
  "winapi",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877630b3de15c0b64cc52f659345724fbf6bdad9bd9566699fc53688f3c34a34"
 
 [[package]]
 name = "peeking_take_while"
@@ -2117,6 +2127,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "triple_accel"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622b09ce2fe2df4618636fb92176d205662f59803f39e70d1c333393082de96c"
+
+[[package]]
 name = "typenum"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2250,16 +2266,6 @@ name = "weezl"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b77fdfd5a253be4ab714e4ffa3c49caf146b4de743e97510c0656cf90f1e8e"
-
-[[package]]
-name = "which"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55551e42cbdf2ce2bedd2203d0cc08dba002c27510f86dab6d0ce304cba3dfe"
-dependencies = [
- "either",
- "libc",
-]
 
 [[package]]
 name = "winapi"

--- a/czkawka_cli/Cargo.toml
+++ b/czkawka_cli/Cargo.toml
@@ -10,4 +10,4 @@ repository = "https://github.com/qarmin/czkawka"
 
 [dependencies]
 czkawka_core = { path = "../czkawka_core" }
-structopt = "0.3.21"
+structopt = "0.3.22"

--- a/czkawka_core/Cargo.toml
+++ b/czkawka_core/Cargo.toml
@@ -18,10 +18,10 @@ crossbeam-channel = "0.5.1"
 directories-next = "2.0.0"
 
 # Needed by similar images
-img_hash = "3.1"
-bk-tree = "0.3"
+img_hash = "3.2.0"
+bk-tree = "0.4.0"
 image = "0.23.14"
-hamming = "0.1"
+hamming = "0.1.3"
 
 # Needed by same music
 bitflags = "1.2.1"

--- a/czkawka_core/src/similar_images.rs
+++ b/czkawka_core/src/similar_images.rs
@@ -60,8 +60,13 @@ pub struct FileEntry {
 struct Hamming;
 
 impl bk_tree::Metric<Node> for Hamming {
-    fn distance(&self, a: &Node, b: &Node) -> u64 {
-        hamming::distance_fast(a, b).unwrap()
+    fn distance(&self, a: &Node, b: &Node) -> u32 {
+        hamming::distance_fast(a, b).unwrap() as u32
+    }
+
+    // TODO Probably needs to be implemented
+    fn threshold_distance(&self, _a: &Node, _b: &Node, _threshold: u32) -> Option<u32> {
+        None
     }
 }
 
@@ -450,7 +455,7 @@ impl SimilarImages {
         Common::print_time(hash_map_modification, SystemTime::now(), "sort_images - saving data to files".to_string());
         let hash_map_modification = SystemTime::now();
 
-        let similarity: u64 = match self.similarity {
+        let similarity: u32 = match self.similarity {
             Similarity::VeryHigh => 0,
             Similarity::High => 1,
             Similarity::Medium => 2,

--- a/czkawka_gui/Cargo.toml
+++ b/czkawka_gui/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/qarmin/czkawka"
 [dependencies]
 czkawka_core = { path = "../czkawka_core" }
 gdk = "0.14.0"
-glib = "0.14.0"
+glib = "0.14.2"
 
 humansize = "1.1.1"
 chrono = "0.4.19"
@@ -26,7 +26,7 @@ futures = "0.3.15"
 directories-next = "2.0.0"
 
 # For opening files
-open = "1.7.0"
+open = "1.7.1"
 
 # To get image preview
 image = "0.23.14"


### PR DESCRIPTION
Looks that for now there is no difference in produced image hash