### PR TITLE
remove default excluded directories and items

### DIFF
--- a/czkawka_gui/src/connect_button_hardlink.rs
+++ b/czkawka_gui/src/connect_button_hardlink.rs
@@ -89,6 +89,10 @@ pub fn hardlink_symlink(tree_view: gtk::TreeView, column_file_name: i32, column_
         }
     }
 
+    if selected_rows.is_empty() {
+        return; // No selected rows
+    }
+
     let mut current_symhardlink_data: Option<SymHardlinkData> = None;
     let mut current_selected_index = 0;
     loop {

--- a/czkawka_gui/src/saving_loading.rs
+++ b/czkawka_gui/src/saving_loading.rs
@@ -542,22 +542,11 @@ pub fn reset_configuration(gui_data: &GuiData, manual_clearing: bool) {
         let tree_view_excluded_directories = gui_data.upper_notebook.tree_view_excluded_directories.clone();
         let list_store = get_list_store(&tree_view_excluded_directories);
         list_store.clear();
-        if cfg!(target_family = "unix") {
-            for i in ["/proc", "/dev", "/sys", "/run", "/snap"].iter() {
-                let values: [(u32, &dyn ToValue); 1] = [(0, &i)];
-                list_store.set(&list_store.append(), &values);
-            }
-        }
+
     }
     // Resetting excluded items
     {
         let entry_excluded_items = gui_data.upper_notebook.entry_excluded_items.clone();
-        if cfg!(target_family = "unix") {
-            entry_excluded_items.set_text("*/.git/*,*/node_modules/*,*/lost+found/*,*/Trash/*,*/.Trash-*/*,*/snap/*,/home/*/.cache/*");
-        }
-        if cfg!(target_family = "windows") {
-            entry_excluded_items.set_text("*\\.git\\*,*\\node_modules\\*,*\\lost+found\\*,*:\\windows\\*");
-        }
     }
     // Resetting allowed extensions
     {

--- a/czkawka_gui/ui/main_window.glade
+++ b/czkawka_gui/ui/main_window.glade
@@ -496,7 +496,7 @@ Author: Rafał Mikrut
                           <object class="GtkEntry" id="entry_excluded_items">
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
-                            <property name="text" translatable="yes">*/.git,*/node_modules,*/lost+found</property>
+                            <property name="text" translatable="yes"></property>
                           </object>
                           <packing>
                             <property name="expand">True</property>


### PR DESCRIPTION
by doing so, when having the two lines:
```
--load_at_start:
false
```
in the config file @ `~/.config/czkawka/czkawka_gui_config.txt` we can make `czkawka_gui` use the working directory as the initial included directory.