### PR TITLE
Readme: Add IPA spelling of the name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![com github qarmin czkawka](https://user-images.githubusercontent.com/41945903/102616149-66490400-4137-11eb-9cd6-813b2b070834.png)
 
-**Czkawka** (_tch•kav•ka_, "hiccup" in Polish) is a simple, fast and free app to remove unnecessary files from your computer.
+**Czkawka** (_tch•kav•ka_ (IPA: [ʈ͡ʂkafka]), "hiccup" in Polish) is a simple, fast and free app to remove unnecessary files from your computer.
 
 ## Features
 - Written in memory safe Rust

--- a/czkawka_gui/src/initialize_gui.rs
+++ b/czkawka_gui/src/initialize_gui.rs
@@ -22,6 +22,7 @@ pub fn initialize_gui(gui_data: &mut GuiData) {
         let buttons_select = gui_data.bottom_buttons.buttons_select.clone();
         let buttons_symlink = gui_data.bottom_buttons.buttons_symlink.clone();
         let buttons_hardlink = gui_data.bottom_buttons.buttons_hardlink.clone();
+        let buttons_move = gui_data.bottom_buttons.buttons_move.clone();
 
         // Disable and show buttons - only search button should be visible
         buttons_search.show();
@@ -30,6 +31,7 @@ pub fn initialize_gui(gui_data: &mut GuiData) {
         buttons_select.hide();
         buttons_symlink.hide();
         buttons_hardlink.hide();
+        buttons_move.hide();
     }
 
     //// Initialize main scrolled view with notebook


### PR DESCRIPTION
This PR adds IPA spelling of the word "czkawka" to the readme.
Although the spelling "tchkavka" is a good approximation for how to pronounce this word, in general this kind of spelling can be confusing for non-native English speakers and therefore I think that it should be followed by IPA spelling for clarity.
Source: https://en.wiktionary.org/wiki/czkawka