### PR TITLE
Cache vidoes with serde to avoid forked vid_dup_finder_lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,6 +493,8 @@ dependencies = [
  "img_hash",
  "rayon",
  "rodio",
+ "serde",
+ "serde_json",
  "tempfile",
  "vid_dup_finder_lib",
  "xxhash-rust",
@@ -2270,7 +2272,8 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 [[package]]
 name = "vid_dup_finder_lib"
 version = "0.1.0"
-source = "git+https://github.com/qarmin/vid_dup_finder_lib#a4809772aea8f73c9a22da6fb43df50bfdd1b31d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64bf85b5022ad9df9ec55750118ec38f33406165fcf9edf19c71eb2bd6823232"
 dependencies = [
  "ffmpeg_cmdline_utils",
  "image",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +488,7 @@ name = "czkawka_core"
 version = "3.3.1"
 dependencies = [
  "audiotags",
+ "bincode",
  "bitflags",
  "bk-tree",
  "blake3",
@@ -494,7 +504,6 @@ dependencies = [
  "rayon",
  "rodio",
  "serde",
- "serde_json",
  "tempfile",
  "vid_dup_finder_lib",
  "xxhash-rust",

--- a/czkawka_core/Cargo.toml
+++ b/czkawka_core/Cargo.toml
@@ -44,8 +44,9 @@ tempfile = "3.2.0"
 # Video Duplactes
 vid_dup_finder_lib = "0.1.0"
 ffmpeg_cmdline_utils = "0.1.0"
-serde = "1.0"
-serde_json = "1.0"
+serde = "1.0.130"
+bincode = "1.3.3"
+
 
 [features]
 default = []

--- a/czkawka_core/Cargo.toml
+++ b/czkawka_core/Cargo.toml
@@ -42,8 +42,10 @@ xxhash-rust = { version = "0.8.2", features = ["xxh3"] }
 tempfile = "3.2.0"
 
 # Video Duplactes
-vid_dup_finder_lib = { git = "https://github.com/qarmin/vid_dup_finder_lib" }
+vid_dup_finder_lib = "0.1.0"
 ffmpeg_cmdline_utils = "0.1.0"
+serde = "1.0"
+serde_json = "1.0"
 
 [features]
 default = []

--- a/czkawka_core/src/similar_videos.rs
+++ b/czkawka_core/src/similar_videos.rs
@@ -621,7 +621,6 @@ pub fn save_hashes_to_file(hashmap: &BTreeMap<String, FileEntry>, text_messages:
 
         if let Err(e) = serde_json::to_writer_pretty(BufWriter::new(file_handler), hashmap) {
             text_messages.messages.push(format!("cannot write data to cache file {}, reason {}", cache_file.display(), e));
-            return;
         }
     }
 }


### PR DESCRIPTION
[Issue #1 in vid_dup_finder_lib](https://github.com/Farmadupe/vid_dup_finder_lib/issues/1) requests to add additional data to the API of vid_dup_finder_lib to serialize VideoHash, however it is already possible to serialize VideoHash using Serde.

Main Changes:
- similar_videos.rs is updated to serialize data to JSON instead of custom format.
- cargo.toml is updated to use vid_dup_finder_lib from crates.io

Other changes:
- In existing functionality, if there was an error on any single line of the cache file, then only that line will fail. In this change, the whole serialization will fail. However I think it is unlikely to experience such an error (unless the user manually edits this file)

Thoughts:
- I chose to use JSON serialization format because the existing format is human-readable and JSON is too. But with large cache it will be slow to serialize. Maybe a binary format would be better (such as bincode)
