### PR TITLE
Add button to ignore images with non unique size.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@
 - Cache support - second and further scans should be a lot faster than the first one
 - CLI frontend - for easy automation
 - GUI frontend - uses modern GTK 3 and looks similar to FSlint
-- Rich search option - allows setting absolute included and excluded directories, set of allowed file extensions 
-  or excluded items with the `*` wildcard
 - No spying - Czkawka does not have access to the Internet, nor does it collect any user information or statistics
 - Multiple tools to use:
   - Duplicates - Finds duplicates based on file name, size or hash
@@ -26,7 +24,7 @@
   - Broken Files - Finds files with an invalid extension or that are corrupted
 
 <!-- The GIF thingy -->
-![Czkawka](https://user-images.githubusercontent.com/41945903/104711404-9cbb7400-5721-11eb-904d-9677c189f7ab.gif)
+![Czkawka](https://user-images.githubusercontent.com/41945903/145280350-506f7e94-4db0-4de7-a68d-6e7c26bbd2bf.gif)
 
 ## How do I use it?
 You can find the instructions on how to use Czkawka [**here**](instructions/Instruction.md).

--- a/czkawka_gui/src/connect_button_search.rs
+++ b/czkawka_gui/src/connect_button_search.rs
@@ -39,6 +39,7 @@ pub fn connect_button_search(
     futures_sender_broken_files: futures::channel::mpsc::UnboundedSender<broken_files::ProgressData>,
 ) {
     let buttons_array = gui_data.bottom_buttons.buttons_array.clone();
+    let check_button_image_ignore_same_size = gui_data.main_notebook.check_button_image_ignore_same_size.clone();
     let buttons_names = gui_data.bottom_buttons.buttons_names.clone();
     let buttons_search_clone = gui_data.bottom_buttons.buttons_search.clone();
     let check_button_duplicates_use_prehash_cache = gui_data.settings.check_button_duplicates_use_prehash_cache.clone();
@@ -344,6 +345,8 @@ pub fn connect_button_search(
                 let minimal_file_size = entry_similar_images_minimal_size.text().as_str().parse::<u64>().unwrap_or(1024 * 16);
                 let maximal_file_size = entry_similar_images_maximal_size.text().as_str().parse::<u64>().unwrap_or(1024 * 1024 * 1024 * 1024);
 
+                let ignore_same_size = check_button_image_ignore_same_size.is_active();
+
                 let similarity = similar_images::Similarity::Similar(scale_similarity_similar_images.value() as u32);
 
                 let delete_outdated_cache = check_button_settings_similar_images_delete_outdated_cache.is_active();
@@ -365,6 +368,7 @@ pub fn connect_button_search(
                     sf.set_hash_size(hash_size);
                     sf.set_image_filter(image_filter);
                     sf.set_delete_outdated_cache(delete_outdated_cache);
+                    sf.set_exclude_images_with_same_size(ignore_same_size);
                     sf.find_similar_images(Some(&stop_receiver), Some(&futures_sender_similar_images));
                     let _ = glib_stop_sender.send(Message::SimilarImages(sf));
                 });

--- a/czkawka_gui/src/gui_main_notebook.rs
+++ b/czkawka_gui/src/gui_main_notebook.rs
@@ -89,6 +89,8 @@ pub struct GuiMainNotebook {
     pub radio_button_similar_hash_size_32: gtk::RadioButton,
     pub radio_button_similar_hash_size_64: gtk::RadioButton,
 
+    pub check_button_image_ignore_same_size: gtk::CheckButton,
+
     pub label_similar_images_minimal_similarity: gtk::Label,
 
     pub image_preview_similar_images: gtk::Image,
@@ -218,6 +220,8 @@ impl GuiMainNotebook {
         radio_button_similar_hash_size_32.set_tooltip_text(Some("Hash of this size provide very big similarity which is more than enough for most usages."));
         radio_button_similar_hash_size_64.set_tooltip_text(Some("Paranoid mode, such tool create really big cache files and will catch almost same images."));
 
+        let check_button_image_ignore_same_size: gtk::CheckButton = builder.object("check_button_image_ignore_same_size").unwrap();
+
         let label_similar_images_minimal_similarity: gtk::Label = builder.object("label_similar_images_minimal_similarity").unwrap();
 
         let image_preview_similar_images: gtk::Image = builder.object("image_preview_similar_images").unwrap();
@@ -290,6 +294,7 @@ impl GuiMainNotebook {
             radio_button_similar_hash_size_16,
             radio_button_similar_hash_size_32,
             radio_button_similar_hash_size_64,
+            check_button_image_ignore_same_size,
             label_similar_images_minimal_similarity,
             image_preview_similar_images,
             entry_duplicate_maximal_size,

--- a/czkawka_gui/src/initialize_gui.rs
+++ b/czkawka_gui/src/initialize_gui.rs
@@ -753,5 +753,9 @@ fn show_preview(tree_view: &TreeView, text_view_errors: &TextView, check_button_
         image_preview_similar_images.show();
     } else {
         image_preview_similar_images.hide();
+        {
+            let mut preview_path = preview_path.borrow_mut();
+            *preview_path = "".to_string();
+        }
     }
 }

--- a/czkawka_gui/ui/main_window.glade
+++ b/czkawka_gui/ui/main_window.glade
@@ -1438,7 +1438,7 @@ Author: Rafał Mikrut
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">4</property>
+                                <property name="position">3</property>
                               </packing>
                             </child>
                             <child>
@@ -1452,6 +1452,20 @@ Author: Rafał Mikrut
                               </object>
                               <packing>
                                 <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">4</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="check_button_image_ignore_same_size">
+                                <property name="label" translatable="yes">Ignore same size</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="draw-indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
                                 <property name="fill">True</property>
                                 <property name="position">5</property>
                               </packing>


### PR DESCRIPTION
This will help with finding different images(non 1:1 which could be easily found by duplicate finder tool)

Also fixes bug with non showing sometimes image preview