### PR TITLE
Fix crash with missing icon

### DIFF
--- a/czkawka_gui/src/gui_data.rs
+++ b/czkawka_gui/src/gui_data.rs
@@ -1,11 +1,14 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::io::BufReader;
 use std::rc::Rc;
 
 use crossbeam_channel::unbounded;
 use gdk::gdk_pixbuf::Pixbuf;
+use glib::value::FromValue;
 use gtk::prelude::*;
 use gtk::Builder;
+use image::EncodableLayout;
 
 use czkawka_core::big_file::BigFile;
 use czkawka_core::broken_files::BrokenFiles;
@@ -29,6 +32,8 @@ use crate::gui_settings::GuiSettings;
 use crate::gui_upper_notebook::GuiUpperNotebook;
 use crate::notebook_enums::*;
 use crate::taskbar_progress::TaskbarProgress;
+
+const ICON_ABOUT: &[u8; 4458] = include_bytes!("../../snap/gui/czkawka.png");
 
 #[derive(Clone)]
 pub struct GuiData {
@@ -91,7 +96,7 @@ impl GuiData {
         window_main.set_title(&fl!("window_main_title"));
         window_main.show_all();
 
-        let pixbuf = Pixbuf::from_file_at_scale("snap/gui/czkawka.png", 200, 200, false).unwrap();
+        let pixbuf = Pixbuf::from_read(std::io::BufReader::new(ICON_ABOUT.as_slice())).unwrap();
         window_main.set_icon(Some(&pixbuf));
 
         window_main.set_application(Some(application));

--- a/czkawka_gui/src/gui_data.rs
+++ b/czkawka_gui/src/gui_data.rs
@@ -1,14 +1,11 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::io::BufReader;
 use std::rc::Rc;
 
 use crossbeam_channel::unbounded;
 use gdk::gdk_pixbuf::Pixbuf;
-use glib::value::FromValue;
 use gtk::prelude::*;
 use gtk::Builder;
-use image::EncodableLayout;
 
 use czkawka_core::big_file::BigFile;
 use czkawka_core::broken_files::BrokenFiles;


### PR DESCRIPTION
Fix with adding proper icon was too simple, so I was 100% sure that something went wrong.

The only problem with current implementation, is this error
```
(czkawka_gui:53165): Gtk-WARNING **: 22:08:45.215: Could not load image '': Image file “/home/rafal/Projekty/Rust/czkawka” contains no data
```