### PR TITLE
Reverse selection when clicking at middle mouse button

### DIFF
--- a/czkawka_gui/src/initialize_gui.rs
+++ b/czkawka_gui/src/initialize_gui.rs
@@ -495,6 +495,7 @@ fn connect_event_mouse(gui_data: &GuiData) {
         gui_data.main_notebook.tree_view_broken_files.clone(),
     ] {
         tree_view.connect_button_press_event(opening_double_click_function);
+        tree_view.connect_button_release_event(opening_middle_mouse_function);
     }
     // Duplicate
     {


### PR DESCRIPTION
Fixes https://github.com/qarmin/czkawka/issues/488
Fixes https://github.com/qarmin/czkawka/issues/465

This reverse selection of all items in group, except the one clicked(it will be more used than total reverse) e.g.

TreeView
HEADER
x - 1
x - 2
x - 3 <- clicked
x - 4
x - 5

later
HEADER
_ - 1
_ - 2
x - 3 <- clicked
_ - 4
_ - 5