### PR TITLE
Fix appstream file

### DIFF
--- a/data/com.github.qarmin.czkawka.metainfo.xml
+++ b/data/com.github.qarmin.czkawka.metainfo.xml
@@ -26,5 +26,5 @@
   <url type="homepage">https://github.com/qarmin/czkawka</url>
   <url type="bugtracker">https://github.com/qarmin/czkawka/issues</url>
   <url type="donation">https://github.com/sponsors/qarmin</url>
-  <url type="translation">https://crowdin.com/project/czkawka</url>
+  <url type="translate">https://crowdin.com/project/czkawka</url>
 </component>


### PR DESCRIPTION
This MR fixes the appstream file to fix the error produced in https://github.com/flathub/com.github.qarmin.czkawka/pull/11.

```
$ flatpak run org.freedesktop.appstream-glib validate data/com.github.qarmin.czkawka.metainfo.xml
data/com.github.qarmin.czkawka.metainfo.xml: OK
```