### PR TITLE
Fix accumulated stop events

### DIFF
--- a/czkawka_gui/src/connect_things/connect_button_search.rs
+++ b/czkawka_gui/src/connect_things/connect_button_search.rs
@@ -155,6 +155,8 @@ pub fn connect_button_search(
 
         let glib_stop_sender = glib_stop_sender.clone();
         let stop_receiver = stop_receiver.clone();
+        // Consume any stale stop messages.
+        stop_receiver.try_iter().for_each(|_| ());
 
         match to_notebook_main_enum(notebook_main.current_page().unwrap()) {
             NotebookMainEnum::Duplicate => {

--- a/czkawka_gui/src/connect_things/connect_button_stop.rs
+++ b/czkawka_gui/src/connect_things/connect_button_stop.rs
@@ -1,7 +1,15 @@
+use crossbeam_channel::{Sender, TrySendError};
 use gtk::prelude::*;
 
 use crate::gui_structs::gui_data::GuiData;
 use crate::help_functions::KEY_ENTER;
+
+fn send_stop_message(stop_sender: &Sender<()>) {
+    stop_sender
+        .try_send(())
+        .map_or_else(|e| if matches!(e, TrySendError::Full(_)) { Ok(()) } else { Err(e) }, |_| Ok(()))
+        .unwrap();
+}
 
 pub fn connect_button_stop(gui_data: &GuiData) {
     let evk_button_stop_in_dialog = gui_data.progress_window.evk_button_stop_in_dialog.clone();
@@ -9,14 +17,14 @@ pub fn connect_button_stop(gui_data: &GuiData) {
     evk_button_stop_in_dialog.connect_key_released(move |_, _, key_code, _| {
         if key_code == KEY_ENTER {
             // Only accept enter key to stop search
-            stop_sender.send(()).unwrap();
+            send_stop_message(&stop_sender);
         }
     });
 
     let button_stop_in_dialog = gui_data.progress_window.button_stop_in_dialog.clone();
     let stop_sender = gui_data.stop_sender.clone();
     button_stop_in_dialog.connect_button_release_event(move |_, _e| {
-        stop_sender.send(()).unwrap();
+        send_stop_message(&stop_sender);
         gtk::Inhibit(false)
     });
 

--- a/czkawka_gui/src/gui_structs/gui_data.rs
+++ b/czkawka_gui/src/gui_structs/gui_data.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use crossbeam_channel::unbounded;
+use crossbeam_channel::bounded;
 use gdk::gdk_pixbuf::Pixbuf;
 use gtk::prelude::*;
 use gtk::Builder;
@@ -156,7 +156,7 @@ impl GuiData {
         scrolled_window_errors.show_all(); // Not sure why needed, but without it text view errors sometimes hide itself
 
         // Used for sending stop signal to thread
-        let (stop_sender, stop_receiver): (crossbeam_channel::Sender<()>, crossbeam_channel::Receiver<()>) = unbounded();
+        let (stop_sender, stop_receiver): (crossbeam_channel::Sender<()>, crossbeam_channel::Receiver<()>) = bounded(1);
 
         Self {
             glade_src,


### PR DESCRIPTION
Change stop message channel to bounded with size of 1 and ensure it's clear before starting a search operation.

Closes #622