### PR TITLE
Periodically check for and handle pending GTK events while performing long operations.

### DIFF
--- a/czkawka_gui/src/connect_things/connect_button_delete.rs
+++ b/czkawka_gui/src/connect_things/connect_button_delete.rs
@@ -292,7 +292,8 @@ pub fn empty_folder_remover(
     let mut messages: String = "".to_string();
 
     // Must be deleted from end to start, because when deleting entries, TreePath(and also TreeIter) will points to invalid data
-    for tree_path in selected_rows.iter().rev() {
+    for (counter, tree_path) in selected_rows.iter().rev().enumerate() {
+        handle_gtk_pending_event_counter(counter);
         let iter = model.iter(tree_path).unwrap();
 
         let name = model.value(&iter, column_file_name).get::<String>().unwrap();
@@ -408,7 +409,8 @@ pub fn basic_remove(
     }
 
     // Must be deleted from end to start, because when deleting entries, TreePath(and also TreeIter) will points to invalid data
-    for tree_path in selected_rows.iter().rev() {
+    for (counter, tree_path) in selected_rows.iter().rev().enumerate() {
+        handle_gtk_pending_event_counter(counter);
         let iter = model.iter(tree_path).unwrap();
 
         let name = model.value(&iter, column_file_name).get::<String>().unwrap();
@@ -504,10 +506,13 @@ pub fn tree_remove(
     }
 
     // Delete duplicated entries, and remove real files
+    let mut counter = 0_usize;
     for (path, mut vec_file_name) in map_with_path_to_delete {
         vec_file_name.sort();
         vec_file_name.dedup();
         for file_name in vec_file_name {
+            handle_gtk_pending_event_counter(counter);
+            counter += 1;
             if !use_trash {
                 if let Err(e) = fs::remove_file(get_full_name_from_path_name(&path, &file_name)) {
                     messages += flg!(

--- a/czkawka_gui/src/connect_things/connect_button_hardlink.rs
+++ b/czkawka_gui/src/connect_things/connect_button_hardlink.rs
@@ -194,7 +194,8 @@ pub fn hardlink_symlink(
     }
     if hardlinking {
         for symhardlink_data in vec_symhardlink_data {
-            for file_to_hardlink in symhardlink_data.files_to_symhardlink {
+            for (counter, file_to_hardlink) in symhardlink_data.files_to_symhardlink.into_iter().enumerate() {
+                handle_gtk_pending_event_counter(counter);
                 if let Err(e) = make_hard_link(&PathBuf::from(&symhardlink_data.original_data), &PathBuf::from(&file_to_hardlink)) {
                     add_text_to_text_view(text_view_errors, format!("{} {}, reason {}", flg!("hardlink_failed"), file_to_hardlink, e).as_str());
                     continue;
@@ -203,7 +204,8 @@ pub fn hardlink_symlink(
         }
     } else {
         for symhardlink_data in vec_symhardlink_data {
-            for file_to_symlink in symhardlink_data.files_to_symhardlink {
+            for (counter, file_to_symlink) in symhardlink_data.files_to_symhardlink.into_iter().enumerate() {
+                handle_gtk_pending_event_counter(counter);
                 if let Err(e) = fs::remove_file(&file_to_symlink) {
                     add_text_to_text_view(
                         text_view_errors,

--- a/czkawka_gui/src/connect_things/connect_button_move.rs
+++ b/czkawka_gui/src/connect_things/connect_button_move.rs
@@ -224,7 +224,8 @@ fn move_files_common(
     let mut moved_files: u32 = 0;
 
     // Save to variable paths of files, and remove it when not removing all occurrences.
-    'next_result: for tree_path in selected_rows.iter().rev() {
+    'next_result: for (counter, tree_path) in selected_rows.iter().rev().enumerate() {
+        handle_gtk_pending_event_counter(counter);
         let iter = model.iter(tree_path).unwrap();
 
         let file_name = model.value(&iter, column_file_name).get::<String>().unwrap();

--- a/czkawka_gui/src/help_functions.rs
+++ b/czkawka_gui/src/help_functions.rs
@@ -41,6 +41,8 @@ pub const KEY_SPACE: u32 = 65;
 // pub const KEY_HOME: u32 = 115;
 // pub const KEY_END: u32 = 110;
 
+pub const CHECK_GTK_EVENTS_INTERVAL: usize = 100;
+
 #[derive(Eq, PartialEq)]
 pub enum PopoverTypes {
     All,
@@ -774,6 +776,21 @@ pub fn get_custom_label_from_button_with_image(button: &gtk::Bin) -> gtk::Label 
         }
     }
     panic!("Button doesn't have proper custom label child");
+}
+
+pub fn handle_gtk_pending_event() -> bool {
+    let have_pending = gtk::events_pending();
+    if have_pending {
+        gtk::main_iteration();
+    }
+    have_pending
+}
+
+pub fn handle_gtk_pending_event_counter(counter: usize) -> bool {
+    if counter > 0 && (counter % CHECK_GTK_EVENTS_INTERVAL) == 0 {
+        return handle_gtk_pending_event();
+    }
+    false
 }
 
 // GTK 4


### PR DESCRIPTION
**Please note**: I really don't know much about GTK (especially with Rust) so this may or may not be the correct approach.

This change checks for and handles a pending GTK event once every 100 files processed. It may make sense to handle all pending events. The frequency of event checking could obviously be changed quote easily, I don't know what the optimal value is but 100 seemed reasonable.

Closes #624 