### PR TITLE
Simplify and speedup preview creating

### DIFF
--- a/czkawka_gui/i18n/en/czkawka_gui.ftl
+++ b/czkawka_gui/i18n/en/czkawka_gui.ftl
@@ -473,11 +473,8 @@ cache_clear_message_label_3 = This may slightly speedup loading/saving to cache.
 cache_clear_message_label_4 = WARNING: Operation will remove all cached data from unplugged external drives. So each hash will need to be regenerated.
 
 # Show preview
-preview_temporary_file = Failed to open temporary image file {$name}, reason {$reason}.
-preview_0_size = Cannot create preview of image {$name}, with 0 width or height.
-preview_temporary_image_save = Failed to save temporary image file to {$name}, reason {$reason}.
-preview_temporary_image_remove = Failed to delete temporary image file {$name}, reason {$reason}.
-preview_failed_to_create_cache_dir = Failed to create dir {$name} needed by image preview, reason {$reason}.
+preview_image_resize_failure = Failed to resize image {$name}.
+preview_image_opening_failure = Failed to open image {$name}, reason {$reason}
 
 # Compare images (L is short Left, R is short Right - they can't take too much space)
 compare_groups_number = Group { $current_group }/{ $all_groups } ({ $images_in_group } images)

--- a/czkawka_gui/src/help_functions.rs
+++ b/czkawka_gui/src/help_functions.rs
@@ -1,4 +1,3 @@
-use directories_next::ProjectDirs;
 use gdk::gdk_pixbuf::{InterpType, Pixbuf};
 use std::cmp::Ordering;
 use std::collections::HashMap;
@@ -6,8 +5,6 @@ use std::path::{Path, PathBuf};
 
 use gtk::prelude::*;
 use gtk::{Bin, ListStore, TextView, TreeView, Widget};
-use image::imageops::FilterType;
-use image::DynamicImage;
 
 use crate::flg;
 use czkawka_core::big_file::BigFile;
@@ -723,26 +720,6 @@ pub fn count_number_of_groups(tree_view: &TreeView, column_color: i32) -> u32 {
     number_of_selected_groups
 }
 
-pub fn resize_dynamic_image_dimension(img: DynamicImage, requested_size: (u32, u32), filter_type: &FilterType) -> DynamicImage {
-    let current_ratio = img.width() as f32 / img.height() as f32;
-    let mut new_size;
-    match current_ratio.partial_cmp(&(requested_size.0 as f32 / requested_size.1 as f32)).unwrap() {
-        Ordering::Greater => {
-            new_size = (requested_size.0, (img.height() * requested_size.0) / img.width());
-            new_size = (std::cmp::max(new_size.0, 1), std::cmp::max(new_size.1, 1));
-        }
-        Ordering::Less => {
-            new_size = ((img.width() * requested_size.1) / img.height(), requested_size.1);
-            new_size = (std::cmp::max(new_size.0, 1), std::cmp::max(new_size.1, 1));
-        }
-        Ordering::Equal => {
-            new_size = (requested_size.0, requested_size.1);
-            new_size = (std::cmp::max(new_size.0, 1), std::cmp::max(new_size.1, 1));
-        }
-    }
-    img.resize(new_size.0, new_size.1, *filter_type)
-}
-
 pub fn resize_pixbuf_dimension(pixbuf: Pixbuf, requested_size: (i32, i32), interp_type: InterpType) -> Option<Pixbuf> {
     let current_ratio = pixbuf.width() as f32 / pixbuf.height() as f32;
     let mut new_size;
@@ -761,16 +738,6 @@ pub fn resize_pixbuf_dimension(pixbuf: Pixbuf, requested_size: (i32, i32), inter
         }
     }
     pixbuf.scale_simple(new_size.0, new_size.1, interp_type)
-}
-
-pub fn get_image_path_temporary(file_name: &str, number: u32, extension: &str) -> PathBuf {
-    let path_buf;
-    if let Some(proj_dirs) = ProjectDirs::from("pl", "Qarmin", "Czkawka") {
-        path_buf = PathBuf::from(proj_dirs.cache_dir());
-    } else {
-        path_buf = PathBuf::new().join("/var");
-    }
-    path_buf.join(format!("{}{}.{}", file_name, number, extension))
 }
 
 pub fn get_max_file_name(file_name: &str, max_length: usize) -> String {

--- a/czkawka_gui/src/help_functions.rs
+++ b/czkawka_gui/src/help_functions.rs
@@ -743,6 +743,26 @@ pub fn resize_dynamic_image_dimension(img: DynamicImage, requested_size: (u32, u
     img.resize(new_size.0, new_size.1, *filter_type)
 }
 
+pub fn resize_pixbuf_dimension(pixbuf: Pixbuf, requested_size: (i32, i32), interp_type: InterpType) -> Option<Pixbuf> {
+    let current_ratio = pixbuf.width() as f32 / pixbuf.height() as f32;
+    let mut new_size;
+    match current_ratio.partial_cmp(&(requested_size.0 as f32 / requested_size.1 as f32)).unwrap() {
+        Ordering::Greater => {
+            new_size = (requested_size.0, (pixbuf.height() * requested_size.0) / pixbuf.width());
+            new_size = (std::cmp::max(new_size.0, 1), std::cmp::max(new_size.1, 1));
+        }
+        Ordering::Less => {
+            new_size = ((pixbuf.width() * requested_size.1) / pixbuf.height(), requested_size.1);
+            new_size = (std::cmp::max(new_size.0, 1), std::cmp::max(new_size.1, 1));
+        }
+        Ordering::Equal => {
+            new_size = (requested_size.0, requested_size.1);
+            new_size = (std::cmp::max(new_size.0, 1), std::cmp::max(new_size.1, 1));
+        }
+    }
+    pixbuf.scale_simple(new_size.0, new_size.1, interp_type)
+}
+
 pub fn get_image_path_temporary(file_name: &str, number: u32, extension: &str) -> PathBuf {
     let path_buf;
     if let Some(proj_dirs) = ProjectDirs::from("pl", "Qarmin", "Czkawka") {


### PR DESCRIPTION
This PR drop time to create preview of images (time to creating preview of cr2 - 35 MB, 6240x4160 dropped from 3-4s to 1-2s)

Previous solution:
- open image via `image-rs`
- resize image to required size
- save image to temporary file
- load image from temporary file to `gtk-rs` image object

New solution:
- open image via `gtk-rs`
- resize pixbuf

Simpler and a lot of faster solution, but sadly looks that in current state not properly rotate some images(maybe migrating to GTK 4 will fix this behavior)

Also speedup comparing images.

Looks that alpha is fixed now