### PR TITLE
Update bad_extensions.rs

### DIFF
--- a/czkawka_core/src/bad_extensions.rs
+++ b/czkawka_core/src/bad_extensions.rs
@@ -83,7 +83,7 @@ static WORKAROUNDS: &[(&str, &str)] = &[
     ("html", "ent"),      // Mingw
     ("html", "md"),       // Markdown
     ("jpg", "jfif"),      // Photo format
-    ("mp4", "m4v"),       // mp4 and m4v are interchangable
+    ("m4v", "mp4"),       // m4v and mp4 are interchangable
     ("mobi", "azw3"),     // Ebook format
     ("mpg", "vob"),       // Weddings in parts have usually vob extension
     ("obj", "bin"),       // Multiple apps, Czkawka, Nvidia, Windows

--- a/czkawka_core/src/bad_extensions.rs
+++ b/czkawka_core/src/bad_extensions.rs
@@ -83,6 +83,7 @@ static WORKAROUNDS: &[(&str, &str)] = &[
     ("html", "ent"),      // Mingw
     ("html", "md"),       // Markdown
     ("jpg", "jfif"),      // Photo format
+    ("mp4", "m4v"),       // mp4 and m4v are interchangable
     ("mobi", "azw3"),     // Ebook format
     ("mpg", "vob"),       // Weddings in parts have usually vob extension
     ("obj", "bin"),       // Multiple apps, Czkawka, Nvidia, Windows


### PR DESCRIPTION
Extensions are interchangeable. mp4 files being flagged as bad extensions of m4v.