### PR TITLE
Run pydantic clippy lints on project

### DIFF
--- a/.github/workflows/linux_cli.yml
+++ b/.github/workflows/linux_cli.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         toolchain: [ stable, 1.65.0 ]
         type: [ release ]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b61a7545f753a88bcbe0a70de1fcc0221e10bfc752f576754fa91e663db1622e"
+checksum = "322296e2f2e5af4270b54df9e85a02ff037e271af20ba3e7fe1575515dc840b8"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -470,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f464457d494b5ed6905c63b0c4704842aba319084a0a3561cdc1359536b53200"
+checksum = "017a1385b05d631e7875b1f151c9f012d37b53491e2a87f65bff5c262b2111d8"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -485,15 +485,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c7119ce3a3701ed81aca8410b9acf6fc399d2629d057b87e2efa4e63a3aaea"
+checksum = "c26bbb078acf09bc1ecda02d4223f03bdd28bd4874edcb0379138efc499ce971"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e07508b90551e610910fa648a1878991d367064997a596135b86df30daf07e"
+checksum = "357f40d1f06a24b60ae1fe122542c1fb05d28d32acb2aed064e84bc2ad1e252e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3085,9 +3085,9 @@ checksum = "4553f467ac8e3d374bc9a177a26801e5d0f9b211aa1673fb137a403afd1c9cf5"
 
 [[package]]
 name = "toml_edit"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729bfd096e40da9c001f778f5cdecbd2957929a24e10e5883d9392220a751581"
+checksum = "56c59d8dd7d0dcbc6428bf7aa2f0e823e26e43b3c9aca15bbc9475d23e5fa12b"
 dependencies = [
  "indexmap",
  "nom8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
+name = "arc-swap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,9 +70,9 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "async-trait"
-version = "0.1.60"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d1d8ab452a3936018a687b20e6f7cf5363d713b732b8884001317b0e48aa3"
+checksum = "eff18d764974428cf3a9328e23fc5c986f5fbed46e6cd4cdf42544df5d297ec1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -184,15 +190,15 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bumpalo"
-version = "3.11.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "bytemuck"
-version = "1.12.3"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaa3a8d9a1ca92e282c96a32d6511b695d7d994d1d102ba85d279f9b2756947f"
+checksum = "c041d3eab048880cb0b86b256447da3f18859a163c3b8d8893f4e6368abe6393"
 
 [[package]]
 name = "byteorder"
@@ -202,9 +208,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bzip2"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6afcd980b5f3a45017c57e57a2fcccbb351cc43a356ce117ef760ef8052b89b0"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
 dependencies = [
  "bzip2-sys",
  "libc",
@@ -304,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.32"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
+checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -319,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.21"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -332,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
 dependencies = [
  "os_str_bytes",
 ]
@@ -452,9 +458,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.85"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add3fc1717409d029b20c5b6903fc0c0b02fa6741d820054f4a2efa5e5816fd"
+checksum = "b61a7545f753a88bcbe0a70de1fcc0221e10bfc752f576754fa91e663db1622e"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -464,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.85"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c87959ba14bc6fbc61df77c3fcfe180fc32b93538c4f1031dd802ccb5f2ff0"
+checksum = "f464457d494b5ed6905c63b0c4704842aba319084a0a3561cdc1359536b53200"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -479,15 +485,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.85"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69a3e162fde4e594ed2b07d0f83c6c67b745e7f28ce58c6df5e6b6bef99dfb59"
+checksum = "43c7119ce3a3701ed81aca8410b9acf6fc399d2629d057b87e2efa4e63a3aaea"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.85"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e7e2adeb6a0d4a282e581096b06e1791532b7d576dcde5ccd9382acf55db8e6"
+checksum = "65e07508b90551e610910fa648a1878991d367064997a596135b86df30daf07e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -663,9 +669,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "encoding_rs"
@@ -990,9 +996,9 @@ dependencies = [
 
 [[package]]
 name = "gdk4"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "272db1bbb9b152ea1fea946f9d464085c86cfe14cafba450d7defa433caff8ec"
+checksum = "bb2181330ebf9d091f8ea7fed6877f7adc92114128592e1fdaeb1da28e0d01e9"
 dependencies = [
  "bitflags",
  "cairo-rs",
@@ -1006,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "gdk4-sys"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45b571f36b889ab529b2e173248dafe83d75c703f5685b9845e490c7994ae309"
+checksum = "de55cb49432901fe2b3534177fa06844665b9b0911d85d8601a8d8b88b7791db"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
@@ -1149,9 +1155,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globalcache"
@@ -1198,9 +1204,9 @@ dependencies = [
 
 [[package]]
 name = "gsk4"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4053293b79099bdfecd9ab0d811d118a0eafce613dfe0b26075419d955f1f652"
+checksum = "591239f5c52ca803b222124ac9c47f230cd180cee9b114c4d672e4a94b74f491"
 dependencies = [
  "bitflags",
  "cairo-rs",
@@ -1214,9 +1220,9 @@ dependencies = [
 
 [[package]]
 name = "gsk4-sys"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08e0642edffdb35028d7d67b830678da98844216b6442e11eee52c91ad2a6dc2"
+checksum = "195a63f0be42529f98c3eb3bae0decfd0428ba2cc683b3e20ced88f340904ec5"
 dependencies = [
  "cairo-sys-rs",
  "gdk4-sys",
@@ -1230,9 +1236,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8954da3659ff1cb35aa95110021b33fadcd8e306e8fe41f32146ffa009665a79"
+checksum = "fd89dba65def483a233dc4fdd3f3dab01576e3d83f80f6c9303ebe421661855e"
 dependencies = [
  "bitflags",
  "cairo-rs",
@@ -1253,9 +1259,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4-macros"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58138cd3c595e04f82df050390aa7d2bd093795ce569e5f1d49eb496ef67fe7b"
+checksum = "832687a415d9d8bc11fe9c17dda1bf13ee262c41b995dd4df1d1cce33cead405"
 dependencies = [
  "anyhow",
  "proc-macro-crate",
@@ -1267,9 +1273,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4-sys"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef29e09e055b2f2550eb1882caa6961a1ae3c971a70bcb25cb9d5ab6cbd63821"
+checksum = "e370564e3fdacff7cffc99f7366b6a4689feb44e819d3ccee598a9a215b71605"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
@@ -1286,9 +1292,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad6a9459c9c30b177b925162351f97e7d967c7ea8bab3b8352805327daf45554"
+checksum = "02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0"
 dependencies = [
  "crunchy",
 ]
@@ -1331,18 +1337,18 @@ dependencies = [
 
 [[package]]
 name = "humansize"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e682e2bd70ecbcce5209f11a992a4ba001fea8e60acf7860ce007629e6d2756"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "i18n-config"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62affcd43abfb51f3cbd8736f9407908dc5b44fc558a9be07460bbfd104d983"
+checksum = "3d9f93ceee6543011739bc81699b5e0cf1f23f3a80364649b6d80de8636bc8df"
 dependencies = [
  "log",
  "serde",
@@ -1354,10 +1360,11 @@ dependencies = [
 
 [[package]]
 name = "i18n-embed"
-version = "0.13.4"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f21ed76e44de8ac3dfa36bb37ab2e6480be0dc75c612474949be1f3cb2c253"
+checksum = "2653dd1a8be0726315603f1c180b29f90e5b2a58f8b943d949d5170d9ad81101"
 dependencies = [
+ "arc-swap",
  "fluent",
  "fluent-langneg",
  "fluent-syntax",
@@ -1375,9 +1382,9 @@ dependencies = [
 
 [[package]]
 name = "i18n-embed-fl"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420a9718ef9d0ab727840a398e25408ea0daff9ba3c681707ba05485face98e"
+checksum = "a425b9bbdc2e4cd797a2a79528662cb61894bd36db582e48da2c56c28eb727cd"
 dependencies = [
  "dashmap",
  "find-crate",
@@ -1505,9 +1512,9 @@ dependencies = [
 
 [[package]]
 name = "infer"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6c16b11a665b26aeeb9b1d7f954cdeb034be38dd00adab4f2ae921a8fee804"
+checksum = "a898e4b7951673fce96614ce5751d13c40fc5674bc2d759288e46c3ab62598b3"
 dependencies = [
  "cfb",
 ]
@@ -1551,9 +1558,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
 dependencies = [
  "libc",
  "windows-sys",
@@ -1844,6 +1851,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom8"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1864,9 +1880,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
+checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
 dependencies = [
  "num-traits",
 ]
@@ -1951,9 +1967,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "opaque-debug"
@@ -2021,9 +2037,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
+checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2113,9 +2129,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.2"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6e86fb9e7026527a0d46bc308b841d73170ef8f443e1807f6ef88526a816d4"
+checksum = "4ab62d2fa33726dbe6321cc97ef96d8cde531e3eeaf858a058de53a8a6d40d8f"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -2188,13 +2204,12 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda0fc3b0fb7c975631757e14d9049da17374063edb6ebbcbc54d880d4fe94e9"
+checksum = "66618389e4ec1c7afe67d51a9bf34ff9236480f8d51e7489b7d5ab0303c13f34"
 dependencies = [
  "once_cell",
- "thiserror",
- "toml",
+ "toml_edit",
 ]
 
 [[package]]
@@ -2223,9 +2238,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
 dependencies = [
  "unicode-ident",
 ]
@@ -2296,9 +2311,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.1"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
+checksum = "356a0625f1954f730c0201cdab48611198dc6ce21f4acff55089b5a78e6e835b"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -2328,9 +2343,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2457,7 +2472,7 @@ version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17d4f6cbdb180c9f4b2a26bbf01c4e647f1e1dea22fe8eb9db54198b32f9434"
 dependencies = [
- "num-complex 0.4.2",
+ "num-complex 0.4.3",
  "num-integer",
  "num-traits",
  "primal-check",
@@ -2468,9 +2483,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.6"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
+checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
 dependencies = [
  "bitflags",
  "errno",
@@ -2714,14 +2729,15 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "symphonia"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17033fe05e4f7f10a6ad602c272bafd2520b2e5cdd9feb61494d9cdce08e002f"
+checksum = "3671dd6f64f4f9d5c87179525054cfc1f60de23ba1f193bd6ceab812737403f1"
 dependencies = [
  "lazy_static",
  "symphonia-bundle-flac",
  "symphonia-bundle-mp3",
  "symphonia-codec-aac",
+ "symphonia-codec-adpcm",
  "symphonia-codec-alac",
  "symphonia-codec-pcm",
  "symphonia-codec-vorbis",
@@ -2735,9 +2751,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-bundle-flac"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "044f655337892b217d6df1d8336ee119414c3886c89c72e0156989cd2ad7934a"
+checksum = "3dc2deed3204967871ba60f913378f95820cb47a2fe9b2eef5a9eedb417dfdc8"
 dependencies = [
  "log",
  "symphonia-core",
@@ -2747,9 +2763,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-bundle-mp3"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db5d3d53535ae2b7d0e39e82f683cac5398a6c8baca25ff1183e107d13959d3e"
+checksum = "55a0846e7a2c9a8081ff799fc83a975170417ad2a143f644a77ec2e3e82a2b73"
 dependencies = [
  "bitflags",
  "lazy_static",
@@ -2760,9 +2776,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-codec-aac"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9431b89428c31b01428563df18e52b1aff7c49e71fb80b2fa8e85632094776"
+checksum = "6fcdd4a10695ca0528572360ec020586320357350eb62791693667e7de8c871a"
 dependencies = [
  "lazy_static",
  "log",
@@ -2770,10 +2786,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "symphonia-codec-alac"
-version = "0.5.1"
+name = "symphonia-codec-adpcm"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "452438d6f32bf07f2f55f35371c3c8e9cce4a028a08b47fb301001f85a950f02"
+checksum = "2a5cfb8d4405e26eb9593157dc45b05e102b8d774b38ed2a95946d6bb9e26e3e"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-alac"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c49e1b209318bcefa7ff452bd85f1f593210943a7d9786b7d4250e8991a7449c"
 dependencies = [
  "log",
  "symphonia-core",
@@ -2781,9 +2807,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-codec-pcm"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cca412c954abda6ab62b5e51223568eb604ed8266ec777d99e1d63c608443c"
+checksum = "8cb9a9f0b9991cccf3217b74644af412d5d082a4815e5e2943f26e0ecabdf3c9"
 dependencies = [
  "log",
  "symphonia-core",
@@ -2791,9 +2817,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-codec-vorbis"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323b94435a1a807e1001e29490aeaef2660fb72b145d47497e8429a6cb1d67c3"
+checksum = "7dfed6f7b6bfa21d7cef1acefc8eae5db80df1608a1aca91871b07cbd28d7b74"
 dependencies = [
  "log",
  "symphonia-core",
@@ -2802,9 +2828,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-core"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "199a6417cd4115bac79289b64b859358ea050b7add0ceb364dc991f628c5b347"
+checksum = "6b9567e2d8a5f866b2f94f5d366d811e0c6826babcff6d37de9e1a6690d38869"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -2815,9 +2841,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-format-isomp4"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dce84cea63247dfcc43e12edf2d19406fbb62ebc24bac1b8e6c49f1ba67b890"
+checksum = "c1818f6f54b4eaba5ec004a8dbcca637c57e617eb1ff4c9addbd3fc065eba437"
 dependencies = [
  "encoding_rs",
  "log",
@@ -2828,9 +2854,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-format-mkv"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f405400330b2cc0c70e19515198628ae9a6a99a59c77800541127d4cff113b96"
+checksum = "1bd22f2def8c8f078495ad66111648bfc7d5222ee33774f2077cb665588f3119"
 dependencies = [
  "lazy_static",
  "log",
@@ -2841,9 +2867,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-format-ogg"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d2f741469a0f103607ed1f2605f7f00b13ba044ea9ddc616764558c6d3d9b7d"
+checksum = "474df6e86b871dcb56913130bada1440245f483057c4a2d8a2981455494c4439"
 dependencies = [
  "log",
  "symphonia-core",
@@ -2853,9 +2879,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-format-wav"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9d771aa6889f05b771e629110f6a60b5e1c0ad580fc41da574bc490fbe2822"
+checksum = "06679bd5646b3037300f88891dfc8a6e1cc4e1133206cc17a98e5d7c22f88296"
 dependencies = [
  "log",
  "symphonia-core",
@@ -2864,9 +2890,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-metadata"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed71acf6b5e6e8bee1509597b86365a06b78c1d73218df47357620a6fe5997b"
+checksum = "acd35c263223ef6161000be79b124a75de3e065eea563bf3ef169b3e94c7bb2e"
 dependencies = [
  "encoding_rs",
  "lazy_static",
@@ -2876,9 +2902,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-utils-xiph"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73cbb0766ce77a8aef535f9438db645e7b6f1b2c4cf3be9bf246b4e11a7d5531"
+checksum = "ce340a6c33ac06cb42de01220308ec056e8a2a3d5cc664aaf34567392557136b"
 dependencies = [
  "symphonia-core",
  "symphonia-metadata",
@@ -2924,9 +2950,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
@@ -3020,9 +3046,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8aeafdfd935e4a7fe16a91ab711fa52d54df84f9c8f7ca5837a9d1d902ef4c2"
+checksum = "7ac3f5b6856e931e15e07b478e98c8045239829a65f9156d4fa7e7788197a5ef"
 dependencies = [
  "displaydoc",
 ]
@@ -3044,11 +3070,28 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "toml"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4553f467ac8e3d374bc9a177a26801e5d0f9b211aa1673fb137a403afd1c9cf5"
+
+[[package]]
+name = "toml_edit"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "729bfd096e40da9c001f778f5cdecbd2957929a24e10e5883d9392220a751581"
+dependencies = [
+ "indexmap",
+ "nom8",
+ "toml_datetime",
 ]
 
 [[package]]
@@ -3196,9 +3239,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
 
 [[package]]
 name = "unicode-ident"
@@ -3407,12 +3450,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04662ed0e3e5630dfa9b26e4cb823b817f1a9addda855d973a9458c236556244"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.0",
- "windows_i686_gnu 0.42.0",
- "windows_i686_msvc 0.42.0",
- "windows_x86_64_gnu 0.42.0",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.0",
+ "windows_x86_64_msvc 0.42.1",
 ]
 
 [[package]]
@@ -3422,19 +3465,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.0",
- "windows_i686_gnu 0.42.0",
- "windows_i686_msvc 0.42.0",
- "windows_x86_64_gnu 0.42.0",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.0",
+ "windows_x86_64_msvc 0.42.1",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3444,9 +3487,9 @@ checksum = "ec7711666096bd4096ffa835238905bb33fb87267910e154b18b44eaabb340f2"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3456,9 +3499,9 @@ checksum = "763fc57100a5f7042e3057e7e8d9bdd7860d330070251a73d003563a3bb49e1b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3468,9 +3511,9 @@ checksum = "7bc7cbfe58828921e10a9f446fcaaf649204dcfe6c1ddd712c5eebae6bda1106"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3480,15 +3523,15 @@ checksum = "6868c165637d653ae1e8dc4d82c25d4f97dd6605eaa8d784b5c6e0ab2a252b65"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3498,9 +3541,9 @@ checksum = "5e4d40883ae9cae962787ca76ba76390ffa29214667a111db9e0a1ad8377e809"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "xxhash-rust"

--- a/czkawka_cli/Cargo.toml
+++ b/czkawka_cli/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/qarmin/czkawka"
 repository = "https://github.com/qarmin/czkawka"
 
 [dependencies]
-clap = { version = "4.0", features = ["derive"] }
+clap = { version = "4.1", features = ["derive"] }
 
 # For enum types
 image_hasher = "1.1.2"

--- a/czkawka_core/Cargo.toml
+++ b/czkawka_core/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/qarmin/czkawka"
 
 
 [dependencies]
-humansize = "2.1.2"
+humansize = "2.1.3"
 rayon = "1.6.1"
 crossbeam-channel = "0.5.6"
 
@@ -53,10 +53,10 @@ bincode = "1.3.3"
 serde_json = "1.0"
 
 # Language
-i18n-embed = { version = "0.13.4", features = ["fluent-system", "desktop-requester"] }
-i18n-embed-fl = "0.6.4"
+i18n-embed = { version = "0.13.8", features = ["fluent-system", "desktop-requester"] }
+i18n-embed-fl = "0.6.5"
 rust-embed = "6.4.2"
-once_cell = "1.16.0"
+once_cell = "1.17.0"
 
 # Raw image files
 rawloader = "0.37.1"
@@ -64,7 +64,7 @@ imagepipe = "0.5.0"
 
 # Checking for invalid extensions
 mime_guess = "2.0.4"
-infer = "0.11.0"
+infer = "0.12.0"
 
 num_cpus = "1.15.0"
 

--- a/czkawka_core/src/bad_extensions.rs
+++ b/czkawka_core/src/bad_extensions.rs
@@ -409,36 +409,35 @@ impl BadExtensions {
 
                 // Check for all extensions that file can use(not sure if it is worth to do it)
                 let mut all_available_extensions: BTreeSet<&str> = Default::default();
-                let think_extension = match current_extension.is_empty() {
-                    true => String::new(),
-                    false => {
-                        for mim in mime_guess::from_ext(proper_extension) {
-                            if let Some(all_ext) = get_mime_extensions(&mim) {
-                                for ext in all_ext {
-                                    all_available_extensions.insert(ext);
-                                }
+                let think_extension = if current_extension.is_empty() {
+                    String::new()
+                } else {
+                    for mim in mime_guess::from_ext(proper_extension) {
+                        if let Some(all_ext) = get_mime_extensions(&mim) {
+                            for ext in all_ext {
+                                all_available_extensions.insert(ext);
                             }
                         }
-
-                        // Workarounds
-                        if let Some(vec_pre) = hashmap_workarounds.get(current_extension.as_str()) {
-                            for pre in vec_pre {
-                                if all_available_extensions.contains(pre) {
-                                    all_available_extensions.insert(current_extension.as_str());
-                                    break;
-                                }
-                            }
-                        }
-
-                        let mut guessed_multiple_extensions = format!("({proper_extension}) - ");
-                        for ext in &all_available_extensions {
-                            guessed_multiple_extensions.push_str(ext);
-                            guessed_multiple_extensions.push(',');
-                        }
-                        guessed_multiple_extensions.pop();
-
-                        guessed_multiple_extensions
                     }
+
+                    // Workarounds
+                    if let Some(vec_pre) = hashmap_workarounds.get(current_extension.as_str()) {
+                        for pre in vec_pre {
+                            if all_available_extensions.contains(pre) {
+                                all_available_extensions.insert(current_extension.as_str());
+                                break;
+                            }
+                        }
+                    }
+
+                    let mut guessed_multiple_extensions = format!("({proper_extension}) - ");
+                    for ext in &all_available_extensions {
+                        guessed_multiple_extensions.push_str(ext);
+                        guessed_multiple_extensions.push(',');
+                    }
+                    guessed_multiple_extensions.pop();
+
+                    guessed_multiple_extensions
                 };
 
                 if all_available_extensions.is_empty() {

--- a/czkawka_core/src/bad_extensions.rs
+++ b/czkawka_core/src/bad_extensions.rs
@@ -166,6 +166,7 @@ pub struct Info {
 }
 
 impl Info {
+    #[must_use]
     pub fn new() -> Self {
         Default::default()
     }
@@ -188,6 +189,7 @@ pub struct BadExtensions {
 }
 
 impl BadExtensions {
+    #[must_use]
     pub fn new() -> Self {
         Self {
             text_messages: Messages::new(),
@@ -219,10 +221,12 @@ impl BadExtensions {
         self.debug_print();
     }
 
+    #[must_use]
     pub fn get_stopped_search(&self) -> bool {
         self.stopped_search
     }
 
+    #[must_use]
     pub const fn get_bad_extensions_files(&self) -> &Vec<BadFileEntry> {
         &self.bad_extensions_files
     }
@@ -246,10 +250,12 @@ impl BadExtensions {
     #[cfg(not(target_family = "unix"))]
     pub fn set_exclude_other_filesystems(&mut self, _exclude_other_filesystems: bool) {}
 
+    #[must_use]
     pub const fn get_text_messages(&self) -> &Messages {
         &self.text_messages
     }
 
+    #[must_use]
     pub const fn get_information(&self) -> &Info {
         &self.information
     }
@@ -388,12 +394,12 @@ impl BadExtensions {
                     }
                     // Text longer than 10 characters is not considered as extension
                     if extension.len() > 10 {
-                        current_extension = "".to_string();
+                        current_extension = String::new();
                     } else {
                         current_extension = extension;
                     }
                 } else {
-                    current_extension = "".to_string();
+                    current_extension = String::new();
                 }
 
                 // Already have proper extension, no need to do more things
@@ -404,7 +410,7 @@ impl BadExtensions {
                 // Check for all extensions that file can use(not sure if it is worth to do it)
                 let mut all_available_extensions: BTreeSet<&str> = Default::default();
                 let think_extension = match current_extension.is_empty() {
-                    true => "".to_string(),
+                    true => String::new(),
                     false => {
                         for mim in mime_guess::from_ext(proper_extension) {
                             if let Some(all_ext) = get_mime_extensions(&mim) {
@@ -456,8 +462,8 @@ impl BadExtensions {
                 }))
             })
             .while_some()
-            .filter(|file_entry| file_entry.is_some())
-            .map(|file_entry| file_entry.unwrap())
+            .filter(std::option::Option::is_some)
+            .map(std::option::Option::unwrap)
             .collect::<Vec<_>>();
 
         // End thread which send info to gui
@@ -540,7 +546,7 @@ impl SaveResults for BadExtensions {
 
         if !self.bad_extensions_files.is_empty() {
             writeln!(writer, "Found {} files with invalid extension.", self.information.number_of_files_with_bad_extension).unwrap();
-            for file_entry in self.bad_extensions_files.iter() {
+            for file_entry in &self.bad_extensions_files {
                 writeln!(writer, "{} ----- {}", file_entry.path.display(), file_entry.proper_extensions).unwrap();
             }
         } else {
@@ -557,7 +563,7 @@ impl PrintResults for BadExtensions {
     fn print_results(&self) {
         let start_time: SystemTime = SystemTime::now();
         println!("Found {} files with invalid extension.\n", self.information.number_of_files_with_bad_extension);
-        for file_entry in self.bad_extensions_files.iter() {
+        for file_entry in &self.bad_extensions_files {
             println!("{} ----- {}", file_entry.path.display(), file_entry.proper_extensions);
         }
 

--- a/czkawka_core/src/bad_extensions.rs
+++ b/czkawka_core/src/bad_extensions.rs
@@ -461,8 +461,8 @@ impl BadExtensions {
                 }))
             })
             .while_some()
-            .filter(std::option::Option::is_some)
-            .map(std::option::Option::unwrap)
+            .filter(Option::is_some)
+            .map(Option::unwrap)
             .collect::<Vec<_>>();
 
         // End thread which send info to gui

--- a/czkawka_core/src/bad_extensions.rs
+++ b/czkawka_core/src/bad_extensions.rs
@@ -307,7 +307,7 @@ impl BadExtensions {
                     self.files_to_check = files_to_check.clone();
                 }
                 self.text_messages.warnings.extend(warnings);
-                Common::print_time(start_time, SystemTime::now(), "check_files".to_string());
+                Common::print_time(start_time, SystemTime::now(), "check_files");
                 true
             }
             DirTraversalResult::SuccessFolders { .. } => {
@@ -476,7 +476,7 @@ impl BadExtensions {
 
         self.information.number_of_files_with_bad_extension = self.bad_extensions_files.len();
 
-        Common::print_time(system_time, SystemTime::now(), "bad extension finding".to_string());
+        Common::print_time(system_time, SystemTime::now(), "bad extension finding");
 
         // Clean unused data
         self.files_to_check = Default::default();
@@ -551,7 +551,7 @@ impl SaveResults for BadExtensions {
         } else {
             write!(writer, "Not found any files with invalid extension.").unwrap();
         }
-        Common::print_time(start_time, SystemTime::now(), "save_results_to_file".to_string());
+        Common::print_time(start_time, SystemTime::now(), "save_results_to_file");
         true
     }
 }
@@ -566,6 +566,6 @@ impl PrintResults for BadExtensions {
             println!("{} ----- {}", file_entry.path.display(), file_entry.proper_extensions);
         }
 
-        Common::print_time(start_time, SystemTime::now(), "print_entries".to_string());
+        Common::print_time(start_time, SystemTime::now(), "print_entries");
     }
 }

--- a/czkawka_core/src/big_file.rs
+++ b/czkawka_core/src/big_file.rs
@@ -56,6 +56,7 @@ pub struct Info {
 }
 
 impl Info {
+    #[must_use]
     pub fn new() -> Self {
         Default::default()
     }
@@ -77,6 +78,7 @@ pub struct BigFile {
 }
 
 impl BigFile {
+    #[must_use]
     pub fn new() -> Self {
         Self {
             text_messages: Default::default(),
@@ -102,6 +104,7 @@ impl BigFile {
         self.delete_files();
         self.debug_print();
     }
+    #[must_use]
     pub fn get_stopped_search(&self) -> bool {
         self.stopped_search
     }
@@ -110,14 +113,17 @@ impl BigFile {
         self.search_mode = search_mode;
     }
 
+    #[must_use]
     pub const fn get_big_files(&self) -> &Vec<(u64, FileEntry)> {
         &self.big_files
     }
 
+    #[must_use]
     pub const fn get_text_messages(&self) -> &Messages {
         &self.text_messages
     }
 
+    #[must_use]
     pub const fn get_information(&self) -> &Info {
         &self.information
     }
@@ -470,7 +476,7 @@ impl SaveResults for BigFile {
             } else {
                 write!(writer, "{} the smallest files.\n\n", self.information.number_of_real_files).unwrap();
             }
-            for (size, file_entry) in self.big_files.iter() {
+            for (size, file_entry) in &self.big_files {
                 writeln!(writer, "{} ({}) - {}", format_size(*size, BINARY), size, file_entry.path.display()).unwrap();
             }
         } else {
@@ -489,7 +495,7 @@ impl PrintResults for BigFile {
         } else {
             println!("{} the smallest files.\n\n", self.information.number_of_real_files);
         }
-        for (size, file_entry) in self.big_files.iter() {
+        for (size, file_entry) in &self.big_files {
             println!("{} ({}) - {}", format_size(*size, BINARY), size, file_entry.path.display());
         }
         Common::print_time(start_time, SystemTime::now(), "print_entries".to_string());

--- a/czkawka_core/src/big_file.rs
+++ b/czkawka_core/src/big_file.rs
@@ -361,7 +361,7 @@ impl BigFile {
             }
         }
 
-        Common::print_time(start_time, SystemTime::now(), "look_for_big_files".to_string());
+        Common::print_time(start_time, SystemTime::now(), "look_for_big_files");
         true
     }
 
@@ -404,7 +404,7 @@ impl BigFile {
             }
         }
 
-        Common::print_time(start_time, SystemTime::now(), "delete_files".to_string());
+        Common::print_time(start_time, SystemTime::now(), "delete_files");
     }
 }
 
@@ -482,7 +482,7 @@ impl SaveResults for BigFile {
         } else {
             write!(writer, "Not found any files.").unwrap();
         }
-        Common::print_time(start_time, SystemTime::now(), "save_results_to_file".to_string());
+        Common::print_time(start_time, SystemTime::now(), "save_results_to_file");
         true
     }
 }
@@ -498,6 +498,6 @@ impl PrintResults for BigFile {
         for (size, file_entry) in &self.big_files {
             println!("{} ({}) - {}", format_size(*size, BINARY), size, file_entry.path.display());
         }
-        Common::print_time(start_time, SystemTime::now(), "print_entries".to_string());
+        Common::print_time(start_time, SystemTime::now(), "print_entries");
     }
 }

--- a/czkawka_core/src/broken_files.rs
+++ b/czkawka_core/src/broken_files.rs
@@ -75,6 +75,7 @@ pub struct Info {
 }
 
 impl Info {
+    #[must_use]
     pub fn new() -> Self {
         Default::default()
     }
@@ -98,6 +99,7 @@ pub struct BrokenFiles {
 }
 
 impl BrokenFiles {
+    #[must_use]
     pub fn new() -> Self {
         Self {
             text_messages: Messages::new(),
@@ -131,10 +133,12 @@ impl BrokenFiles {
         self.debug_print();
     }
 
+    #[must_use]
     pub fn get_stopped_search(&self) -> bool {
         self.stopped_search
     }
 
+    #[must_use]
     pub const fn get_broken_files(&self) -> &Vec<FileEntry> {
         &self.broken_files
     }
@@ -143,10 +147,12 @@ impl BrokenFiles {
         self.checked_types = checked_types;
     }
 
+    #[must_use]
     pub const fn get_text_messages(&self) -> &Messages {
         &self.text_messages
     }
 
+    #[must_use]
     pub const fn get_information(&self) -> &Info {
         &self.information
     }
@@ -354,7 +360,7 @@ impl BrokenFiles {
                                 },
                                 size: metadata.len(),
                                 type_of_file,
-                                error_string: "".to_string(),
+                                error_string: String::new(),
                             };
 
                             fe_result.push((current_file_name.to_string_lossy().to_string(), fe));
@@ -556,8 +562,8 @@ impl BrokenFiles {
                 }
             })
             .while_some()
-            .filter(|file_entry| file_entry.is_some())
-            .map(|file_entry| file_entry.unwrap())
+            .filter(std::option::Option::is_some)
+            .map(std::option::Option::unwrap)
             .collect::<Vec<FileEntry>>();
 
         // End thread which send info to gui
@@ -602,7 +608,7 @@ impl BrokenFiles {
 
         match self.delete_method {
             DeleteMethod::Delete => {
-                for file_entry in self.broken_files.iter() {
+                for file_entry in &self.broken_files {
                     if fs::remove_file(&file_entry.path).is_err() {
                         self.text_messages.warnings.push(file_entry.path.display().to_string());
                     }
@@ -680,7 +686,7 @@ impl SaveResults for BrokenFiles {
 
         if !self.broken_files.is_empty() {
             writeln!(writer, "Found {} broken files.", self.information.number_of_broken_files).unwrap();
-            for file_entry in self.broken_files.iter() {
+            for file_entry in &self.broken_files {
                 writeln!(writer, "{} - {}", file_entry.path.display(), file_entry.error_string).unwrap();
             }
         } else {
@@ -697,7 +703,7 @@ impl PrintResults for BrokenFiles {
     fn print_results(&self) {
         let start_time: SystemTime = SystemTime::now();
         println!("Found {} broken files.\n", self.information.number_of_broken_files);
-        for file_entry in self.broken_files.iter() {
+        for file_entry in &self.broken_files {
             println!("{} - {}", file_entry.path.display(), file_entry.error_string);
         }
 

--- a/czkawka_core/src/broken_files.rs
+++ b/czkawka_core/src/broken_files.rs
@@ -562,8 +562,8 @@ impl BrokenFiles {
                 }
             })
             .while_some()
-            .filter(std::option::Option::is_some)
-            .map(std::option::Option::unwrap)
+            .filter(Option::is_some)
+            .map(Option::unwrap)
             .collect::<Vec<FileEntry>>();
 
         // End thread which send info to gui

--- a/czkawka_core/src/broken_files.rs
+++ b/czkawka_core/src/broken_files.rs
@@ -387,7 +387,7 @@ impl BrokenFiles {
         progress_thread_run.store(false, Ordering::Relaxed);
         progress_thread_handle.join().unwrap();
 
-        Common::print_time(start_time, SystemTime::now(), "check_files".to_string());
+        Common::print_time(start_time, SystemTime::now(), "check_files");
         true
     }
     fn look_for_broken_files(&mut self, stop_receiver: Option<&Receiver<()>>, progress_sender: Option<&futures::channel::mpsc::UnboundedSender<ProgressData>>) -> bool {
@@ -595,7 +595,7 @@ impl BrokenFiles {
 
         self.information.number_of_broken_files = self.broken_files.len();
 
-        Common::print_time(system_time, SystemTime::now(), "sort_images - reading data from files in parallel".to_string());
+        Common::print_time(system_time, SystemTime::now(), "sort_images - reading data from files in parallel");
 
         // Clean unused data
         self.files_to_check = Default::default();
@@ -619,7 +619,7 @@ impl BrokenFiles {
             }
         }
 
-        Common::print_time(start_time, SystemTime::now(), "delete_files".to_string());
+        Common::print_time(start_time, SystemTime::now(), "delete_files");
     }
 }
 
@@ -692,7 +692,7 @@ impl SaveResults for BrokenFiles {
         } else {
             write!(writer, "Not found any broken files.").unwrap();
         }
-        Common::print_time(start_time, SystemTime::now(), "save_results_to_file".to_string());
+        Common::print_time(start_time, SystemTime::now(), "save_results_to_file");
         true
     }
 }
@@ -707,7 +707,7 @@ impl PrintResults for BrokenFiles {
             println!("{} - {}", file_entry.path.display(), file_entry.error_string);
         }
 
-        Common::print_time(start_time, SystemTime::now(), "print_entries".to_string());
+        Common::print_time(start_time, SystemTime::now(), "print_entries");
     }
 }
 

--- a/czkawka_core/src/common.rs
+++ b/czkawka_core/src/common.rs
@@ -26,6 +26,7 @@ pub fn get_number_of_threads() -> usize {
 pub fn set_default_number_of_threads() {
     set_number_of_threads(num_cpus::get());
 }
+#[must_use]
 pub fn get_default_number_of_threads() -> usize {
     num_cpus::get()
 }
@@ -181,6 +182,7 @@ pub fn get_dynamic_image_from_raw_image(path: impl AsRef<Path> + std::fmt::Debug
     Some(DynamicImage::ImageRgb8(image))
 }
 
+#[must_use]
 pub fn split_path(path: &Path) -> (String, String) {
     match (path.parent(), path.file_name()) {
         (Some(dir), Some(file)) => (dir.display().to_string(), file.to_string_lossy().into_owned()),
@@ -189,6 +191,7 @@ pub fn split_path(path: &Path) -> (String, String) {
     }
 }
 
+#[must_use]
 pub fn create_crash_message(library_name: &str, file_path: &str, home_library_url: &str) -> String {
     format!("{library_name} library crashed when opening \"{file_path}\", please check if this is fixed with the latest version of {library_name} (e.g. with https://github.com/qarmin/crates_tester) and if it is not fixed, please report bug here - {home_library_url}")
 }
@@ -205,6 +208,7 @@ impl Common {
         );
     }
 
+    #[must_use]
     pub fn delete_multiple_entries(entries: &[String]) -> Vec<String> {
         let mut path: &Path;
         let mut warnings: Vec<String> = Vec::new();
@@ -220,9 +224,10 @@ impl Common {
         }
         warnings
     }
+    #[must_use]
     pub fn delete_one_entry(entry: &str) -> String {
         let path: &Path = Path::new(entry);
-        let mut warning: String = String::from("");
+        let mut warning: String = String::new();
         if path.is_dir() {
             if let Err(e) = fs::remove_dir_all(entry) {
                 warning = format!("Failed to remove folder {entry}, reason {e}")

--- a/czkawka_core/src/common.rs
+++ b/czkawka_core/src/common.rs
@@ -199,7 +199,7 @@ pub fn create_crash_message(library_name: &str, file_path: &str, home_library_ur
 impl Common {
     /// Printing time which took between start and stop point and prints also function name
     #[allow(unused_variables)]
-    pub fn print_time(start_time: SystemTime, end_time: SystemTime, function_name: String) {
+    pub fn print_time(start_time: SystemTime, end_time: SystemTime, function_name: &str) {
         #[cfg(debug_assertions)]
         println!(
             "Execution of function \"{}\" took {:?}",
@@ -230,10 +230,10 @@ impl Common {
         let mut warning: String = String::new();
         if path.is_dir() {
             if let Err(e) = fs::remove_dir_all(entry) {
-                warning = format!("Failed to remove folder {entry}, reason {e}")
+                warning = format!("Failed to remove folder {entry}, reason {e}");
             }
         } else if let Err(e) = fs::remove_file(entry) {
-            warning = format!("Failed to remove file {entry}, reason {e}")
+            warning = format!("Failed to remove file {entry}, reason {e}");
         }
         warning
     }

--- a/czkawka_core/src/common_dir_traversal.rs
+++ b/czkawka_core/src/common_dir_traversal.rs
@@ -155,67 +155,80 @@ impl<'a, 'b> DirTraversalBuilder<'a, 'b, ()> {
 }
 
 impl<'a, 'b, F> DirTraversalBuilder<'a, 'b, F> {
+    #[must_use]
     pub fn root_dirs(mut self, dirs: Vec<PathBuf>) -> Self {
         self.root_dirs = dirs;
         self
     }
 
+    #[must_use]
     pub fn stop_receiver(mut self, stop_receiver: Option<&'a Receiver<()>>) -> Self {
         self.stop_receiver = stop_receiver;
         self
     }
 
+    #[must_use]
     pub fn progress_sender(mut self, progress_sender: Option<&'b futures::channel::mpsc::UnboundedSender<ProgressData>>) -> Self {
         self.progress_sender = progress_sender;
         self
     }
 
+    #[must_use]
     pub fn checking_method(mut self, checking_method: CheckingMethod) -> Self {
         self.checking_method = checking_method;
         self
     }
 
+    #[must_use]
     pub fn max_stage(mut self, max_stage: u8) -> Self {
         self.max_stage = max_stage;
         self
     }
 
+    #[must_use]
     pub fn minimal_file_size(mut self, minimal_file_size: u64) -> Self {
         self.minimal_file_size = Some(minimal_file_size);
         self
     }
 
+    #[must_use]
     pub fn maximal_file_size(mut self, maximal_file_size: u64) -> Self {
         self.maximal_file_size = Some(maximal_file_size);
         self
     }
 
+    #[must_use]
     pub fn collect(mut self, collect: Collect) -> Self {
         self.collect = collect;
         self
     }
 
+    #[must_use]
     pub fn directories(mut self, directories: Directories) -> Self {
         self.directories = Some(directories);
         self
     }
 
+    #[must_use]
     pub fn allowed_extensions(mut self, allowed_extensions: Extensions) -> Self {
         self.allowed_extensions = Some(allowed_extensions);
         self
     }
 
+    #[must_use]
     pub fn excluded_items(mut self, excluded_items: ExcludedItems) -> Self {
         self.excluded_items = Some(excluded_items);
         self
     }
 
+    #[must_use]
     pub fn recursive_search(mut self, recursive_search: bool) -> Self {
         self.recursive_search = recursive_search;
         self
     }
 
     #[cfg(target_family = "unix")]
+    #[must_use]
     pub fn exclude_other_filesystems(mut self, exclude_other_filesystems: bool) -> Self {
         match self.directories {
             Some(ref mut directories) => directories.set_exclude_other_filesystems(exclude_other_filesystems),

--- a/czkawka_core/src/common_dir_traversal.rs
+++ b/czkawka_core/src/common_dir_traversal.rs
@@ -62,7 +62,7 @@ pub enum ErrorType {
 // Empty folders
 
 /// Enum with values which show if folder is empty.
-/// In function "optimize_folders" automatically "Maybe" is changed to "Yes", so it is not necessary to put it here
+/// In function "`optimize_folders`" automatically "Maybe" is changed to "Yes", so it is not necessary to put it here
 #[derive(Eq, PartialEq, Copy, Clone)]
 pub(crate) enum FolderEmptiness {
     No,
@@ -134,6 +134,7 @@ impl<'a, 'b> Default for DirTraversalBuilder<'a, 'b, ()> {
 }
 
 impl<'a, 'b> DirTraversalBuilder<'a, 'b, ()> {
+    #[must_use]
     pub fn new() -> DirTraversalBuilder<'a, 'b, ()> {
         DirTraversalBuilder {
             group_by: None,
@@ -413,7 +414,7 @@ where
                             }
                         };
                         match (entry_type(&metadata), collect) {
-                            (EntryType::Dir, Collect::Files) | (EntryType::Dir, Collect::InvalidSymlinks) => {
+                            (EntryType::Dir, Collect::Files | Collect::InvalidSymlinks) => {
                                 if !recursive_search {
                                     continue 'dir;
                                 }
@@ -540,14 +541,14 @@ where
                                                 0
                                             }
                                         },
-                                        hash: "".to_string(),
+                                        hash: String::new(),
                                         symlink_info: None,
                                     };
 
                                     fe_result.push(fe);
                                 }
                             }
-                            (EntryType::File, Collect::EmptyFolders) | (EntryType::Symlink, Collect::EmptyFolders) => {
+                            (EntryType::File | EntryType::Symlink, Collect::EmptyFolders) => {
                                 #[cfg(target_family = "unix")]
                                 if directories.exclude_other_filesystems() {
                                     match directories.is_on_other_filesystems(current_folder) {
@@ -653,7 +654,7 @@ where
                                         }
                                     },
                                     size: 0,
-                                    hash: "".to_string(),
+                                    hash: String::new(),
                                     symlink_info: Some(SymlinkInfo { destination_path, type_of_error }),
                                 };
 

--- a/czkawka_core/src/common_directory.rs
+++ b/czkawka_core/src/common_directory.rs
@@ -19,6 +19,7 @@ pub struct Directories {
 }
 
 impl Directories {
+    #[must_use]
     pub fn new() -> Self {
         Default::default()
     }
@@ -323,6 +324,7 @@ impl Directories {
     }
 
     #[cfg(target_family = "unix")]
+    #[must_use]
     pub fn exclude_other_filesystems(&self) -> bool {
         self.exclude_other_filesystems.unwrap_or(false)
     }

--- a/czkawka_core/src/common_directory.rs
+++ b/czkawka_core/src/common_directory.rs
@@ -90,7 +90,7 @@ impl Directories {
 
         self.included_directories = checked_directories;
 
-        Common::print_time(start_time, SystemTime::now(), "set_included_directory".to_string());
+        Common::print_time(start_time, SystemTime::now(), "set_included_directory");
         true
     }
 
@@ -149,7 +149,7 @@ impl Directories {
         }
         self.excluded_directories = checked_directories;
 
-        Common::print_time(start_time, SystemTime::now(), "set_excluded_directory".to_string());
+        Common::print_time(start_time, SystemTime::now(), "set_excluded_directory");
     }
 
     #[cfg(target_family = "unix")]
@@ -295,7 +295,7 @@ impl Directories {
         // Not needed, but better is to have sorted everything
         self.excluded_directories.sort_unstable();
         self.included_directories.sort_unstable();
-        Common::print_time(start_time, SystemTime::now(), "optimize_directories".to_string());
+        Common::print_time(start_time, SystemTime::now(), "optimize_directories");
 
         // Get device IDs for included directories
         #[cfg(target_family = "unix")]

--- a/czkawka_core/src/common_directory.rs
+++ b/czkawka_core/src/common_directory.rs
@@ -25,7 +25,7 @@ impl Directories {
     }
 
     pub fn set_reference_directory(&mut self, reference_directory: Vec<PathBuf>) {
-        self.reference_directories = reference_directory
+        self.reference_directories = reference_directory;
     }
 
     /// Setting included directories, at least one must be provided or scan won't start
@@ -154,7 +154,7 @@ impl Directories {
 
     #[cfg(target_family = "unix")]
     pub fn set_exclude_other_filesystems(&mut self, exclude_other_filesystems: bool) {
-        self.exclude_other_filesystems = Some(exclude_other_filesystems)
+        self.exclude_other_filesystems = Some(exclude_other_filesystems);
     }
 
     /// Remove unused entries when included or excluded overlaps with each other or are duplicated etc.

--- a/czkawka_core/src/common_extensions.rs
+++ b/czkawka_core/src/common_extensions.rs
@@ -57,7 +57,7 @@ impl Extensions {
                 .messages
                 .push("No valid extensions were provided, so allowing all extensions by default.".to_string());
         }
-        Common::print_time(start_time, SystemTime::now(), "set_allowed_extensions".to_string());
+        Common::print_time(start_time, SystemTime::now(), "set_allowed_extensions");
     }
 
     #[must_use]

--- a/czkawka_core/src/common_extensions.rs
+++ b/czkawka_core/src/common_extensions.rs
@@ -9,6 +9,7 @@ pub struct Extensions {
 }
 
 impl Extensions {
+    #[must_use]
     pub fn new() -> Self {
         Default::default()
     }
@@ -24,7 +25,7 @@ impl Extensions {
         allowed_extensions = allowed_extensions.replace("MUSIC", "mp3,flac,ogg,tta,wma,webm");
         allowed_extensions = allowed_extensions.replace("TEXT", "txt,doc,docx,odt,rtf");
 
-        let extensions: Vec<String> = allowed_extensions.split(',').map(|e| e.trim()).map(String::from).collect();
+        let extensions: Vec<String> = allowed_extensions.split(',').map(str::trim).map(String::from).collect();
         for mut extension in extensions {
             if extension.is_empty() || extension.replace(['.', ' '], "").trim().is_empty() {
                 continue;
@@ -59,6 +60,7 @@ impl Extensions {
         Common::print_time(start_time, SystemTime::now(), "set_allowed_extensions".to_string());
     }
 
+    #[must_use]
     pub fn matches_filename(&self, file_name: &str) -> bool {
         // assert_eq!(file_name, file_name.to_lowercase());
         if !self.file_extensions.is_empty() && !self.file_extensions.iter().any(|e| file_name.ends_with(e)) {
@@ -67,6 +69,7 @@ impl Extensions {
         true
     }
 
+    #[must_use]
     pub fn using_custom_extensions(&self) -> bool {
         !self.file_extensions.is_empty()
     }
@@ -74,7 +77,7 @@ impl Extensions {
     pub fn extend_allowed_extensions(&mut self, file_extensions: &[&str]) {
         for extension in file_extensions {
             assert!(extension.starts_with('.'));
-            self.file_extensions.push(extension.to_string());
+            self.file_extensions.push((*extension).to_string());
         }
     }
 
@@ -83,8 +86,8 @@ impl Extensions {
 
         for extension in file_extensions {
             assert!(extension.starts_with('.'));
-            if self.file_extensions.contains(&extension.to_string()) {
-                current_file_extensions.push(extension.to_string());
+            if self.file_extensions.contains(&(*extension).to_string()) {
+                current_file_extensions.push((*extension).to_string());
             }
         }
         self.file_extensions = current_file_extensions;

--- a/czkawka_core/src/common_items.rs
+++ b/czkawka_core/src/common_items.rs
@@ -55,7 +55,7 @@ impl ExcludedItems {
             checked_expressions.push(expression);
         }
         self.items = checked_expressions;
-        Common::print_time(start_time, SystemTime::now(), "set_excluded_items".to_string());
+        Common::print_time(start_time, SystemTime::now(), "set_excluded_items");
     }
 
     /// Checks whether a specified path is excluded from searching

--- a/czkawka_core/src/common_items.rs
+++ b/czkawka_core/src/common_items.rs
@@ -10,6 +10,7 @@ pub struct ExcludedItems {
 }
 
 impl ExcludedItems {
+    #[must_use]
     pub fn new() -> Self {
         Default::default()
     }

--- a/czkawka_core/src/common_messages.rs
+++ b/czkawka_core/src/common_messages.rs
@@ -6,14 +6,16 @@ pub struct Messages {
 }
 
 impl Messages {
+    #[must_use]
     pub fn new() -> Self {
         Default::default()
     }
     pub fn print_messages(&self) {
         println!("{}", self.create_messages_text());
     }
+    #[must_use]
     pub fn create_messages_text(&self) -> String {
-        let mut text_to_return: String = "".to_string();
+        let mut text_to_return: String = String::new();
 
         if !self.messages.is_empty() {
             text_to_return += "-------------------------------MESSAGES--------------------------------\n";

--- a/czkawka_core/src/duplicate.rs
+++ b/czkawka_core/src/duplicate.rs
@@ -73,6 +73,7 @@ pub struct Info {
 }
 
 impl Info {
+    #[must_use]
     pub fn new() -> Self {
         Default::default()
     }
@@ -109,6 +110,7 @@ pub struct DuplicateFinder {
 }
 
 impl DuplicateFinder {
+    #[must_use]
     pub fn new() -> Self {
         Self {
             text_messages: Messages::new(),
@@ -184,10 +186,12 @@ impl DuplicateFinder {
         self.case_sensitive_name_comparison = case_sensitive_name_comparison;
     }
 
+    #[must_use]
     pub const fn get_check_method(&self) -> &CheckingMethod {
         &self.check_method
     }
 
+    #[must_use]
     pub fn get_stopped_search(&self) -> bool {
         self.stopped_search
     }
@@ -200,6 +204,7 @@ impl DuplicateFinder {
         self.minimal_prehash_cache_file_size = minimal_prehash_cache_file_size;
     }
 
+    #[must_use]
     pub const fn get_files_sorted_by_names(&self) -> &BTreeMap<String, Vec<FileEntry>> {
         &self.files_with_identical_names
     }
@@ -212,10 +217,12 @@ impl DuplicateFinder {
         self.use_prehash_cache = use_prehash_cache;
     }
 
+    #[must_use]
     pub const fn get_files_sorted_by_size(&self) -> &BTreeMap<u64, Vec<FileEntry>> {
         &self.files_with_identical_size
     }
 
+    #[must_use]
     pub const fn get_files_sorted_by_hash(&self) -> &BTreeMap<u64, Vec<Vec<FileEntry>>> {
         &self.files_with_identical_hashes
     }
@@ -226,10 +233,12 @@ impl DuplicateFinder {
         };
     }
 
+    #[must_use]
     pub const fn get_text_messages(&self) -> &Messages {
         &self.text_messages
     }
 
+    #[must_use]
     pub const fn get_information(&self) -> &Info {
         &self.information
     }
@@ -261,6 +270,7 @@ impl DuplicateFinder {
         };
     }
 
+    #[must_use]
     pub fn get_use_reference(&self) -> bool {
         self.use_reference_folders
     }
@@ -295,14 +305,17 @@ impl DuplicateFinder {
         self.allowed_extensions.set_allowed_extensions(allowed_extensions, &mut self.text_messages);
     }
 
+    #[must_use]
     pub fn get_files_with_identical_hashes_referenced(&self) -> &BTreeMap<u64, Vec<(FileEntry, Vec<FileEntry>)>> {
         &self.files_with_identical_hashes_referenced
     }
 
+    #[must_use]
     pub fn get_files_with_identical_name_referenced(&self) -> &BTreeMap<String, (FileEntry, Vec<FileEntry>)> {
         &self.files_with_identical_names_referenced
     }
 
+    #[must_use]
     pub fn get_files_with_identical_size_referenced(&self) -> &BTreeMap<u64, (FileEntry, Vec<FileEntry>)> {
         &self.files_with_identical_size_referenced
     }
@@ -520,7 +533,7 @@ impl DuplicateFinder {
             let progress_send = progress_sender.clone();
             let progress_thread_run = progress_thread_run.clone();
             let atomic_file_counter = atomic_file_counter.clone();
-            let files_to_check = self.files_with_identical_size.values().map(|e| e.len()).sum();
+            let files_to_check = self.files_with_identical_size.values().map(std::vec::Vec::len).sum();
             let checking_method = self.check_method;
             thread::spawn(move || loop {
                 progress_send
@@ -679,7 +692,7 @@ impl DuplicateFinder {
             let progress_send = progress_sender.clone();
             let progress_thread_run = progress_thread_run.clone();
             let atomic_file_counter = atomic_file_counter.clone();
-            let files_to_check = pre_checked_map.values().map(|vec_file_entry| vec_file_entry.len()).sum();
+            let files_to_check = pre_checked_map.values().map(std::vec::Vec::len).sum();
             let checking_method = self.check_method;
             thread::spawn(move || loop {
                 progress_send
@@ -895,7 +908,7 @@ impl DuplicateFinder {
         true
     }
 
-    /// Function to delete files, from filed before BTreeMap
+    /// Function to delete files, from filed before `BTreeMap`
     /// Using another function to delete files to avoid duplicates data
     fn delete_files(&mut self) {
         let start_time: SystemTime = SystemTime::now();
@@ -1127,7 +1140,7 @@ impl PrintResults for DuplicateFinder {
                 }
             }
             CheckingMethod::Hash => {
-                for (_size, vector) in self.files_with_identical_hashes.iter() {
+                for (_size, vector) in &self.files_with_identical_hashes {
                     for j in vector {
                         number_of_files += j.len() as u64;
                         number_of_groups += 1;
@@ -1190,7 +1203,7 @@ fn delete_files(vector: &[FileEntry], delete_method: &DeleteMethod, text_message
         DeleteMethod::OneNewest | DeleteMethod::AllExceptOldest | DeleteMethod::HardLink => values.min_by(|(_, l), (_, r)| l.modified_date.cmp(&r.modified_date)),
         DeleteMethod::None => values.next(),
     };
-    let q_index = q_index.map(|t| t.0).unwrap_or(0);
+    let q_index = q_index.map_or(0, |t| t.0);
     let n = match delete_method {
         DeleteMethod::OneNewest | DeleteMethod::OneOldest => 1,
         DeleteMethod::AllExceptNewest | DeleteMethod::AllExceptOldest | DeleteMethod::None | DeleteMethod::HardLink => usize::MAX,
@@ -1372,7 +1385,7 @@ pub fn load_hashes_from_file(text_messages: &mut Messages, delete_outdated_cache
 
         text_messages.messages.push(flc!(
             "core_loading_from_cache",
-            generate_translation_hashmap(vec![("number", hashmap_loaded_entries.values().map(|e| e.len()).sum::<usize>().to_string())])
+            generate_translation_hashmap(vec![("number", hashmap_loaded_entries.values().map(std::vec::Vec::len).sum::<usize>().to_string())])
         ));
 
         return Some(hashmap_loaded_entries);

--- a/czkawka_core/src/duplicate.rs
+++ b/czkawka_core/src/duplicate.rs
@@ -532,7 +532,7 @@ impl DuplicateFinder {
             let progress_send = progress_sender.clone();
             let progress_thread_run = progress_thread_run.clone();
             let atomic_file_counter = atomic_file_counter.clone();
-            let files_to_check = self.files_with_identical_size.values().map(std::vec::Vec::len).sum();
+            let files_to_check = self.files_with_identical_size.values().map(Vec::len).sum();
             let checking_method = self.check_method;
             thread::spawn(move || loop {
                 progress_send
@@ -691,7 +691,7 @@ impl DuplicateFinder {
             let progress_send = progress_sender.clone();
             let progress_thread_run = progress_thread_run.clone();
             let atomic_file_counter = atomic_file_counter.clone();
-            let files_to_check = pre_checked_map.values().map(std::vec::Vec::len).sum();
+            let files_to_check = pre_checked_map.values().map(Vec::len).sum();
             let checking_method = self.check_method;
             thread::spawn(move || loop {
                 progress_send

--- a/czkawka_core/src/duplicate.rs
+++ b/czkawka_core/src/duplicate.rs
@@ -401,7 +401,7 @@ impl DuplicateFinder {
                     }
                 }
 
-                Common::print_time(start_time, SystemTime::now(), "check_files_name".to_string());
+                Common::print_time(start_time, SystemTime::now(), "check_files_name");
                 true
             }
             DirTraversalResult::SuccessFolders { .. } => {
@@ -503,7 +503,7 @@ impl DuplicateFinder {
                     }
                 }
 
-                Common::print_time(start_time, SystemTime::now(), "check_files_size".to_string());
+                Common::print_time(start_time, SystemTime::now(), "check_files_size");
                 true
             }
             DirTraversalResult::SuccessFolders { .. } => {
@@ -677,7 +677,7 @@ impl DuplicateFinder {
 
         ///////////////////////////////////////////////////////////////////////////// PREHASHING END
 
-        Common::print_time(start_time, SystemTime::now(), "check_files_hash - prehash".to_string());
+        Common::print_time(start_time, SystemTime::now(), "check_files_hash - prehash");
         let start_time: SystemTime = SystemTime::now();
 
         /////////////////////////
@@ -865,9 +865,8 @@ impl DuplicateFinder {
 
                         if files_from_referenced_folders.is_empty() || normal_files.is_empty() {
                             continue;
-                        } else {
-                            all_results_with_same_size.push((files_from_referenced_folders.pop().unwrap(), normal_files));
                         }
+                        all_results_with_same_size.push((files_from_referenced_folders.pop().unwrap(), normal_files));
                     }
                     if all_results_with_same_size.is_empty() {
                         None
@@ -899,7 +898,7 @@ impl DuplicateFinder {
             }
         }
 
-        Common::print_time(start_time, SystemTime::now(), "check_files_hash - full hash".to_string());
+        Common::print_time(start_time, SystemTime::now(), "check_files_hash - full hash");
 
         // Clean unused data
         self.files_with_identical_size = Default::default();
@@ -939,7 +938,7 @@ impl DuplicateFinder {
             }
         }
 
-        Common::print_time(start_time, SystemTime::now(), "delete_files".to_string());
+        Common::print_time(start_time, SystemTime::now(), "delete_files");
     }
 }
 
@@ -1110,7 +1109,7 @@ impl SaveResults for DuplicateFinder {
                 panic!();
             }
         }
-        Common::print_time(start_time, SystemTime::now(), "save_results_to_file".to_string());
+        Common::print_time(start_time, SystemTime::now(), "save_results_to_file");
         true
     }
 }
@@ -1139,7 +1138,7 @@ impl PrintResults for DuplicateFinder {
                 }
             }
             CheckingMethod::Hash => {
-                for (_size, vector) in &self.files_with_identical_hashes {
+                for vector in self.files_with_identical_hashes.values() {
                     for j in vector {
                         number_of_files += j.len() as u64;
                         number_of_groups += 1;
@@ -1185,7 +1184,7 @@ impl PrintResults for DuplicateFinder {
                 panic!("Checking Method shouldn't be ever set to None");
             }
         }
-        Common::print_time(start_time, SystemTime::now(), "print_entries".to_string());
+        Common::print_time(start_time, SystemTime::now(), "print_entries");
     }
 }
 
@@ -1210,7 +1209,8 @@ fn delete_files(vector: &[FileEntry], delete_method: &DeleteMethod, text_message
     for (index, file) in vector.iter().enumerate() {
         if q_index == index {
             continue;
-        } else if removed_files + failed_to_remove_files >= n {
+        }
+        if removed_files + failed_to_remove_files >= n {
             break;
         }
 
@@ -1299,9 +1299,8 @@ pub fn save_hashes_to_file(hashmap: &BTreeMap<String, FileEntry>, text_messages:
                         .warnings
                         .push(format!("Failed to save some data to cache file {}, reason {}", cache_file.display(), e));
                     return;
-                } else {
-                    how_much += 1;
                 }
+                how_much += 1;
             }
         }
 

--- a/czkawka_core/src/duplicate.rs
+++ b/czkawka_core/src/duplicate.rs
@@ -40,7 +40,6 @@ pub enum HashType {
 }
 
 impl HashType {
-    #[inline(always)]
     fn hasher(self: &HashType) -> Box<dyn MyHasher> {
         match self {
             HashType::Blake3 => Box::new(blake3::Hasher::new()),
@@ -867,7 +866,7 @@ impl DuplicateFinder {
                         if files_from_referenced_folders.is_empty() || normal_files.is_empty() {
                             continue;
                         } else {
-                            all_results_with_same_size.push((files_from_referenced_folders.pop().unwrap(), normal_files))
+                            all_results_with_same_size.push((files_from_referenced_folders.pop().unwrap(), normal_files));
                         }
                     }
                     if all_results_with_same_size.is_empty() {

--- a/czkawka_core/src/empty_files.rs
+++ b/czkawka_core/src/empty_files.rs
@@ -28,6 +28,7 @@ pub struct Info {
 }
 
 impl Info {
+    #[must_use]
     pub fn new() -> Self {
         Default::default()
     }
@@ -47,6 +48,7 @@ pub struct EmptyFiles {
 }
 
 impl EmptyFiles {
+    #[must_use]
     pub fn new() -> Self {
         Self {
             text_messages: Messages::new(),
@@ -72,18 +74,22 @@ impl EmptyFiles {
         self.debug_print();
     }
 
+    #[must_use]
     pub fn get_stopped_search(&self) -> bool {
         self.stopped_search
     }
 
+    #[must_use]
     pub const fn get_empty_files(&self) -> &Vec<FileEntry> {
         &self.empty_files
     }
 
+    #[must_use]
     pub const fn get_text_messages(&self) -> &Messages {
         &self.text_messages
     }
 
+    #[must_use]
     pub const fn get_information(&self) -> &Info {
         &self.information
     }
@@ -239,7 +245,7 @@ impl SaveResults for EmptyFiles {
 
         if !self.empty_files.is_empty() {
             writeln!(writer, "Found {} empty files.", self.information.number_of_empty_files).unwrap();
-            for file_entry in self.empty_files.iter() {
+            for file_entry in &self.empty_files {
                 writeln!(writer, "{}", file_entry.path.display()).unwrap();
             }
         } else {
@@ -256,7 +262,7 @@ impl PrintResults for EmptyFiles {
     fn print_results(&self) {
         let start_time: SystemTime = SystemTime::now();
         println!("Found {} empty files.\n", self.information.number_of_empty_files);
-        for file_entry in self.empty_files.iter() {
+        for file_entry in &self.empty_files {
             println!("{}", file_entry.path.display());
         }
 

--- a/czkawka_core/src/empty_files.rs
+++ b/czkawka_core/src/empty_files.rs
@@ -150,7 +150,7 @@ impl EmptyFiles {
                 }
                 self.information.number_of_empty_files = self.empty_files.len();
                 self.text_messages.warnings.extend(warnings);
-                Common::print_time(start_time, SystemTime::now(), "check_files_name".to_string());
+                Common::print_time(start_time, SystemTime::now(), "check_files_name");
                 true
             }
             DirTraversalResult::SuccessFolders { .. } => {
@@ -177,7 +177,7 @@ impl EmptyFiles {
             }
         }
 
-        Common::print_time(start_time, SystemTime::now(), "delete_files".to_string());
+        Common::print_time(start_time, SystemTime::now(), "delete_files");
     }
 }
 
@@ -251,7 +251,7 @@ impl SaveResults for EmptyFiles {
         } else {
             write!(writer, "Not found any empty files.").unwrap();
         }
-        Common::print_time(start_time, SystemTime::now(), "save_results_to_file".to_string());
+        Common::print_time(start_time, SystemTime::now(), "save_results_to_file");
         true
     }
 }
@@ -266,6 +266,6 @@ impl PrintResults for EmptyFiles {
             println!("{}", file_entry.path.display());
         }
 
-        Common::print_time(start_time, SystemTime::now(), "print_entries".to_string());
+        Common::print_time(start_time, SystemTime::now(), "print_entries");
     }
 }

--- a/czkawka_core/src/empty_folder.rs
+++ b/czkawka_core/src/empty_folder.rs
@@ -159,7 +159,7 @@ impl EmptyFolder {
 
                 self.text_messages.warnings.extend(warnings);
 
-                Common::print_time(start_time, SystemTime::now(), "check_for_empty_folder".to_string());
+                Common::print_time(start_time, SystemTime::now(), "check_for_empty_folder");
                 true
             }
             DirTraversalResult::Stopped => false,
@@ -177,7 +177,7 @@ impl EmptyFolder {
             };
         }
 
-        Common::print_time(start_time, SystemTime::now(), "delete_files".to_string());
+        Common::print_time(start_time, SystemTime::now(), "delete_files");
     }
 
     /// Set included dir which needs to be relative, exists etc.
@@ -247,7 +247,7 @@ impl SaveResults for EmptyFolder {
         } else {
             write!(writer, "Not found any empty folders.").unwrap();
         }
-        Common::print_time(start_time, SystemTime::now(), "save_results_to_file".to_string());
+        Common::print_time(start_time, SystemTime::now(), "save_results_to_file");
         true
     }
 }

--- a/czkawka_core/src/empty_folder.rs
+++ b/czkawka_core/src/empty_folder.rs
@@ -32,14 +32,16 @@ pub struct Info {
 }
 
 impl Info {
+    #[must_use]
     pub fn new() -> Self {
         Default::default()
     }
 }
 
-/// Method implementation for EmptyFolder
+/// Method implementation for `EmptyFolder`
 impl EmptyFolder {
     /// New function providing basics values
+    #[must_use]
     pub fn new() -> Self {
         Self {
             information: Default::default(),
@@ -52,17 +54,21 @@ impl EmptyFolder {
         }
     }
 
+    #[must_use]
     pub fn get_stopped_search(&self) -> bool {
         self.stopped_search
     }
 
+    #[must_use]
     pub const fn get_empty_folder_list(&self) -> &BTreeMap<PathBuf, FolderEntry> {
         &self.empty_folder_list
     }
 
+    #[must_use]
     pub const fn get_text_messages(&self) -> &Messages {
         &self.text_messages
     }
+    #[must_use]
     pub const fn get_information(&self) -> &Info {
         &self.information
     }
@@ -121,7 +127,7 @@ impl EmptyFolder {
     }
 
     /// Function to check if folder are empty.
-    /// Parameter initial_checking for second check before deleting to be sure that checked folder is still empty
+    /// Parameter `initial_checking` for second check before deleting to be sure that checked folder is still empty
     fn check_for_empty_folders(&mut self, stop_receiver: Option<&Receiver<()>>, progress_sender: Option<&futures::channel::mpsc::UnboundedSender<ProgressData>>) -> bool {
         let result = DirTraversalBuilder::new()
             .root_dirs(self.directories.included_directories.clone())

--- a/czkawka_core/src/invalid_symlinks.rs
+++ b/czkawka_core/src/invalid_symlinks.rs
@@ -148,7 +148,7 @@ impl InvalidSymlinks {
                 }
                 self.information.number_of_invalid_symlinks = self.invalid_symlinks.len();
                 self.text_messages.warnings.extend(warnings);
-                Common::print_time(start_time, SystemTime::now(), "check_files_name".to_string());
+                Common::print_time(start_time, SystemTime::now(), "check_files_name");
                 true
             }
             DirTraversalResult::SuccessFolders { .. } => unreachable!(),
@@ -173,7 +173,7 @@ impl InvalidSymlinks {
             }
         }
 
-        Common::print_time(start_time, SystemTime::now(), "delete_files".to_string());
+        Common::print_time(start_time, SystemTime::now(), "delete_files");
     }
 }
 
@@ -257,7 +257,7 @@ impl SaveResults for InvalidSymlinks {
         } else {
             write!(writer, "Not found any invalid symlinks.").unwrap();
         }
-        Common::print_time(start_time, SystemTime::now(), "save_results_to_file".to_string());
+        Common::print_time(start_time, SystemTime::now(), "save_results_to_file");
         true
     }
 }
@@ -280,6 +280,6 @@ impl PrintResults for InvalidSymlinks {
             );
         }
 
-        Common::print_time(start_time, SystemTime::now(), "print_entries".to_string());
+        Common::print_time(start_time, SystemTime::now(), "print_entries");
     }
 }

--- a/czkawka_core/src/invalid_symlinks.rs
+++ b/czkawka_core/src/invalid_symlinks.rs
@@ -28,6 +28,7 @@ pub struct Info {
 }
 
 impl Info {
+    #[must_use]
     pub fn new() -> Self {
         Default::default()
     }
@@ -47,6 +48,7 @@ pub struct InvalidSymlinks {
 }
 
 impl InvalidSymlinks {
+    #[must_use]
     pub fn new() -> Self {
         Self {
             text_messages: Messages::new(),
@@ -71,18 +73,22 @@ impl InvalidSymlinks {
         self.debug_print();
     }
 
+    #[must_use]
     pub fn get_stopped_search(&self) -> bool {
         self.stopped_search
     }
 
+    #[must_use]
     pub const fn get_invalid_symlinks(&self) -> &Vec<FileEntry> {
         &self.invalid_symlinks
     }
 
+    #[must_use]
     pub const fn get_text_messages(&self) -> &Messages {
         &self.text_messages
     }
 
+    #[must_use]
     pub const fn get_information(&self) -> &Info {
         &self.information
     }
@@ -235,7 +241,7 @@ impl SaveResults for InvalidSymlinks {
 
         if !self.invalid_symlinks.is_empty() {
             writeln!(writer, "Found {} invalid symlinks.", self.information.number_of_invalid_symlinks).unwrap();
-            for file_entry in self.invalid_symlinks.iter() {
+            for file_entry in &self.invalid_symlinks {
                 writeln!(
                     writer,
                     "{}\t\t{}\t\t{}",
@@ -262,7 +268,7 @@ impl PrintResults for InvalidSymlinks {
     fn print_results(&self) {
         let start_time: SystemTime = SystemTime::now();
         println!("Found {} invalid symlinks.\n", self.information.number_of_invalid_symlinks);
-        for file_entry in self.invalid_symlinks.iter() {
+        for file_entry in &self.invalid_symlinks {
             println!(
                 "{}\t\t{}\t\t{}",
                 file_entry.path.display(),

--- a/czkawka_core/src/localizer_core.rs
+++ b/czkawka_core/src/localizer_core.rs
@@ -45,10 +45,10 @@ pub fn generate_translation_hashmap(vec: Vec<(&'static str, String)>) -> HashMap
     hashmap
 }
 
-pub fn fnc_get_similarity_very_high() -> String {
+#[must_use] pub fn fnc_get_similarity_very_high() -> String {
     flc!("core_similarity_very_high")
 }
 
-pub fn fnc_get_similarity_minimal() -> String {
+#[must_use] pub fn fnc_get_similarity_minimal() -> String {
     flc!("core_similarity_minimal")
 }

--- a/czkawka_core/src/localizer_core.rs
+++ b/czkawka_core/src/localizer_core.rs
@@ -31,10 +31,12 @@ macro_rules! flc {
 }
 
 // Get the `Localizer` to be used for localizing this library.
+#[must_use]
 pub fn localizer_core() -> Box<dyn Localizer> {
     Box::from(DefaultLocalizer::new(&*LANGUAGE_LOADER_CORE, &Localizations))
 }
 
+#[must_use]
 pub fn generate_translation_hashmap(vec: Vec<(&'static str, String)>) -> HashMap<&'static str, String> {
     let mut hashmap: HashMap<&'static str, String> = Default::default();
     for (key, value) in vec {

--- a/czkawka_core/src/localizer_core.rs
+++ b/czkawka_core/src/localizer_core.rs
@@ -45,10 +45,12 @@ pub fn generate_translation_hashmap(vec: Vec<(&'static str, String)>) -> HashMap
     hashmap
 }
 
-#[must_use] pub fn fnc_get_similarity_very_high() -> String {
+#[must_use]
+pub fn fnc_get_similarity_very_high() -> String {
     flc!("core_similarity_very_high")
 }
 
-#[must_use] pub fn fnc_get_similarity_minimal() -> String {
+#[must_use]
+pub fn fnc_get_similarity_minimal() -> String {
     flc!("core_similarity_minimal")
 }

--- a/czkawka_core/src/same_music.rs
+++ b/czkawka_core/src/same_music.rs
@@ -297,7 +297,7 @@ impl SameMusic {
                     }
                 }
                 self.text_messages.warnings.extend(warnings);
-                Common::print_time(start_time, SystemTime::now(), "check_files".to_string());
+                Common::print_time(start_time, SystemTime::now(), "check_files");
                 true
             }
             DirTraversalResult::SuccessFolders { .. } => {
@@ -396,18 +396,17 @@ impl SameMusic {
                     }
                 });
 
-                let tagged_file = match result {
-                    Ok(t) => match t {
+                let tagged_file = if let Ok(t) = result {
+                    match t {
                         Some(r) => r,
                         None => {
                             return Some(Some(music_entry));
                         }
-                    },
-                    Err(_) => {
-                        let message = create_crash_message("Lofty", &path, "https://github.com/image-rs/image/issues");
-                        println!("{message}");
-                        return Some(None);
                     }
+                } else {
+                    let message = create_crash_message("Lofty", &path, "https://github.com/image-rs/image/issues");
+                    println!("{message}");
+                    return Some(None);
                 };
 
                 let properties = tagged_file.properties();
@@ -507,7 +506,7 @@ impl SameMusic {
             return false;
         }
 
-        Common::print_time(start_time, SystemTime::now(), "check_records_multithreaded".to_string());
+        Common::print_time(start_time, SystemTime::now(), "check_records_multithreaded");
 
         true
     }
@@ -751,7 +750,7 @@ impl SameMusic {
             }
         }
 
-        Common::print_time(start_time, SystemTime::now(), "check_for_duplicates".to_string());
+        Common::print_time(start_time, SystemTime::now(), "check_for_duplicates");
 
         // Clear unused data
         self.music_entries.clear();
@@ -783,7 +782,7 @@ impl SameMusic {
         //     }
         // }
 
-        Common::print_time(start_time, SystemTime::now(), "delete_files".to_string());
+        Common::print_time(start_time, SystemTime::now(), "delete_files");
     }
 }
 
@@ -929,7 +928,7 @@ impl SaveResults for SameMusic {
         } else {
             write!(writer, "Not found any empty files.").unwrap();
         }
-        Common::print_time(start_time, SystemTime::now(), "save_results_to_file".to_string());
+        Common::print_time(start_time, SystemTime::now(), "save_results_to_file");
         true
     }
 }
@@ -956,7 +955,7 @@ impl PrintResults for SameMusic {
             println!();
         }
 
-        Common::print_time(start_time, SystemTime::now(), "print_entries".to_string());
+        Common::print_time(start_time, SystemTime::now(), "print_entries");
     }
 }
 

--- a/czkawka_core/src/same_music.rs
+++ b/czkawka_core/src/same_music.rs
@@ -39,7 +39,7 @@ bitflags! {
         const YEAR = 0b100;
         const LENGTH = 0b1000;
         const GENRE = 0b10000;
-        const BITRATE = 0b100000;
+        const BITRATE = 0b10_0000;
     }
 }
 
@@ -65,11 +65,11 @@ impl FileEntry {
             path: self.path.clone(),
             modified_date: self.modified_date,
 
-            track_title: "".to_string(),
-            track_artist: "".to_string(),
-            year: "".to_string(),
-            length: "".to_string(),
-            genre: "".to_string(),
+            track_title: String::new(),
+            track_artist: String::new(),
+            year: String::new(),
+            length: String::new(),
+            genre: String::new(),
             bitrate: 0,
         }
     }
@@ -83,6 +83,7 @@ pub struct Info {
 }
 
 impl Info {
+    #[must_use]
     pub fn new() -> Self {
         Default::default()
     }
@@ -113,6 +114,7 @@ pub struct SameMusic {
 }
 
 impl SameMusic {
+    #[must_use]
     pub fn new() -> Self {
         Self {
             text_messages: Messages::new(),
@@ -157,21 +159,26 @@ impl SameMusic {
         self.debug_print();
     }
 
+    #[must_use]
     pub fn get_stopped_search(&self) -> bool {
         self.stopped_search
     }
 
+    #[must_use]
     pub const fn get_duplicated_music_entries(&self) -> &Vec<Vec<MusicEntry>> {
         &self.duplicated_music_entries
     }
+    #[must_use]
     pub const fn get_music_similarity(&self) -> &MusicSimilarity {
         &self.music_similarity
     }
 
+    #[must_use]
     pub const fn get_text_messages(&self) -> &Messages {
         &self.text_messages
     }
 
+    #[must_use]
     pub const fn get_information(&self) -> &Info {
         &self.information
     }
@@ -235,10 +242,12 @@ impl SameMusic {
         };
     }
 
+    #[must_use]
     pub fn get_similar_music_referenced(&self) -> &Vec<(MusicEntry, Vec<MusicEntry>)> {
         &self.duplicated_music_entries_referenced
     }
 
+    #[must_use]
     pub fn get_number_of_base_duplicated_files(&self) -> usize {
         if self.use_reference_folders {
             self.duplicated_music_entries_referenced.len()
@@ -247,6 +256,7 @@ impl SameMusic {
         }
     }
 
+    #[must_use]
     pub fn get_use_reference(&self) -> bool {
         self.use_reference_folders
     }
@@ -402,10 +412,10 @@ impl SameMusic {
 
                 let properties = tagged_file.properties();
 
-                let mut track_title = "".to_string();
-                let mut track_artist = "".to_string();
-                let mut year = "".to_string();
-                let mut genre = "".to_string();
+                let mut track_title = String::new();
+                let mut track_artist = String::new();
+                let mut year = String::new();
+                let mut genre = String::new();
 
                 let bitrate = properties.audio_bitrate().unwrap_or(0);
                 let mut length = properties.duration().as_millis().to_string();
@@ -451,10 +461,10 @@ impl SameMusic {
                         // That means, that audio have length smaller that second, but length is properly read
                         length = "0:01".to_string();
                     } else {
-                        length = "".to_string();
+                        length = String::new();
                     }
                 } else {
-                    length = "".to_string();
+                    length = String::new();
                 }
 
                 music_entry.track_title = track_title;
@@ -467,8 +477,8 @@ impl SameMusic {
                 Some(Some(music_entry))
             })
             .while_some()
-            .filter(|music_entry| music_entry.is_some())
-            .map(|music_entry| music_entry.unwrap())
+            .filter(std::option::Option::is_some)
+            .map(std::option::Option::unwrap)
             .collect::<Vec<_>>();
 
         // End thread which send info to gui
@@ -502,9 +512,7 @@ impl SameMusic {
         true
     }
     fn check_for_duplicates(&mut self, stop_receiver: Option<&Receiver<()>>, progress_sender: Option<&futures::channel::mpsc::UnboundedSender<ProgressData>>) -> bool {
-        if MusicSimilarity::NONE == self.music_similarity {
-            panic!("This can't be none");
-        }
+        assert!(MusicSimilarity::NONE != self.music_similarity, "This can't be none");
         let start_time: SystemTime = SystemTime::now();
 
         //// PROGRESS THREAD START
@@ -915,7 +923,7 @@ impl SaveResults for SameMusic {
 
         if !self.music_entries.is_empty() {
             writeln!(writer, "Found {} same music files.", self.information.number_of_duplicates).unwrap();
-            for file_entry in self.music_entries.iter() {
+            for file_entry in &self.music_entries {
                 writeln!(writer, "{}", file_entry.path.display()).unwrap();
             }
         } else {
@@ -932,7 +940,7 @@ impl PrintResults for SameMusic {
     fn print_results(&self) {
         let start_time: SystemTime = SystemTime::now();
         println!("Found {} similar music files.\n", self.duplicated_music_entries.len());
-        for vec_file_entry in self.duplicated_music_entries.iter() {
+        for vec_file_entry in &self.duplicated_music_entries {
             for file_entry in vec_file_entry {
                 println!(
                     "TT: {}  -  TA: {}  -  Y: {}  -  L: {}  -  G: {}  -  B: {}  -  P: {}",

--- a/czkawka_core/src/same_music.rs
+++ b/czkawka_core/src/same_music.rs
@@ -476,8 +476,8 @@ impl SameMusic {
                 Some(Some(music_entry))
             })
             .while_some()
-            .filter(std::option::Option::is_some)
-            .map(std::option::Option::unwrap)
+            .filter(Option::is_some)
+            .map(Option::unwrap)
             .collect::<Vec<_>>();
 
         // End thread which send info to gui

--- a/czkawka_core/src/similar_images.rs
+++ b/czkawka_core/src/similar_images.rs
@@ -1116,7 +1116,7 @@ fn image_to_check<'a>(
         }
         // But when there is no record, just add it
         else {
-            need_to_add = true
+            need_to_add = true;
         }
     }
 

--- a/czkawka_core/src/similar_images.rs
+++ b/czkawka_core/src/similar_images.rs
@@ -479,7 +479,7 @@ impl SimilarImages {
         // End thread which send info to gui
         progress_thread_run.store(false, Ordering::Relaxed);
         progress_thread_handle.join().unwrap();
-        Common::print_time(start_time, SystemTime::now(), "check_for_similar_images".to_string());
+        Common::print_time(start_time, SystemTime::now(), "check_for_similar_images");
         true
     }
 
@@ -522,11 +522,7 @@ impl SimilarImages {
             mem::swap(&mut self.images_to_check, &mut non_cached_files_to_check);
         }
 
-        Common::print_time(
-            hash_map_modification,
-            SystemTime::now(),
-            "sort_images - reading data from cache and preparing them".to_string(),
-        );
+        Common::print_time(hash_map_modification, SystemTime::now(), "sort_images - reading data from cache and preparing them");
         let hash_map_modification = SystemTime::now();
 
         //// PROGRESS THREAD START
@@ -645,7 +641,7 @@ impl SimilarImages {
         progress_thread_run.store(false, Ordering::Relaxed);
         progress_thread_handle.join().unwrap();
 
-        Common::print_time(hash_map_modification, SystemTime::now(), "sort_images - reading data from files in parallel".to_string());
+        Common::print_time(hash_map_modification, SystemTime::now(), "sort_images - reading data from files in parallel");
         let hash_map_modification = SystemTime::now();
 
         // Just connect loaded results with already calculated hashes
@@ -682,7 +678,7 @@ impl SimilarImages {
             return false;
         }
 
-        Common::print_time(hash_map_modification, SystemTime::now(), "sort_images - saving data to files".to_string());
+        Common::print_time(hash_map_modification, SystemTime::now(), "sort_images - saving data to files");
         true
     }
 
@@ -849,7 +845,7 @@ impl SimilarImages {
 
                     #[cfg(debug_assertions)]
                     if !self.use_reference_folders {
-                        debug_check_for_duplicated_things(hashes_parents.clone(), hashes_similarity.clone(), all_hashed_images.clone(), "BEFORE");
+                        debug_check_for_duplicated_things(&hashes_parents, &hashes_similarity, &all_hashed_images, "BEFORE");
                     }
 
                     Some((hashes_parents, hashes_similarity))
@@ -897,7 +893,7 @@ impl SimilarImages {
 
                 #[cfg(debug_assertions)]
                 if !self.use_reference_folders {
-                    debug_check_for_duplicated_things(hashes_parents.clone(), hashes_similarity.clone(), all_hashed_images.clone(), "LATTER");
+                    debug_check_for_duplicated_things(&hashes_parents, &hashes_similarity, &all_hashed_images, "LATTER");
                 }
 
                 // Just simple check if all original hashes with multiple entries are available in end results
@@ -967,7 +963,7 @@ impl SimilarImages {
         {
             let mut result_hashset: HashSet<String> = Default::default();
             let mut found = false;
-            for (_hash, vec_file_entry) in &collected_similar_images {
+            for vec_file_entry in collected_similar_images.values() {
                 if vec_file_entry.is_empty() {
                     println!("Empty Element {vec_file_entry:?}");
                     found = true;
@@ -1036,7 +1032,7 @@ impl SimilarImages {
                 .collect::<Vec<(FileEntry, Vec<FileEntry>)>>();
         }
 
-        Common::print_time(hash_map_modification, SystemTime::now(), "sort_images - selecting data from HashMap".to_string());
+        Common::print_time(hash_map_modification, SystemTime::now(), "sort_images - selecting data from HashMap");
 
         if self.use_reference_folders {
             for (_fe, vector) in &self.similar_referenced_vectors {
@@ -1204,7 +1200,7 @@ impl SaveResults for SimilarImages {
             write!(writer, "Not found any similar images.").unwrap();
         }
 
-        Common::print_time(start_time, SystemTime::now(), "save_results_to_file".to_string());
+        Common::print_time(start_time, SystemTime::now(), "save_results_to_file");
         true
     }
 }
@@ -1322,6 +1318,7 @@ fn get_cache_file(hash_size: &u8, hash_alg: &HashAlg, image_filter: &FilterType)
     )
 }
 
+#[must_use]
 pub fn get_string_from_similarity(similarity: &u32, hash_size: u8) -> String {
     let index_preset = match hash_size {
         8 => 0,
@@ -1459,15 +1456,15 @@ pub fn test_image_conversion_speed() {
 // E.g. /a.jpg is used also as master and similar image which is forbidden, because may
 // cause accidentally delete more pictures that user wanted
 fn debug_check_for_duplicated_things(
-    hashes_parents: HashMap<&Vec<u8>, u32>,
-    hashes_similarity: HashMap<&Vec<u8>, (&Vec<u8>, u32)>,
-    all_hashed_images: HashMap<Vec<u8>, Vec<FileEntry>>,
+    hashes_parents: &HashMap<&Vec<u8>, u32>,
+    hashes_similarity: &HashMap<&Vec<u8>, (&Vec<u8>, u32)>,
+    all_hashed_images: &HashMap<Vec<u8>, Vec<FileEntry>>,
     numm: &str,
 ) {
     let mut found_broken_thing = false;
     let mut hashmap_hashes: HashSet<_> = Default::default();
     let mut hashmap_names: HashSet<_> = Default::default();
-    for (hash, number_of_children) in &hashes_parents {
+    for (hash, number_of_children) in hashes_parents {
         if *number_of_children > 0 {
             if hashmap_hashes.contains(*hash) {
                 println!("------1--HASH--{}  {:?}", numm, all_hashed_images.get(*hash).unwrap());

--- a/czkawka_core/src/similar_images.rs
+++ b/czkawka_core/src/similar_images.rs
@@ -119,14 +119,16 @@ pub struct Info {
 }
 
 impl Info {
+    #[must_use]
     pub fn new() -> Self {
         Default::default()
     }
 }
 
-/// Method implementation for EmptyFolder
+/// Method implementation for `EmptyFolder`
 impl SimilarImages {
     /// New function providing basics values
+    #[must_use]
     pub fn new() -> Self {
         Self {
             information: Default::default(),
@@ -184,26 +186,32 @@ impl SimilarImages {
         self.save_also_as_json = save_also_as_json;
     }
 
+    #[must_use]
     pub fn get_stopped_search(&self) -> bool {
         self.stopped_search
     }
 
+    #[must_use]
     pub const fn get_text_messages(&self) -> &Messages {
         &self.text_messages
     }
 
+    #[must_use]
     pub const fn get_similar_images(&self) -> &Vec<Vec<FileEntry>> {
         &self.similar_vectors
     }
 
+    #[must_use]
     pub fn get_similar_images_referenced(&self) -> &Vec<(FileEntry, Vec<FileEntry>)> {
         &self.similar_referenced_vectors
     }
 
+    #[must_use]
     pub fn get_use_reference(&self) -> bool {
         self.use_reference_folders
     }
 
+    #[must_use]
     pub const fn get_information(&self) -> &Info {
         &self.information
     }
@@ -270,7 +278,7 @@ impl SimilarImages {
     // }
 
     /// Function to check if folder are empty.
-    /// Parameter initial_checking for second check before deleting to be sure that checked folder is still empty
+    /// Parameter `initial_checking` for second check before deleting to be sure that checked folder is still empty
     fn check_for_similar_images(&mut self, stop_receiver: Option<&Receiver<()>>, progress_sender: Option<&futures::channel::mpsc::UnboundedSender<ProgressData>>) -> bool {
         let start_time: SystemTime = SystemTime::now();
         let mut folders_to_check: Vec<PathBuf> = Vec::with_capacity(1024 * 2); // This should be small enough too not see to big difference and big enough to store most of paths without needing to resize vector
@@ -422,7 +430,7 @@ impl SimilarImages {
                                 let fe: FileEntry = FileEntry {
                                     path: current_file_name.clone(),
                                     size: metadata.len(),
-                                    dimensions: "".to_string(),
+                                    dimensions: String::new(),
                                     modified_date: match metadata.modified() {
                                         Ok(t) => match t.duration_since(UNIX_EPOCH) {
                                             Ok(d) => d.as_secs(),
@@ -629,8 +637,8 @@ impl SimilarImages {
                 Some(Some((file_entry, buf)))
             })
             .while_some()
-            .filter(|file_entry| file_entry.is_some())
-            .map(|file_entry| file_entry.unwrap())
+            .filter(std::option::Option::is_some)
+            .map(std::option::Option::unwrap)
             .collect::<Vec<(FileEntry, Vec<u8>)>>();
 
         // End thread which send info to gui
@@ -760,7 +768,7 @@ impl SimilarImages {
                     if vec_files.len() >= 2 {
                         hashes_with_multiple_images.insert(hash);
                     }
-                    self.bktree.add(hash.to_vec());
+                    self.bktree.add(hash.clone());
                 }
                 for (hash, vec_files) in &files_from_referenced_folders {
                     if vec_files.len() >= 2 {
@@ -781,7 +789,7 @@ impl SimilarImages {
                         additional_chunk_to_check.push(hash);
                         hashes_with_multiple_images.insert(hash);
                     } else {
-                        self.bktree.add(hash.to_vec());
+                        self.bktree.add(hash.clone());
                     }
                 }
                 chunk_size = all_hashes.len() / number_of_processors;
@@ -809,7 +817,7 @@ impl SimilarImages {
                     for (index, hash_to_check) in hashes_to_check.iter().enumerate() {
                         // Don't check for user stop too often
                         // Also don't add too often data to atomic variable
-                        const CYCLES_COUNTER: usize = 0b111111;
+                        const CYCLES_COUNTER: usize = 0b11_1111;
                         if ((index & CYCLES_COUNTER) == CYCLES_COUNTER) && index != 0 {
                             atomic_mode_counter.fetch_add(CYCLES_COUNTER, Ordering::Relaxed);
                             if stop_receiver.is_some() && stop_receiver.unwrap().try_recv().is_ok() {
@@ -959,7 +967,7 @@ impl SimilarImages {
         {
             let mut result_hashset: HashSet<String> = Default::default();
             let mut found = false;
-            for (_hash, vec_file_entry) in collected_similar_images.iter() {
+            for (_hash, vec_file_entry) in &collected_similar_images {
                 if vec_file_entry.is_empty() {
                     println!("Empty Element {vec_file_entry:?}");
                     found = true;
@@ -980,9 +988,7 @@ impl SimilarImages {
                     }
                 }
             }
-            if found {
-                panic!("Found Invalid entries");
-            }
+            assert!(!found, "Found Invalid entries");
         }
         self.similar_vectors = collected_similar_images.into_values().collect();
 
@@ -1179,7 +1185,7 @@ impl SaveResults for SimilarImages {
         if !self.similar_vectors.is_empty() {
             write!(writer, "{} images which have similar friends\n\n", self.similar_vectors.len()).unwrap();
 
-            for struct_similar in self.similar_vectors.iter() {
+            for struct_similar in &self.similar_vectors {
                 writeln!(writer, "Found {} images which have similar friends", self.similar_vectors.len()).unwrap();
                 for file_entry in struct_similar {
                     writeln!(
@@ -1364,6 +1370,7 @@ pub fn get_string_from_similarity(similarity: &u32, hash_size: u8) -> String {
     }
 }
 
+#[must_use]
 pub fn return_similarity_from_similarity_preset(similarity_preset: &SimilarityPreset, hash_size: u8) -> u32 {
     let index_preset = match hash_size {
         8 => 0,
@@ -1466,7 +1473,7 @@ fn debug_check_for_duplicated_things(
                 println!("------1--HASH--{}  {:?}", numm, all_hashed_images.get(*hash).unwrap());
                 found_broken_thing = true;
             }
-            hashmap_hashes.insert(hash.to_vec());
+            hashmap_hashes.insert((*hash).clone());
 
             for i in all_hashed_images.get(*hash).unwrap() {
                 let name = i.path.to_string_lossy().to_string();
@@ -1483,7 +1490,7 @@ fn debug_check_for_duplicated_things(
             println!("------2--HASH--{}  {:?}", numm, all_hashed_images.get(*hash).unwrap());
             found_broken_thing = true;
         }
-        hashmap_hashes.insert(hash.to_vec());
+        hashmap_hashes.insert((*hash).clone());
 
         for i in all_hashed_images.get(*hash).unwrap() {
             let name = i.path.to_string_lossy().to_string();

--- a/czkawka_core/src/similar_images.rs
+++ b/czkawka_core/src/similar_images.rs
@@ -633,8 +633,8 @@ impl SimilarImages {
                 Some(Some((file_entry, buf)))
             })
             .while_some()
-            .filter(std::option::Option::is_some)
-            .map(std::option::Option::unwrap)
+            .filter(Option::is_some)
+            .map(Option::unwrap)
             .collect::<Vec<(FileEntry, Vec<u8>)>>();
 
         // End thread which send info to gui

--- a/czkawka_core/src/similar_videos.rs
+++ b/czkawka_core/src/similar_videos.rs
@@ -442,7 +442,7 @@ impl SimilarVideos {
         // End thread which send info to gui
         progress_thread_run.store(false, Ordering::Relaxed);
         progress_thread_handle.join().unwrap();
-        Common::print_time(start_time, SystemTime::now(), "check_for_similar_videos".to_string());
+        Common::print_time(start_time, SystemTime::now(), "check_for_similar_videos");
         true
     }
 
@@ -478,11 +478,7 @@ impl SimilarVideos {
             mem::swap(&mut self.videos_to_check, &mut non_cached_files_to_check);
         }
 
-        Common::print_time(
-            hash_map_modification,
-            SystemTime::now(),
-            "sort_videos - reading data from cache and preparing them".to_string(),
-        );
+        Common::print_time(hash_map_modification, SystemTime::now(), "sort_videos - reading data from cache and preparing them");
         let hash_map_modification = SystemTime::now();
 
         //// PROGRESS THREAD START
@@ -545,7 +541,7 @@ impl SimilarVideos {
         progress_thread_run.store(false, Ordering::Relaxed);
         progress_thread_handle.join().unwrap();
 
-        Common::print_time(hash_map_modification, SystemTime::now(), "sort_videos - reading data from files in parallel".to_string());
+        Common::print_time(hash_map_modification, SystemTime::now(), "sort_videos - reading data from files in parallel");
         let hash_map_modification = SystemTime::now();
 
         // Just connect loaded results with already calculated hashes
@@ -579,7 +575,7 @@ impl SimilarVideos {
             return false;
         }
 
-        Common::print_time(hash_map_modification, SystemTime::now(), "sort_videos - saving data to files".to_string());
+        Common::print_time(hash_map_modification, SystemTime::now(), "sort_videos - saving data to files");
         let hash_map_modification = SystemTime::now();
 
         let match_group = vid_dup_finder_lib::search(vector_of_hashes, NormalizedTolerance::new(self.tolerance as f64 / 100.0f64));
@@ -644,7 +640,7 @@ impl SimilarVideos {
             }
         }
 
-        Common::print_time(hash_map_modification, SystemTime::now(), "sort_videos - selecting data from BtreeMap".to_string());
+        Common::print_time(hash_map_modification, SystemTime::now(), "sort_videos - selecting data from BtreeMap");
 
         // Clean unused data
         self.videos_hashes = Default::default();
@@ -732,7 +728,7 @@ impl SaveResults for SimilarVideos {
             write!(writer, "Not found any similar videos.").unwrap();
         }
 
-        Common::print_time(start_time, SystemTime::now(), "save_results_to_file".to_string());
+        Common::print_time(start_time, SystemTime::now(), "save_results_to_file");
         true
     }
 }

--- a/czkawka_core/src/similar_videos.rs
+++ b/czkawka_core/src/similar_videos.rs
@@ -93,14 +93,16 @@ pub struct Info {
 }
 
 impl Info {
+    #[must_use]
     pub fn new() -> Self {
         Default::default()
     }
 }
 
-/// Method implementation for EmptyFolder
+/// Method implementation for `EmptyFolder`
 impl SimilarVideos {
     /// New function providing basics values
+    #[must_use]
     pub fn new() -> Self {
         Self {
             information: Default::default(),
@@ -141,10 +143,12 @@ impl SimilarVideos {
         self.save_also_as_json = save_also_as_json;
     }
 
+    #[must_use]
     pub fn get_stopped_search(&self) -> bool {
         self.stopped_search
     }
 
+    #[must_use]
     pub const fn get_text_messages(&self) -> &Messages {
         &self.text_messages
     }
@@ -153,10 +157,12 @@ impl SimilarVideos {
         self.allowed_extensions.set_allowed_extensions(allowed_extensions, &mut self.text_messages);
     }
 
+    #[must_use]
     pub const fn get_similar_videos(&self) -> &Vec<Vec<FileEntry>> {
         &self.similar_vectors
     }
 
+    #[must_use]
     pub const fn get_information(&self) -> &Info {
         &self.information
     }
@@ -188,10 +194,12 @@ impl SimilarVideos {
             t => t,
         };
     }
+    #[must_use]
     pub fn get_similar_videos_referenced(&self) -> &Vec<(FileEntry, Vec<FileEntry>)> {
         &self.similar_referenced_vectors
     }
 
+    #[must_use]
     pub fn get_number_of_base_duplicated_files(&self) -> usize {
         if self.use_reference_folders {
             self.similar_referenced_vectors.len()
@@ -200,6 +208,7 @@ impl SimilarVideos {
         }
     }
 
+    #[must_use]
     pub fn get_use_reference(&self) -> bool {
         self.use_reference_folders
     }
@@ -238,7 +247,7 @@ impl SimilarVideos {
     // }
 
     /// Function to check if folder are empty.
-    /// Parameter initial_checking for second check before deleting to be sure that checked folder is still empty
+    /// Parameter `initial_checking` for second check before deleting to be sure that checked folder is still empty
     fn check_for_similar_videos(&mut self, stop_receiver: Option<&Receiver<()>>, progress_sender: Option<&futures::channel::mpsc::UnboundedSender<ProgressData>>) -> bool {
         let start_time: SystemTime = SystemTime::now();
         let mut folders_to_check: Vec<PathBuf> = Vec::with_capacity(1024 * 2); // This should be small enough too not see to big difference and big enough to store most of paths without needing to resize vector
@@ -406,7 +415,7 @@ impl SimilarVideos {
                                         }
                                     },
                                     vhash: Default::default(),
-                                    error: "".to_string(),
+                                    error: String::new(),
                                 };
 
                                 fe_result.push((current_file_name.to_string_lossy().to_string(), fe));
@@ -712,7 +721,7 @@ impl SaveResults for SimilarVideos {
         if !self.similar_vectors.is_empty() {
             write!(writer, "{} videos which have similar friends\n\n", self.similar_vectors.len()).unwrap();
 
-            for struct_similar in self.similar_vectors.iter() {
+            for struct_similar in &self.similar_vectors {
                 writeln!(writer, "Found {} videos which have similar friends", self.similar_vectors.len()).unwrap();
                 for file_entry in struct_similar {
                     writeln!(writer, "{} - {}", file_entry.path.display(), format_size(file_entry.size, BINARY)).unwrap();
@@ -813,6 +822,7 @@ fn get_cache_file() -> String {
     "cache_similar_videos.bin".to_string()
 }
 
+#[must_use]
 pub fn check_if_ffmpeg_is_installed() -> bool {
     let vid = "9999czekoczekoczekolada999.txt";
     if let Err(DetermineVideo {

--- a/czkawka_core/src/similar_videos.rs
+++ b/czkawka_core/src/similar_videos.rs
@@ -51,12 +51,12 @@ pub struct FileEntry {
 struct Hamming;
 
 impl bk_tree::Metric<Vec<u8>> for Hamming {
-    #[inline(always)]
+    #[inline]
     fn distance(&self, a: &Vec<u8>, b: &Vec<u8>) -> u32 {
         hamming::distance_fast(a, b).unwrap() as u32
     }
 
-    #[inline(always)]
+    #[inline]
     fn threshold_distance(&self, a: &Vec<u8>, b: &Vec<u8>, _threshold: u32) -> Option<u32> {
         Some(self.distance(a, b))
     }
@@ -137,7 +137,7 @@ impl SimilarVideos {
 
     pub fn set_tolerance(&mut self, tolerance: i32) {
         assert!((0..=MAX_TOLERANCE).contains(&tolerance));
-        self.tolerance = tolerance
+        self.tolerance = tolerance;
     }
     pub fn set_save_also_as_json(&mut self, save_also_as_json: bool) {
         self.save_also_as_json = save_also_as_json;

--- a/czkawka_core/src/temporary.rs
+++ b/czkawka_core/src/temporary.rs
@@ -331,7 +331,7 @@ impl Temporary {
         progress_thread_handle.join().unwrap();
         self.information.number_of_temporary_files = self.temporary_files.len();
 
-        Common::print_time(start_time, SystemTime::now(), "check_files_size".to_string());
+        Common::print_time(start_time, SystemTime::now(), "check_files_size");
         true
     }
 
@@ -352,7 +352,7 @@ impl Temporary {
             }
         }
 
-        Common::print_time(start_time, SystemTime::now(), "delete_files".to_string());
+        Common::print_time(start_time, SystemTime::now(), "delete_files");
     }
 }
 
@@ -425,7 +425,7 @@ impl SaveResults for Temporary {
         } else {
             write!(writer, "Not found any temporary files.").unwrap();
         }
-        Common::print_time(start_time, SystemTime::now(), "save_results_to_file".to_string());
+        Common::print_time(start_time, SystemTime::now(), "save_results_to_file");
         true
     }
 }
@@ -438,6 +438,6 @@ impl PrintResults for Temporary {
             println!("{}", file_entry.path.display());
         }
 
-        Common::print_time(start_time, SystemTime::now(), "print_entries".to_string());
+        Common::print_time(start_time, SystemTime::now(), "print_entries");
     }
 }

--- a/czkawka_core/src/temporary.rs
+++ b/czkawka_core/src/temporary.rs
@@ -45,6 +45,7 @@ pub struct Info {
 }
 
 impl Info {
+    #[must_use]
     pub fn new() -> Self {
         Default::default()
     }
@@ -63,6 +64,7 @@ pub struct Temporary {
 }
 
 impl Temporary {
+    #[must_use]
     pub fn new() -> Self {
         Self {
             text_messages: Messages::new(),
@@ -86,17 +88,21 @@ impl Temporary {
         self.delete_files();
         self.debug_print();
     }
+    #[must_use]
     pub fn get_stopped_search(&self) -> bool {
         self.stopped_search
     }
 
+    #[must_use]
     pub const fn get_temporary_files(&self) -> &Vec<FileEntry> {
         &self.temporary_files
     }
+    #[must_use]
     pub const fn get_text_messages(&self) -> &Messages {
         &self.text_messages
     }
 
+    #[must_use]
     pub const fn get_information(&self) -> &Info {
         &self.information
     }
@@ -413,7 +419,7 @@ impl SaveResults for Temporary {
 
         if !self.temporary_files.is_empty() {
             writeln!(writer, "Found {} temporary files.", self.information.number_of_temporary_files).unwrap();
-            for file_entry in self.temporary_files.iter() {
+            for file_entry in &self.temporary_files {
                 writeln!(writer, "{}", file_entry.path.display()).unwrap();
             }
         } else {
@@ -428,7 +434,7 @@ impl PrintResults for Temporary {
     fn print_results(&self) {
         let start_time: SystemTime = SystemTime::now();
         println!("Found {} temporary files.\n", self.information.number_of_temporary_files);
-        for file_entry in self.temporary_files.iter() {
+        for file_entry in &self.temporary_files {
             println!("{}", file_entry.path.display());
         }
 

--- a/czkawka_gui/Cargo.toml
+++ b/czkawka_gui/Cargo.toml
@@ -10,10 +10,10 @@ homepage = "https://github.com/qarmin/czkawka"
 repository = "https://github.com/qarmin/czkawka"
 
 [dependencies]
-gdk4 = "0.5.4"
+gdk4 = "0.5.5"
 glib = "0.16.7"
 
-humansize = "2.1.2"
+humansize = "2.1.3"
 chrono = "0.4.23"
 
 # Used for sending stop signal across threads
@@ -32,7 +32,7 @@ open = "3.2.0"
 image = "0.24.5"
 
 # To be able to use custom select
-regex = "1.7.0"
+regex = "1.7.1"
 
 # To get image_hasher types
 image_hasher = "1.1.2"
@@ -44,16 +44,16 @@ trash = "3.0.0"
 fs_extra = "1.2.0"
 
 # Language
-i18n-embed = { version = "0.13.4", features = ["fluent-system", "desktop-requester"] }
-i18n-embed-fl = "0.6.4"
+i18n-embed = { version = "0.13.8", features = ["fluent-system", "desktop-requester"] }
+i18n-embed-fl = "0.6.5"
 rust-embed = "6.4.2"
-once_cell = "1.16.0"
+once_cell = "1.17.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["combaseapi", "objbase", "shobjidl_core", "windef", "winerror", "wtypesbase", "winuser"] }
 
 [dependencies.gtk4]
-version = "0.5.4"
+version = "0.5.5"
 default-features = false
 features = ["v4_6"]
 

--- a/czkawka_gui/src/compute_results.rs
+++ b/czkawka_gui/src/compute_results.rs
@@ -352,11 +352,11 @@ pub fn connect_compute_results(gui_data: &GuiData, glib_stop_receiver: Receiver<
                                         let values: [(u32, &dyn ToValue); 10] = [
                                             (ColumnsDuplicates::ActivatableSelectButton as u32, &false),
                                             (ColumnsDuplicates::SelectionButton as u32, &false),
-                                            (ColumnsDuplicates::Size as u32, (&"".to_string())),
-                                            (ColumnsDuplicates::Name as u32, (&"".to_string())),
+                                            (ColumnsDuplicates::Size as u32, (&String::new())),
+                                            (ColumnsDuplicates::Name as u32, (&String::new())),
                                             (ColumnsDuplicates::Path as u32, (&(format!("{} results", vector.len())))),
-                                            (ColumnsDuplicates::Modification as u32, (&"".to_string())), // No text in 3 column
-                                            (ColumnsDuplicates::ModificationAsSecs as u32, (&(0))),      // Not used here
+                                            (ColumnsDuplicates::Modification as u32, (&String::new())), // No text in 3 column
+                                            (ColumnsDuplicates::ModificationAsSecs as u32, (&(0))),     // Not used here
                                             (ColumnsDuplicates::Color as u32, &(HEADER_ROW_COLOR.to_string())),
                                             (ColumnsDuplicates::IsHeader as u32, &true),
                                             (ColumnsDuplicates::TextColor as u32, &(TEXT_COLOR.to_string())),
@@ -408,10 +408,10 @@ pub fn connect_compute_results(gui_data: &GuiData, glib_stop_receiver: Receiver<
                                             let values: [(u32, &dyn ToValue); 10] = [
                                                 (ColumnsDuplicates::ActivatableSelectButton as u32, &false),
                                                 (ColumnsDuplicates::SelectionButton as u32, &false),
-                                                (ColumnsDuplicates::Size as u32, (&"".to_string())),
-                                                (ColumnsDuplicates::Name as u32, (&"".to_string())),
-                                                (ColumnsDuplicates::Path as u32, (&"".to_string())),
-                                                (ColumnsDuplicates::Modification as u32, &"".to_string()), // No text in 3 column
+                                                (ColumnsDuplicates::Size as u32, (&String::new())),
+                                                (ColumnsDuplicates::Name as u32, (&String::new())),
+                                                (ColumnsDuplicates::Path as u32, (&String::new())),
+                                                (ColumnsDuplicates::Modification as u32, &String::new()), // No text in 3 column
                                                 (ColumnsDuplicates::ModificationAsSecs as u32, &(0)),
                                                 (ColumnsDuplicates::Color as u32, &(HEADER_ROW_COLOR.to_string())),
                                                 (ColumnsDuplicates::IsHeader as u32, &true),
@@ -461,11 +461,11 @@ pub fn connect_compute_results(gui_data: &GuiData, glib_stop_receiver: Receiver<
                                         let values: [(u32, &dyn ToValue); 10] = [
                                             (ColumnsDuplicates::ActivatableSelectButton as u32, &false),
                                             (ColumnsDuplicates::SelectionButton as u32, &false),
-                                            (ColumnsDuplicates::Size as u32, (&"".to_string())),
-                                            (ColumnsDuplicates::Name as u32, (&"".to_string())),
-                                            (ColumnsDuplicates::Path as u32, (&"".to_string())),
-                                            (ColumnsDuplicates::Modification as u32, &"".to_string()), // No text in 3 column
-                                            (ColumnsDuplicates::ModificationAsSecs as u32, &(0)),      // Not used here
+                                            (ColumnsDuplicates::Size as u32, (&String::new())),
+                                            (ColumnsDuplicates::Name as u32, (&String::new())),
+                                            (ColumnsDuplicates::Path as u32, (&String::new())),
+                                            (ColumnsDuplicates::Modification as u32, &String::new()), // No text in 3 column
+                                            (ColumnsDuplicates::ModificationAsSecs as u32, &(0)),     // Not used here
                                             (ColumnsDuplicates::Color as u32, &(HEADER_ROW_COLOR.to_string())),
                                             (ColumnsDuplicates::IsHeader as u32, &true),
                                             (ColumnsDuplicates::TextColor as u32, &(TEXT_COLOR.to_string())),
@@ -831,7 +831,7 @@ pub fn connect_compute_results(gui_data: &GuiData, glib_stop_receiver: Receiver<
                                 let values: [(u32, &dyn ToValue); 13] = [
                                     (ColumnsSimilarImages::ActivatableSelectButton as u32, &false),
                                     (ColumnsSimilarImages::SelectionButton as u32, &false),
-                                    (ColumnsSimilarImages::Similarity as u32, &"".to_string()),
+                                    (ColumnsSimilarImages::Similarity as u32, &String::new()),
                                     (ColumnsSimilarImages::Size as u32, &format_size(base_file_entry.size, BINARY)),
                                     (ColumnsSimilarImages::SizeAsBytes as u32, &base_file_entry.size),
                                     (ColumnsSimilarImages::Dimensions as u32, &base_file_entry.dimensions),
@@ -849,7 +849,7 @@ pub fn connect_compute_results(gui_data: &GuiData, glib_stop_receiver: Receiver<
                                 list_store.set(&list_store.append(), &values);
 
                                 // Meat
-                                for file_entry in vec_file_entry.iter() {
+                                for file_entry in &vec_file_entry {
                                     let (directory, file) = split_path(&file_entry.path);
                                     let values: [(u32, &dyn ToValue); 13] = [
                                         (ColumnsSimilarImages::ActivatableSelectButton as u32, &true),
@@ -892,13 +892,13 @@ pub fn connect_compute_results(gui_data: &GuiData, glib_stop_receiver: Receiver<
                                 let values: [(u32, &dyn ToValue); 13] = [
                                     (ColumnsSimilarImages::ActivatableSelectButton as u32, &false),
                                     (ColumnsSimilarImages::SelectionButton as u32, &false),
-                                    (ColumnsSimilarImages::Similarity as u32, &"".to_string()),
-                                    (ColumnsSimilarImages::Size as u32, &"".to_string()),
+                                    (ColumnsSimilarImages::Similarity as u32, &String::new()),
+                                    (ColumnsSimilarImages::Size as u32, &String::new()),
                                     (ColumnsSimilarImages::SizeAsBytes as u32, &(0)),
-                                    (ColumnsSimilarImages::Dimensions as u32, &"".to_string()),
-                                    (ColumnsSimilarImages::Name as u32, &"".to_string()),
-                                    (ColumnsSimilarImages::Path as u32, &"".to_string()),
-                                    (ColumnsSimilarImages::Modification as u32, &"".to_string()),
+                                    (ColumnsSimilarImages::Dimensions as u32, &String::new()),
+                                    (ColumnsSimilarImages::Name as u32, &String::new()),
+                                    (ColumnsSimilarImages::Path as u32, &String::new()),
+                                    (ColumnsSimilarImages::Modification as u32, &String::new()),
                                     (ColumnsSimilarImages::ModificationAsSecs as u32, &(0)),
                                     (ColumnsSimilarImages::Color as u32, &(HEADER_ROW_COLOR.to_string())),
                                     (ColumnsSimilarImages::IsHeader as u32, &true),
@@ -907,7 +907,7 @@ pub fn connect_compute_results(gui_data: &GuiData, glib_stop_receiver: Receiver<
                                 list_store.set(&list_store.append(), &values);
 
                                 // Meat
-                                for file_entry in vec_file_entry.iter() {
+                                for file_entry in &vec_file_entry {
                                     let (directory, file) = split_path(&file_entry.path);
                                     let values: [(u32, &dyn ToValue); 13] = [
                                         (ColumnsSimilarImages::ActivatableSelectButton as u32, &true),
@@ -1030,7 +1030,7 @@ pub fn connect_compute_results(gui_data: &GuiData, glib_stop_receiver: Receiver<
                                 list_store.set(&list_store.append(), &values);
 
                                 // Meat
-                                for file_entry in vec_file_entry.iter() {
+                                for file_entry in &vec_file_entry {
                                     let (directory, file) = split_path(&file_entry.path);
                                     let values: [(u32, &dyn ToValue); 11] = [
                                         (ColumnsSimilarVideos::ActivatableSelectButton as u32, &true),
@@ -1071,11 +1071,11 @@ pub fn connect_compute_results(gui_data: &GuiData, glib_stop_receiver: Receiver<
                                 let values: [(u32, &dyn ToValue); 11] = [
                                     (ColumnsSimilarVideos::ActivatableSelectButton as u32, &false),
                                     (ColumnsSimilarVideos::SelectionButton as u32, &false),
-                                    (ColumnsSimilarVideos::Size as u32, &"".to_string()),
+                                    (ColumnsSimilarVideos::Size as u32, &String::new()),
                                     (ColumnsSimilarVideos::SizeAsBytes as u32, &(0)),
-                                    (ColumnsSimilarVideos::Name as u32, &"".to_string()),
-                                    (ColumnsSimilarVideos::Path as u32, &"".to_string()),
-                                    (ColumnsSimilarVideos::Modification as u32, &"".to_string()),
+                                    (ColumnsSimilarVideos::Name as u32, &String::new()),
+                                    (ColumnsSimilarVideos::Path as u32, &String::new()),
+                                    (ColumnsSimilarVideos::Modification as u32, &String::new()),
                                     (ColumnsSimilarVideos::ModificationAsSecs as u32, &(0)),
                                     (ColumnsSimilarVideos::Color as u32, &(HEADER_ROW_COLOR.to_string())),
                                     (ColumnsSimilarVideos::IsHeader as u32, &true),
@@ -1084,7 +1084,7 @@ pub fn connect_compute_results(gui_data: &GuiData, glib_stop_receiver: Receiver<
                                 list_store.set(&list_store.append(), &values);
 
                                 // Meat
-                                for file_entry in vec_file_entry.iter() {
+                                for file_entry in &vec_file_entry {
                                     let (directory, file) = split_path(&file_entry.path);
                                     let values: [(u32, &dyn ToValue); 11] = [
                                         (ColumnsSimilarVideos::ActivatableSelectButton as u32, &true),
@@ -1265,36 +1265,36 @@ pub fn connect_compute_results(gui_data: &GuiData, glib_stop_receiver: Receiver<
                                 let values: [(u32, &dyn ToValue); 18] = [
                                     (ColumnsSameMusic::ActivatableSelectButton as u32, &false),
                                     (ColumnsSameMusic::SelectionButton as u32, &false),
-                                    (ColumnsSameMusic::Size as u32, &"".to_string()),
+                                    (ColumnsSameMusic::Size as u32, &String::new()),
                                     (ColumnsSameMusic::SizeAsBytes as u32, &(0)),
-                                    (ColumnsSameMusic::Name as u32, &"".to_string()),
-                                    (ColumnsSameMusic::Path as u32, &"".to_string()),
+                                    (ColumnsSameMusic::Name as u32, &String::new()),
+                                    (ColumnsSameMusic::Path as u32, &String::new()),
                                     (
                                         ColumnsSameMusic::Title as u32,
                                         &(match is_track_title {
                                             true => text.clone(),
-                                            false => "".to_string(),
+                                            false => String::new(),
                                         }),
                                     ),
                                     (
                                         ColumnsSameMusic::Artist as u32,
                                         &(match is_track_artist {
                                             true => text.clone(),
-                                            false => "".to_string(),
+                                            false => String::new(),
                                         }),
                                     ),
                                     (
                                         ColumnsSameMusic::Year as u32,
                                         &(match is_year {
                                             true => text.clone(),
-                                            false => "".to_string(),
+                                            false => String::new(),
                                         }),
                                     ),
                                     (
                                         ColumnsSameMusic::Bitrate as u32,
                                         &(match is_bitrate {
                                             true => text.clone(),
-                                            false => "".to_string(),
+                                            false => String::new(),
                                         }),
                                     ),
                                     (ColumnsSameMusic::BitrateAsNumber as u32, &(0)),
@@ -1302,17 +1302,17 @@ pub fn connect_compute_results(gui_data: &GuiData, glib_stop_receiver: Receiver<
                                         ColumnsSameMusic::Genre as u32,
                                         &(match is_genre {
                                             true => text.clone(),
-                                            false => "".to_string(),
+                                            false => String::new(),
                                         }),
                                     ),
                                     (
                                         ColumnsSameMusic::Length as u32,
                                         &(match is_length {
                                             true => text.clone(),
-                                            false => "".to_string(),
+                                            false => String::new(),
                                         }),
                                     ),
-                                    (ColumnsSameMusic::Modification as u32, &"".to_string()),
+                                    (ColumnsSameMusic::Modification as u32, &String::new()),
                                     (ColumnsSameMusic::ModificationAsSecs as u32, &(0)),
                                     (ColumnsSameMusic::Color as u32, &(HEADER_ROW_COLOR.to_string())),
                                     (ColumnsSameMusic::IsHeader as u32, &true),

--- a/czkawka_gui/src/compute_results.rs
+++ b/czkawka_gui/src/compute_results.rs
@@ -1269,49 +1269,13 @@ pub fn connect_compute_results(gui_data: &GuiData, glib_stop_receiver: Receiver<
                                     (ColumnsSameMusic::SizeAsBytes as u32, &(0)),
                                     (ColumnsSameMusic::Name as u32, &String::new()),
                                     (ColumnsSameMusic::Path as u32, &String::new()),
-                                    (
-                                        ColumnsSameMusic::Title as u32,
-                                        &(match is_track_title {
-                                            true => text.clone(),
-                                            false => String::new(),
-                                        }),
-                                    ),
-                                    (
-                                        ColumnsSameMusic::Artist as u32,
-                                        &(match is_track_artist {
-                                            true => text.clone(),
-                                            false => String::new(),
-                                        }),
-                                    ),
-                                    (
-                                        ColumnsSameMusic::Year as u32,
-                                        &(match is_year {
-                                            true => text.clone(),
-                                            false => String::new(),
-                                        }),
-                                    ),
-                                    (
-                                        ColumnsSameMusic::Bitrate as u32,
-                                        &(match is_bitrate {
-                                            true => text.clone(),
-                                            false => String::new(),
-                                        }),
-                                    ),
+                                    (ColumnsSameMusic::Title as u32, &(if is_track_title { text.clone() } else { String::new() })),
+                                    (ColumnsSameMusic::Artist as u32, &(if is_track_artist { text.clone() } else { String::new() })),
+                                    (ColumnsSameMusic::Year as u32, &(if is_year { text.clone() } else { String::new() })),
+                                    (ColumnsSameMusic::Bitrate as u32, &(if is_bitrate { text.clone() } else { String::new() })),
                                     (ColumnsSameMusic::BitrateAsNumber as u32, &(0)),
-                                    (
-                                        ColumnsSameMusic::Genre as u32,
-                                        &(match is_genre {
-                                            true => text.clone(),
-                                            false => String::new(),
-                                        }),
-                                    ),
-                                    (
-                                        ColumnsSameMusic::Length as u32,
-                                        &(match is_length {
-                                            true => text.clone(),
-                                            false => String::new(),
-                                        }),
-                                    ),
+                                    (ColumnsSameMusic::Genre as u32, &(if is_genre { text.clone() } else { String::new() })),
+                                    (ColumnsSameMusic::Length as u32, &(if is_length { text.clone() } else { String::new() })),
                                     (ColumnsSameMusic::Modification as u32, &String::new()),
                                     (ColumnsSameMusic::ModificationAsSecs as u32, &(0)),
                                     (ColumnsSameMusic::Color as u32, &(HEADER_ROW_COLOR.to_string())),

--- a/czkawka_gui/src/connect_things/connect_about_buttons.rs
+++ b/czkawka_gui/src/connect_things/connect_about_buttons.rs
@@ -11,28 +11,28 @@ pub fn connect_about_buttons(gui_data: &GuiData) {
     let button_donation = gui_data.about.button_donation.clone();
     button_donation.connect_clicked(move |_| {
         if let Err(e) = open::that(SPONSOR_SITE) {
-            println!("Failed to open sponsor site: {SPONSOR_SITE}, reason {e}")
+            println!("Failed to open sponsor site: {SPONSOR_SITE}, reason {e}");
         };
     });
 
     let button_instruction = gui_data.about.button_instruction.clone();
     button_instruction.connect_clicked(move |_| {
         if let Err(e) = open::that(INSTRUCTION_SITE) {
-            println!("Failed to open instruction site: {INSTRUCTION_SITE}, reason {e}")
+            println!("Failed to open instruction site: {INSTRUCTION_SITE}, reason {e}");
         };
     });
 
     let button_repository = gui_data.about.button_repository.clone();
     button_repository.connect_clicked(move |_| {
         if let Err(e) = open::that(REPOSITORY_SITE) {
-            println!("Failed to open repository site: {REPOSITORY_SITE}, reason {e}")
+            println!("Failed to open repository site: {REPOSITORY_SITE}, reason {e}");
         };
     });
 
     let button_translation = gui_data.about.button_translation.clone();
     button_translation.connect_clicked(move |_| {
         if let Err(e) = open::that(TRANSLATION_SITE) {
-            println!("Failed to open repository site: {TRANSLATION_SITE}, reason {e}")
+            println!("Failed to open repository site: {TRANSLATION_SITE}, reason {e}");
         };
     });
 }

--- a/czkawka_gui/src/connect_things/connect_button_compare.rs
+++ b/czkawka_gui/src/connect_things/connect_button_compare.rs
@@ -78,8 +78,8 @@ pub fn connect_button_compare(gui_data: &GuiData) {
             &check_button_right_preview_text,
             &scrolled_window_compare_choose_images,
             &label_group_info,
-            shared_image_cache.clone(),
-            shared_using_for_preview.clone(),
+            &shared_image_cache,
+            &shared_using_for_preview,
             &button_go_previous_compare_group,
             &button_go_next_compare_group,
         );
@@ -152,8 +152,8 @@ pub fn connect_button_compare(gui_data: &GuiData) {
             &check_button_right_preview_text,
             &scrolled_window_compare_choose_images,
             &label_group_info,
-            shared_image_cache.clone(),
-            shared_using_for_preview.clone(),
+            &shared_image_cache,
+            &shared_using_for_preview,
             button_go_previous_compare_group,
             &button_go_next_compare_group,
         );
@@ -204,8 +204,8 @@ pub fn connect_button_compare(gui_data: &GuiData) {
             &check_button_right_preview_text,
             &scrolled_window_compare_choose_images,
             &label_group_info,
-            shared_image_cache.clone(),
-            shared_using_for_preview.clone(),
+            &shared_image_cache,
+            &shared_using_for_preview,
             &button_go_previous_compare_group,
             button_go_next_compare_group,
         );
@@ -271,8 +271,8 @@ fn populate_groups_at_start(
     check_button_right_preview_text: &CheckButton,
     scrolled_window_compare_choose_images: &ScrolledWindow,
     label_group_info: &gtk4::Label,
-    shared_image_cache: Rc<RefCell<Vec<(String, String, Image, Image, TreePath)>>>,
-    shared_using_for_preview: Rc<RefCell<(Option<TreePath>, Option<TreePath>)>>,
+    shared_image_cache: &Rc<RefCell<Vec<(String, String, Image, Image, TreePath)>>>,
+    shared_using_for_preview: &Rc<RefCell<(Option<TreePath>, Option<TreePath>)>>,
     button_go_previous_compare_group: &gtk4::Button,
     button_go_next_compare_group: &gtk4::Button,
 ) {
@@ -318,8 +318,8 @@ fn populate_groups_at_start(
         &cache_all_images,
         image_compare_left,
         image_compare_right,
-        &shared_using_for_preview,
-        &shared_image_cache,
+        shared_using_for_preview,
+        shared_image_cache,
         check_button_left_preview_text,
         check_button_right_preview_text,
         model,
@@ -332,7 +332,7 @@ fn populate_groups_at_start(
     for i in get_all_direct_children(&scrolled_window_compare_choose_images.child().unwrap().downcast::<gtk4::Viewport>().unwrap()) {
         if i.widget_name() == "all_box" {
             let gtk_box = i.downcast::<gtk4::Box>().unwrap();
-            update_bottom_buttons(&gtk_box, &shared_using_for_preview, &shared_image_cache);
+            update_bottom_buttons(&gtk_box, shared_using_for_preview, shared_image_cache);
             found = true;
             break;
         }

--- a/czkawka_gui/src/connect_things/connect_button_compare.rs
+++ b/czkawka_gui/src/connect_things/connect_button_compare.rs
@@ -457,9 +457,7 @@ fn get_all_path(model: &TreeModel, current_path: &TreePath, column_header: i32, 
         returned_vector.push((full_name, name, model.path(&used_iter)));
     }
 
-    if !model.iter_next(&used_iter) {
-        panic!("Found only header!");
-    }
+    assert!(model.iter_next(&used_iter), "Found only header!");
 
     loop {
         let name = model.get::<String>(&used_iter, column_name);
@@ -490,13 +488,9 @@ fn move_iter(model: &TreeModel, tree_path: &TreePath, column_header: i32, go_nex
     assert!(model.get::<bool>(&tree_iter, column_header));
 
     if go_next {
-        if !model.iter_next(&tree_iter) {
-            panic!("Found only header!");
-        }
+        assert!(model.iter_next(&tree_iter), "Found only header!");
     } else {
-        if !model.iter_previous(&tree_iter) {
-            panic!("Found only header!");
-        }
+        assert!(model.iter_previous(&tree_iter), "Found only header!");
     }
 
     loop {

--- a/czkawka_gui/src/connect_things/connect_button_compare.rs
+++ b/czkawka_gui/src/connect_things/connect_button_compare.rs
@@ -371,12 +371,12 @@ fn generate_cache_for_results(vector_with_path: Vec<(String, String, TreePath)>)
                                     pixbuf = t;
                                 }
                                 Err(e) => {
-                                    println!("Failed to open image {}, reason {}", full_path, e);
+                                    println!("Failed to open image {full_path}, reason {e}");
                                 }
                             };
                         }
                         Err(e) => {
-                            println!("Failed to open image {}, reason {}", full_path, e);
+                            println!("Failed to open image {full_path}, reason {e}");
                         }
                     };
                     break 'czystka;

--- a/czkawka_gui/src/connect_things/connect_button_compare.rs
+++ b/czkawka_gui/src/connect_things/connect_button_compare.rs
@@ -60,7 +60,7 @@ pub fn connect_button_compare(gui_data: &GuiData) {
         }
 
         // Check selected items
-        let (current_group, tree_path) = get_current_group_and_iter_from_selection(&model, tree_view.selection(), nb_object.column_header.unwrap());
+        let (current_group, tree_path) = get_current_group_and_iter_from_selection(&model, &tree_view.selection(), nb_object.column_header.unwrap());
 
         *shared_current_of_groups.borrow_mut() = current_group;
         *shared_numbers_of_groups.borrow_mut() = group_number;
@@ -68,7 +68,7 @@ pub fn connect_button_compare(gui_data: &GuiData) {
         populate_groups_at_start(
             nb_object,
             &model,
-            shared_current_path.clone(),
+            &shared_current_path,
             tree_path,
             &image_compare_left,
             &image_compare_right,
@@ -142,7 +142,7 @@ pub fn connect_button_compare(gui_data: &GuiData) {
         populate_groups_at_start(
             nb_object,
             &model,
-            shared_current_path.clone(),
+            &shared_current_path,
             tree_path,
             &image_compare_left,
             &image_compare_right,
@@ -194,7 +194,7 @@ pub fn connect_button_compare(gui_data: &GuiData) {
         populate_groups_at_start(
             nb_object,
             &model,
-            shared_current_path.clone(),
+            &shared_current_path,
             tree_path,
             &image_compare_left,
             &image_compare_right,
@@ -261,7 +261,7 @@ pub fn connect_button_compare(gui_data: &GuiData) {
 fn populate_groups_at_start(
     nb_object: &NotebookObject,
     model: &TreeModel,
-    shared_current_path: Rc<RefCell<Option<TreePath>>>,
+    shared_current_path: &Rc<RefCell<Option<TreePath>>>,
     tree_path: TreePath,
     image_compare_left: &Image,
     image_compare_right: &Image,
@@ -318,8 +318,8 @@ fn populate_groups_at_start(
         &cache_all_images,
         image_compare_left,
         image_compare_right,
-        shared_using_for_preview.clone(),
-        shared_image_cache.clone(),
+        &shared_using_for_preview,
+        &shared_image_cache,
         check_button_left_preview_text,
         check_button_right_preview_text,
         model,
@@ -332,7 +332,7 @@ fn populate_groups_at_start(
     for i in get_all_direct_children(&scrolled_window_compare_choose_images.child().unwrap().downcast::<gtk4::Viewport>().unwrap()) {
         if i.widget_name() == "all_box" {
             let gtk_box = i.downcast::<gtk4::Box>().unwrap();
-            update_bottom_buttons(&gtk_box, shared_using_for_preview, shared_image_cache);
+            update_bottom_buttons(&gtk_box, &shared_using_for_preview, &shared_image_cache);
             found = true;
             break;
         }
@@ -414,14 +414,14 @@ fn generate_cache_for_results(vector_with_path: Vec<(String, String, TreePath)>)
 
         #[allow(clippy::never_loop)]
         loop {
-            let pixbuf_big = match resize_pixbuf_dimension(pixbuf, (BIG_PREVIEW_SIZE, BIG_PREVIEW_SIZE), InterpType::Bilinear) {
+            let pixbuf_big = match resize_pixbuf_dimension(&pixbuf, (BIG_PREVIEW_SIZE, BIG_PREVIEW_SIZE), InterpType::Bilinear) {
                 None => {
                     println!("Failed to resize image {full_path}.");
                     break;
                 }
                 Some(pixbuf) => pixbuf,
             };
-            let pixbuf_small = match resize_pixbuf_dimension(pixbuf_big.clone(), (SMALL_PREVIEW_SIZE, SMALL_PREVIEW_SIZE), InterpType::Bilinear) {
+            let pixbuf_small = match resize_pixbuf_dimension(&pixbuf_big, (SMALL_PREVIEW_SIZE, SMALL_PREVIEW_SIZE), InterpType::Bilinear) {
                 None => {
                     println!("Failed to resize image {full_path}.");
                     break;
@@ -517,8 +517,8 @@ fn populate_similar_scrolled_view(
     image_cache: &[(String, String, Image, Image, TreePath)],
     image_compare_left: &Image,
     image_compare_right: &Image,
-    shared_using_for_preview: Rc<RefCell<(Option<TreePath>, Option<TreePath>)>>,
-    shared_image_cache: Rc<RefCell<Vec<(String, String, Image, Image, TreePath)>>>,
+    shared_using_for_preview: &Rc<RefCell<(Option<TreePath>, Option<TreePath>)>>,
+    shared_image_cache: &Rc<RefCell<Vec<(String, String, Image, Image, TreePath)>>>,
     check_button_left_preview_text: &CheckButton,
     check_button_right_preview_text: &CheckButton,
     model: &TreeModel,
@@ -554,7 +554,7 @@ fn populate_similar_scrolled_view(
 
         button_left.connect_clicked(move |_button_left| {
             shared_using_for_preview_clone.borrow_mut().0 = Some(tree_path_clone.clone());
-            update_bottom_buttons(&all_gtk_box_clone, shared_using_for_preview_clone.clone(), shared_image_cache_clone.clone());
+            update_bottom_buttons(&all_gtk_box_clone, &shared_using_for_preview_clone, &shared_image_cache_clone);
             image_compare_left.set_paintable(big_thumbnail_clone.paintable().as_ref());
 
             let is_active = model_clone.get::<bool>(&model_clone.iter(&tree_path_clone).unwrap(), column_selection);
@@ -573,7 +573,7 @@ fn populate_similar_scrolled_view(
 
         button_right.connect_clicked(move |_button_right| {
             shared_using_for_preview_clone.borrow_mut().1 = Some(tree_path_clone.clone());
-            update_bottom_buttons(&all_gtk_box_clone, shared_using_for_preview_clone.clone(), shared_image_cache_clone.clone());
+            update_bottom_buttons(&all_gtk_box_clone, &shared_using_for_preview_clone, &shared_image_cache_clone);
             image_compare_right.set_paintable(big_thumbnail_clone.paintable().as_ref());
 
             let is_active = model_clone.get::<bool>(&model_clone.iter(&tree_path_clone).unwrap(), column_selection);
@@ -609,8 +609,8 @@ fn populate_similar_scrolled_view(
 /// Disables/Enables L/R buttons at the bottom scrolled view
 fn update_bottom_buttons(
     all_gtk_box: &gtk4::Box,
-    shared_using_for_preview: Rc<RefCell<(Option<TreePath>, Option<TreePath>)>>,
-    image_cache: Rc<RefCell<Vec<(String, String, Image, Image, TreePath)>>>,
+    shared_using_for_preview: &Rc<RefCell<(Option<TreePath>, Option<TreePath>)>>,
+    image_cache: &Rc<RefCell<Vec<(String, String, Image, Image, TreePath)>>>,
 ) {
     let left_tree_view = (shared_using_for_preview.borrow()).0.clone().unwrap();
     let right_tree_view = (shared_using_for_preview.borrow()).1.clone().unwrap();
@@ -629,7 +629,7 @@ fn update_bottom_buttons(
     }
 }
 
-fn get_current_group_and_iter_from_selection(model: &TreeModel, selection: TreeSelection, column_header: i32) -> (u32, TreePath) {
+fn get_current_group_and_iter_from_selection(model: &TreeModel, selection: &TreeSelection, column_header: i32) -> (u32, TreePath) {
     let mut current_group = 1;
     let mut possible_group = 1;
     let mut header_clone: TreeIter;

--- a/czkawka_gui/src/connect_things/connect_button_delete.rs
+++ b/czkawka_gui/src/connect_things/connect_button_delete.rs
@@ -108,7 +108,7 @@ pub async fn delete_things(gui_data: GuiData) {
             } else {
                 image_preview_duplicates.hide();
             }
-            *preview_path.borrow_mut() = "".to_string();
+            *preview_path.borrow_mut() = String::new();
         }
         _ => {}
     }
@@ -294,7 +294,7 @@ pub fn empty_folder_remover(
         return; // No selected rows
     }
 
-    let mut messages: String = "".to_string();
+    let mut messages: String = String::new();
 
     // Must be deleted from end to start, because when deleting entries, TreePath(and also TreeIter) will points to invalid data
     for tree_path in selected_rows.iter().rev() {
@@ -334,7 +334,7 @@ pub fn empty_folder_remover(
                     }
                 };
                 if metadata.is_dir() {
-                    next_folder = "".to_owned()
+                    next_folder = String::new()
                         + &current_folder
                         + "/"
                         + match &entry_data.file_name().into_string() {
@@ -392,7 +392,7 @@ pub fn basic_remove(
 
     let model = get_list_store(tree_view);
 
-    let mut messages: String = "".to_string();
+    let mut messages: String = String::new();
 
     let mut selected_rows = Vec::new();
 
@@ -468,7 +468,7 @@ pub fn tree_remove(
 
     let model = get_list_store(tree_view);
 
-    let mut messages: String = "".to_string();
+    let mut messages: String = String::new();
 
     let mut vec_path_to_delete: Vec<(String, String)> = Vec::new();
     let mut map_with_path_to_delete: BTreeMap<String, Vec<String>> = Default::default(); // BTreeMap<Path,Vec<FileName>>

--- a/czkawka_gui/src/connect_things/connect_button_delete.rs
+++ b/czkawka_gui/src/connect_things/connect_button_delete.rs
@@ -245,22 +245,22 @@ pub async fn check_if_deleting_all_files_in_group(
 
     if !selected_all_records {
         return false;
-    } else {
-        let (confirmation_dialog_group_delete, check_button) = create_dialog_group_deletion(window_main);
+    }
 
-        let response_type = confirmation_dialog_group_delete.run_future().await;
-        if response_type == ResponseType::Ok {
-            if !check_button.is_active() {
-                check_button_settings_confirm_group_deletion.set_active(false);
-            }
-        } else {
-            confirmation_dialog_group_delete.hide();
-            confirmation_dialog_group_delete.close();
-            return true;
+    let (confirmation_dialog_group_delete, check_button) = create_dialog_group_deletion(window_main);
+
+    let response_type = confirmation_dialog_group_delete.run_future().await;
+    if response_type == ResponseType::Ok {
+        if !check_button.is_active() {
+            check_button_settings_confirm_group_deletion.set_active(false);
         }
+    } else {
         confirmation_dialog_group_delete.hide();
         confirmation_dialog_group_delete.close();
+        return true;
     }
+    confirmation_dialog_group_delete.hide();
+    confirmation_dialog_group_delete.close();
 
     false
 }

--- a/czkawka_gui/src/connect_things/connect_button_hardlink.rs
+++ b/czkawka_gui/src/connect_things/connect_button_hardlink.rs
@@ -19,6 +19,12 @@ enum TypeOfTool {
     Symlinking,
 }
 
+#[derive(Debug)]
+struct SymHardlinkData {
+    original_data: String,
+    files_to_symhardlink: Vec<String>,
+}
+
 pub fn connect_button_hardlink_symlink(gui_data: &GuiData) {
     // Hardlinking
     {
@@ -62,7 +68,7 @@ async fn sym_hard_link_things(gui_data: GuiData, hardlinking: TypeOfTool) {
 
     let check_button_settings_confirm_link = gui_data.settings.check_button_settings_confirm_link.clone();
 
-    if !check_if_anything_is_selected_async(tree_view, column_header, nb_object.column_selection).await {
+    if !check_if_anything_is_selected_async(tree_view, column_header, nb_object.column_selection) {
         return;
     }
 
@@ -110,11 +116,6 @@ fn hardlink_symlink(
 
     let model = get_list_store(tree_view);
 
-    #[derive(Debug)]
-    struct SymHardlinkData {
-        original_data: String,
-        files_to_symhardlink: Vec<String>,
-    }
     let mut vec_tree_path_to_remove: Vec<TreePath> = Vec::new(); // List of hardlinked files without its root
     let mut vec_symhardlink_data: Vec<SymHardlinkData> = Vec::new();
 
@@ -328,7 +329,7 @@ pub async fn check_if_changing_one_item_in_group_and_continue(tree_view: &gtk4::
     true
 }
 
-pub async fn check_if_anything_is_selected_async(tree_view: &gtk4::TreeView, column_header: i32, column_selection: i32) -> bool {
+pub fn check_if_anything_is_selected_async(tree_view: &gtk4::TreeView, column_header: i32, column_selection: i32) -> bool {
     let model = get_list_store(tree_view);
 
     if let Some(iter) = model.iter_first() {

--- a/czkawka_gui/src/connect_things/connect_button_hardlink.rs
+++ b/czkawka_gui/src/connect_things/connect_button_hardlink.rs
@@ -86,7 +86,7 @@ async fn sym_hard_link_things(gui_data: GuiData, hardlinking: TypeOfTool) {
         nb_object.column_path,
         column_header,
         nb_object.column_selection,
-        hardlinking,
+        &hardlinking,
         &text_view_errors,
     );
 
@@ -109,7 +109,7 @@ fn hardlink_symlink(
     column_path: i32,
     column_header: i32,
     column_selection: i32,
-    hardlinking: TypeOfTool,
+    hardlinking: &TypeOfTool,
     text_view_errors: &TextView,
 ) {
     reset_text_view(text_view_errors);
@@ -198,7 +198,7 @@ fn hardlink_symlink(
             break;
         }
     }
-    if hardlinking == TypeOfTool::Hardlinking {
+    if hardlinking == &TypeOfTool::Hardlinking {
         for symhardlink_data in vec_symhardlink_data {
             for file_to_hardlink in symhardlink_data.files_to_symhardlink {
                 if let Err(e) = make_hard_link(&PathBuf::from(&symhardlink_data.original_data), &PathBuf::from(&file_to_hardlink)) {

--- a/czkawka_gui/src/connect_things/connect_button_hardlink.rs
+++ b/czkawka_gui/src/connect_things/connect_button_hardlink.rs
@@ -91,7 +91,7 @@ async fn sym_hard_link_things(gui_data: GuiData, hardlinking: TypeOfTool) {
             } else {
                 image_preview_duplicates.hide();
             }
-            *preview_path.borrow_mut() = "".to_string();
+            *preview_path.borrow_mut() = String::new();
         }
         _ => {}
     }
@@ -154,9 +154,7 @@ fn hardlink_symlink(
             }
 
             current_symhardlink_data = None;
-            if !model.iter_next(&current_iter) {
-                panic!("HEADER, shouldn't be a last item.");
-            }
+            assert!(model.iter_next(&current_iter), "HEADER, shouldn't be a last item.");
             continue;
         }
 
@@ -201,7 +199,7 @@ fn hardlink_symlink(
     }
     if hardlinking == TypeOfTool::Hardlinking {
         for symhardlink_data in vec_symhardlink_data {
-            for file_to_hardlink in symhardlink_data.files_to_symhardlink.into_iter() {
+            for file_to_hardlink in symhardlink_data.files_to_symhardlink {
                 if let Err(e) = make_hard_link(&PathBuf::from(&symhardlink_data.original_data), &PathBuf::from(&file_to_hardlink)) {
                     add_text_to_text_view(text_view_errors, format!("{} {}, reason {}", flg!("hardlink_failed"), file_to_hardlink, e).as_str());
                     continue;
@@ -210,7 +208,7 @@ fn hardlink_symlink(
         }
     } else {
         for symhardlink_data in vec_symhardlink_data {
-            for file_to_symlink in symhardlink_data.files_to_symhardlink.into_iter() {
+            for file_to_symlink in symhardlink_data.files_to_symhardlink {
                 if let Err(e) = fs::remove_file(&file_to_symlink) {
                     add_text_to_text_view(
                         text_view_errors,

--- a/czkawka_gui/src/connect_things/connect_button_move.rs
+++ b/czkawka_gui/src/connect_things/connect_button_move.rs
@@ -122,12 +122,12 @@ fn move_things(
                         column_path,
                         column_header,
                         column_selection,
-                        folder,
+                        &folder,
                         &entry_info,
                         &text_view_errors,
                     );
                 } else {
-                    move_with_list(&tree_view, column_file_name, column_path, column_selection, folder, &entry_info, &text_view_errors);
+                    move_with_list(&tree_view, column_file_name, column_path, column_selection, &folder, &entry_info, &text_view_errors);
                 }
             }
         }
@@ -141,7 +141,7 @@ fn move_with_tree(
     column_path: i32,
     column_header: i32,
     column_selection: i32,
-    destination_folder: PathBuf,
+    destination_folder: &Path,
     entry_info: &gtk4::Entry,
     text_view_errors: &gtk4::TextView,
 ) {
@@ -169,7 +169,7 @@ fn move_with_tree(
         return; // No selected rows
     }
 
-    move_files_common(&selected_rows, &model, column_file_name, column_path, &destination_folder, entry_info, text_view_errors);
+    move_files_common(&selected_rows, &model, column_file_name, column_path, destination_folder, entry_info, text_view_errors);
 
     clean_invalid_headers(&model, column_header, column_path);
 }
@@ -179,7 +179,7 @@ fn move_with_list(
     column_file_name: i32,
     column_path: i32,
     column_selection: i32,
-    destination_folder: PathBuf,
+    destination_folder: &Path,
     entry_info: &gtk4::Entry,
     text_view_errors: &gtk4::TextView,
 ) {
@@ -203,7 +203,7 @@ fn move_with_list(
         return; // No selected rows
     }
 
-    move_files_common(&selected_rows, &model, column_file_name, column_path, &destination_folder, entry_info, text_view_errors)
+    move_files_common(&selected_rows, &model, column_file_name, column_path, destination_folder, entry_info, text_view_errors);
 }
 
 fn move_files_common(

--- a/czkawka_gui/src/connect_things/connect_button_move.rs
+++ b/czkawka_gui/src/connect_things/connect_button_move.rs
@@ -55,7 +55,7 @@ pub fn connect_button_move(gui_data: &GuiData) {
                 } else {
                     image_preview_duplicates.hide();
                 }
-                *preview_path.borrow_mut() = "".to_string();
+                *preview_path.borrow_mut() = String::new();
             }
             _ => {}
         }
@@ -215,7 +215,7 @@ fn move_files_common(
     entry_info: &gtk4::Entry,
     text_view_errors: &gtk4::TextView,
 ) {
-    let mut messages: String = "".to_string();
+    let mut messages: String = String::new();
 
     let mut moved_files: u32 = 0;
 

--- a/czkawka_gui/src/connect_things/connect_button_search.rs
+++ b/czkawka_gui/src/connect_things/connect_button_search.rs
@@ -231,7 +231,7 @@ pub fn connect_button_search(
                     df.set_case_sensitive_name_comparison(case_sensitive_name_comparison);
                     df.set_exclude_other_filesystems(ignore_other_filesystems);
                     df.find_duplicates(Some(&stop_receiver), Some(&futures_sender_duplicate_files));
-                    let _ = glib_stop_sender.send(Message::Duplicates(df));
+                    glib_stop_sender.send(Message::Duplicates(df)).unwrap();
                 });
             }
             NotebookMainEnum::EmptyFiles => {
@@ -253,7 +253,7 @@ pub fn connect_button_search(
                     vf.set_allowed_extensions(allowed_extensions);
                     vf.set_exclude_other_filesystems(ignore_other_filesystems);
                     vf.find_empty_files(Some(&stop_receiver), Some(&futures_sender_empty_files));
-                    let _ = glib_stop_sender.send(Message::EmptyFiles(vf));
+                    glib_stop_sender.send(Message::EmptyFiles(vf)).unwrap();
                 });
             }
             NotebookMainEnum::EmptyDirectories => {
@@ -272,7 +272,7 @@ pub fn connect_button_search(
                     ef.set_excluded_items(excluded_items);
                     ef.set_exclude_other_filesystems(ignore_other_filesystems);
                     ef.find_empty_folders(Some(&stop_receiver), Some(&futures_sender_empty_folder));
-                    let _ = glib_stop_sender.send(Message::EmptyFolders(ef));
+                    glib_stop_sender.send(Message::EmptyFolders(ef)).unwrap();
                 });
             }
             NotebookMainEnum::BigFiles => {
@@ -301,7 +301,7 @@ pub fn connect_button_search(
                     bf.set_search_mode(big_files_mode);
                     bf.set_exclude_other_filesystems(ignore_other_filesystems);
                     bf.find_big_files(Some(&stop_receiver), Some(&futures_sender_big_file));
-                    let _ = glib_stop_sender.send(Message::BigFiles(bf));
+                    glib_stop_sender.send(Message::BigFiles(bf)).unwrap();
                 });
             }
             NotebookMainEnum::Temporary => {
@@ -322,7 +322,7 @@ pub fn connect_button_search(
                     tf.set_excluded_items(excluded_items);
                     tf.set_exclude_other_filesystems(ignore_other_filesystems);
                     tf.find_temporary_files(Some(&stop_receiver), Some(&futures_sender_temporary));
-                    let _ = glib_stop_sender.send(Message::Temporary(tf));
+                    glib_stop_sender.send(Message::Temporary(tf)).unwrap();
                 });
             }
             NotebookMainEnum::SimilarImages => {
@@ -372,7 +372,7 @@ pub fn connect_button_search(
                     sf.set_save_also_as_json(save_also_as_json);
                     sf.set_exclude_other_filesystems(ignore_other_filesystems);
                     sf.find_similar_images(Some(&stop_receiver), Some(&futures_sender_similar_images));
-                    let _ = glib_stop_sender.send(Message::SimilarImages(sf));
+                    glib_stop_sender.send(Message::SimilarImages(sf)).unwrap();
                 });
             }
             NotebookMainEnum::SimilarVideos => {
@@ -408,7 +408,7 @@ pub fn connect_button_search(
                     sf.set_save_also_as_json(save_also_as_json);
                     sf.set_exclude_other_filesystems(ignore_other_filesystems);
                     sf.find_similar_videos(Some(&stop_receiver), Some(&futures_sender_similar_videos));
-                    let _ = glib_stop_sender.send(Message::SimilarVideos(sf));
+                    glib_stop_sender.send(Message::SimilarVideos(sf)).unwrap();
                 });
             }
             NotebookMainEnum::SameMusic => {
@@ -460,7 +460,7 @@ pub fn connect_button_search(
                         mf.set_save_also_as_json(save_also_as_json);
                         mf.set_exclude_other_filesystems(ignore_other_filesystems);
                         mf.find_same_music(Some(&stop_receiver), Some(&futures_sender_same_music));
-                        let _ = glib_stop_sender.send(Message::SameMusic(mf));
+                        glib_stop_sender.send(Message::SameMusic(mf)).unwrap();
                     });
                 } else {
                     set_buttons(
@@ -496,7 +496,7 @@ pub fn connect_button_search(
                     isf.set_allowed_extensions(allowed_extensions);
                     isf.set_exclude_other_filesystems(ignore_other_filesystems);
                     isf.find_invalid_links(Some(&stop_receiver), Some(&futures_sender_invalid_symlinks));
-                    let _ = glib_stop_sender.send(Message::InvalidSymlinks(isf));
+                    glib_stop_sender.send(Message::InvalidSymlinks(isf)).unwrap();
                 });
             }
             NotebookMainEnum::BrokenFiles => {
@@ -537,7 +537,7 @@ pub fn connect_button_search(
                         br.set_checked_types(checked_types);
                         br.set_exclude_other_filesystems(ignore_other_filesystems);
                         br.find_broken_files(Some(&stop_receiver), Some(&futures_sender_broken_files));
-                        let _ = glib_stop_sender.send(Message::BrokenFiles(br));
+                        glib_stop_sender.send(Message::BrokenFiles(br)).unwrap();
                     });
                 } else {
                     set_buttons(
@@ -575,7 +575,7 @@ pub fn connect_button_search(
                     be.set_recursive_search(recursive_search);
                     be.set_exclude_other_filesystems(ignore_other_filesystems);
                     be.find_bad_extensions_files(Some(&stop_receiver), Some(&futures_sender_bad_extensions));
-                    let _ = glib_stop_sender.send(Message::BadExtensions(be));
+                    glib_stop_sender.send(Message::BadExtensions(be)).unwrap();
                 });
             }
         }

--- a/czkawka_gui/src/connect_things/connect_button_search.rs
+++ b/czkawka_gui/src/connect_things/connect_button_search.rs
@@ -124,9 +124,9 @@ pub fn connect_button_search(
             return;
         }
 
-        let included_directories = get_path_buf_from_vector_of_strings(get_string_from_list_store(&tree_view_included_directories, ColumnsIncludedDirectory::Path as i32, None));
-        let excluded_directories = get_path_buf_from_vector_of_strings(get_string_from_list_store(&tree_view_excluded_directories, ColumnsExcludedDirectory::Path as i32, None));
-        let reference_directories = get_path_buf_from_vector_of_strings(get_string_from_list_store(
+        let included_directories = get_path_buf_from_vector_of_strings(&get_string_from_list_store(&tree_view_included_directories, ColumnsIncludedDirectory::Path as i32, None));
+        let excluded_directories = get_path_buf_from_vector_of_strings(&get_string_from_list_store(&tree_view_excluded_directories, ColumnsExcludedDirectory::Path as i32, None));
+        let reference_directories = get_path_buf_from_vector_of_strings(&get_string_from_list_store(
             &tree_view_included_directories,
             ColumnsIncludedDirectory::Path as i32,
             Some(ColumnsIncludedDirectory::ReferenceButton as i32),

--- a/czkawka_gui/src/connect_things/connect_button_search.rs
+++ b/czkawka_gui/src/connect_things/connect_button_search.rs
@@ -132,7 +132,13 @@ pub fn connect_button_search(
             Some(ColumnsIncludedDirectory::ReferenceButton as i32),
         ));
         let recursive_search = check_button_recursive.is_active();
-        let excluded_items = entry_excluded_items.text().as_str().to_string().split(',').map(|e| e.to_string()).collect::<Vec<String>>();
+        let excluded_items = entry_excluded_items
+            .text()
+            .as_str()
+            .to_string()
+            .split(',')
+            .map(std::string::ToString::to_string)
+            .collect::<Vec<String>>();
         let allowed_extensions = entry_allowed_extensions.text().as_str().to_string();
         let hide_hard_links = check_button_settings_hide_hard_links.is_active();
         let use_cache = check_button_settings_use_cache.is_active();

--- a/czkawka_gui/src/connect_things/connect_change_language.rs
+++ b/czkawka_gui/src/connect_things/connect_change_language.rs
@@ -23,7 +23,7 @@ fn change_language(gui_data: &GuiData) {
         ("czkawka_gui", localizer_gui::localizer_gui()),
     ];
 
-    let lang_short = get_language_from_combo_box_text(gui_data.settings.combo_box_settings_language.active_text().unwrap().to_string()).short_text;
+    let lang_short = get_language_from_combo_box_text(&gui_data.settings.combo_box_settings_language.active_text().unwrap()).short_text;
 
     let lang_identifier = vec![LanguageIdentifier::from_bytes(lang_short.as_bytes()).unwrap()];
     for (lib, localizer) in localizers {

--- a/czkawka_gui/src/connect_things/connect_change_language.rs
+++ b/czkawka_gui/src/connect_things/connect_change_language.rs
@@ -39,7 +39,7 @@ pub fn load_system_language(gui_data: &GuiData) {
 
     if let Some(language) = requested_languages.get(0) {
         let old_short_lang = language.to_string();
-        let mut short_lang = "".to_string();
+        let mut short_lang = String::new();
         // removes from e.g. en_zb, ending _zd since Czkawka don't support this(maybe could add this in future, but only when)
         for i in old_short_lang.chars() {
             if i.is_ascii_alphabetic() {

--- a/czkawka_gui/src/connect_things/connect_change_language.rs
+++ b/czkawka_gui/src/connect_things/connect_change_language.rs
@@ -43,7 +43,7 @@ pub fn load_system_language(gui_data: &GuiData) {
         // removes from e.g. en_zb, ending _zd since Czkawka don't support this(maybe could add this in future, but only when)
         for i in old_short_lang.chars() {
             if i.is_ascii_alphabetic() {
-                short_lang.push(i)
+                short_lang.push(i);
             } else {
                 break;
             }

--- a/czkawka_gui/src/connect_things/connect_popovers.rs
+++ b/czkawka_gui/src/connect_things/connect_popovers.rs
@@ -290,7 +290,7 @@ fn popover_custom_select_unselect(
                 let message;
                 let text_to_check = entry_rust_regex.text().to_string();
                 if text_to_check.is_empty() {
-                    message = "".to_string();
+                    message = String::new();
                 } else {
                     match Regex::new(&text_to_check) {
                         Ok(_) => message = flg!("popover_valid_regex"),

--- a/czkawka_gui/src/connect_things/connect_popovers.rs
+++ b/czkawka_gui/src/connect_things/connect_popovers.rs
@@ -172,10 +172,7 @@ fn popover_one_oldest_newest(
             let mut tree_iter_array: Vec<TreeIter> = Vec::new();
             let mut used_index: Option<usize> = None;
             let mut current_index: usize = 0;
-            let mut modification_time_min_max: u64 = match check_oldest {
-                true => u64::MAX,
-                false => 0,
-            };
+            let mut modification_time_min_max: u64 = if check_oldest { u64::MAX } else { 0 };
 
             let mut file_length: usize = 0;
 
@@ -242,9 +239,10 @@ fn popover_custom_select_unselect(
 ) {
     popover.popdown();
 
-    let window_title = match select_things {
-        false => flg!("popover_custom_mode_unselect"),
-        true => flg!("popover_custom_mode_select"),
+    let window_title = if select_things {
+        flg!("popover_custom_mode_select")
+    } else {
+        flg!("popover_custom_mode_unselect")
     };
 
     // Dialog for select/unselect items
@@ -382,26 +380,25 @@ fn popover_custom_select_unselect(
                 let check_all_selected = check_button_select_not_all_results.is_active();
 
                 if check_button_path.is_active() || check_button_name.is_active() || check_button_rust_regex.is_active() {
-                    let compiled_regex = match check_regex {
-                        true => match Regex::new(&regex_wildcard) {
-                            Ok(t) => t,
-                            Err(_) => {
-                                eprintln!("What? Regex should compile properly.");
-                                confirmation_dialog_select_unselect.close();
-                                return;
-                            }
-                        },
-                        false => Regex::new("").unwrap(),
+                    let compiled_regex = if check_regex {
+                        if let Ok(t) = Regex::new(&regex_wildcard) {
+                            t
+                        } else {
+                            eprintln!("What? Regex should compile properly.");
+                            confirmation_dialog_select_unselect.close();
+                            return;
+                        }
+                    } else {
+                        Regex::new("").unwrap()
                     };
 
                     let model = get_list_store(&tree_view);
 
-                    let iter = match model.iter_first() {
-                        Some(t) => t,
-                        None => {
-                            confirmation_dialog_select_unselect.close();
-                            return;
-                        }
+                    let iter = if let Some(t) = model.iter_first() {
+                        t
+                    } else {
+                        confirmation_dialog_select_unselect.close();
+                        return;
                     };
 
                     let mut number_of_all_things = 0;
@@ -524,14 +521,8 @@ fn popover_all_except_biggest_smallest(
             let mut tree_iter_array: Vec<TreeIter> = Vec::new();
             let mut used_index: Option<usize> = None;
             let mut current_index: usize = 0;
-            let mut size_as_bytes_min_max: u64 = match except_biggest {
-                true => 0,
-                false => u64::MAX,
-            };
-            let mut number_of_pixels_min_max: u64 = match except_biggest {
-                true => 0,
-                false => u64::MAX,
-            };
+            let mut size_as_bytes_min_max: u64 = if except_biggest { 0 } else { u64::MAX };
+            let mut number_of_pixels_min_max: u64 = if except_biggest { 0 } else { u64::MAX };
 
             loop {
                 if model.get::<bool>(&iter, column_header) {
@@ -547,7 +538,7 @@ fn popover_all_except_biggest_smallest(
                 if let Some(column_dimensions) = column_dimensions {
                     let dimensions_string = model.get::<String>(&iter, column_dimensions);
 
-                    let dimensions = change_dimension_to_krotka(dimensions_string);
+                    let dimensions = change_dimension_to_krotka(&dimensions_string);
                     let number_of_pixels = dimensions.0 * dimensions.1;
 
                     if except_biggest {

--- a/czkawka_gui/src/connect_things/connect_popovers.rs
+++ b/czkawka_gui/src/connect_things/connect_popovers.rs
@@ -98,10 +98,8 @@ fn popover_all_except_oldest_newest(
             let mut tree_iter_array: Vec<TreeIter> = Vec::new();
             let mut used_index: Option<usize> = None;
             let mut current_index: usize = 0;
-            let mut modification_time_min_max: u64 = match except_oldest {
-                true => u64::MAX,
-                false => 0,
-            };
+
+            let mut modification_time_min_max: u64 = if except_oldest { u64::MAX } else { 0 };
 
             let mut file_length: usize = 0;
 

--- a/czkawka_gui/src/connect_things/connect_settings.rs
+++ b/czkawka_gui/src/connect_things/connect_settings.rs
@@ -111,7 +111,7 @@ pub fn connect_settings(gui_data: &GuiData) {
             let entry_settings_cache_file_minimal_size = gui_data.settings.entry_settings_cache_file_minimal_size.clone();
 
             button_settings_duplicates_clear_cache.connect_clicked(move |_| {
-                let dialog = create_clear_cache_dialog(flg!("cache_clear_duplicates_title"), &settings_window);
+                let dialog = create_clear_cache_dialog(&flg!("cache_clear_duplicates_title"), &settings_window);
                 dialog.show();
 
                 let text_view_errors = text_view_errors.clone();
@@ -135,7 +135,7 @@ pub fn connect_settings(gui_data: &GuiData) {
                                         type_of_hash,
                                         use_prehash,
                                         entry_settings_cache_file_minimal_size.text().as_str().parse::<u64>().unwrap_or(2 * 1024 * 1024),
-                                    )
+                                    );
                                 }
                             }
 
@@ -153,7 +153,7 @@ pub fn connect_settings(gui_data: &GuiData) {
             let text_view_errors = gui_data.text_view_errors.clone();
 
             button_settings_similar_images_clear_cache.connect_clicked(move |_| {
-                let dialog = create_clear_cache_dialog(flg!("cache_clear_similar_images_title"), &settings_window);
+                let dialog = create_clear_cache_dialog(&flg!("cache_clear_similar_images_title"), &settings_window);
                 dialog.show();
 
                 let text_view_errors = text_view_errors.clone();
@@ -190,7 +190,7 @@ pub fn connect_settings(gui_data: &GuiData) {
             let text_view_errors = gui_data.text_view_errors.clone();
 
             button_settings_similar_videos_clear_cache.connect_clicked(move |_| {
-                let dialog = create_clear_cache_dialog(flg!("cache_clear_similar_videos_title"), &settings_window);
+                let dialog = create_clear_cache_dialog(&flg!("cache_clear_similar_videos_title"), &settings_window);
                 dialog.show();
 
                 let text_view_errors = text_view_errors.clone();
@@ -212,8 +212,8 @@ pub fn connect_settings(gui_data: &GuiData) {
     }
 }
 
-fn create_clear_cache_dialog(title_str: String, window_settings: &Window) -> gtk4::Dialog {
-    let dialog = gtk4::Dialog::builder().title(&title_str).modal(true).transient_for(window_settings).build();
+fn create_clear_cache_dialog(title_str: &str, window_settings: &Window) -> gtk4::Dialog {
+    let dialog = gtk4::Dialog::builder().title(title_str).modal(true).transient_for(window_settings).build();
     dialog.add_button(&flg!("general_ok_button"), ResponseType::Ok);
     dialog.add_button(&flg!("general_close_button"), ResponseType::Cancel);
 

--- a/czkawka_gui/src/connect_things/connect_settings.rs
+++ b/czkawka_gui/src/connect_things/connect_settings.rs
@@ -121,7 +121,7 @@ pub fn connect_settings(gui_data: &GuiData) {
                     if response_type == ResponseType::Ok {
                         let mut messages: Messages = Messages::new();
                         for use_prehash in [true, false] {
-                            for type_of_hash in [HashType::Xxh3, HashType::Blake3, HashType::Crc32].iter() {
+                            for type_of_hash in &[HashType::Xxh3, HashType::Blake3, HashType::Crc32] {
                                 if let Some(cache_entries) = czkawka_core::duplicate::load_hashes_from_file(&mut messages, true, type_of_hash, use_prehash) {
                                     let mut hashmap_to_save: BTreeMap<String, czkawka_core::common_dir_traversal::FileEntry> = Default::default();
                                     for (_, vec_file_entry) in cache_entries {
@@ -161,17 +161,15 @@ pub fn connect_settings(gui_data: &GuiData) {
                 dialog.connect_response(move |dialog, response_type| {
                     if response_type == ResponseType::Ok {
                         let mut messages: Messages = Messages::new();
-                        for hash_size in [8, 16, 32, 64].iter() {
-                            for image_filter in [
+                        for hash_size in &[8, 16, 32, 64] {
+                            for image_filter in &[
                                 FilterType::Lanczos3,
                                 FilterType::CatmullRom,
                                 FilterType::Gaussian,
                                 FilterType::Nearest,
                                 FilterType::Triangle,
-                            ]
-                            .iter()
-                            {
-                                for hash_alg in [HashAlg::Blockhash, HashAlg::Gradient, HashAlg::DoubleGradient, HashAlg::VertGradient, HashAlg::Mean].iter() {
+                            ] {
+                                for hash_alg in &[HashAlg::Blockhash, HashAlg::Gradient, HashAlg::DoubleGradient, HashAlg::VertGradient, HashAlg::Mean] {
                                     if let Some(cache_entries) = czkawka_core::similar_images::load_hashes_from_file(&mut messages, true, *hash_size, *hash_alg, *image_filter) {
                                         czkawka_core::similar_images::save_hashes_to_file(&cache_entries, &mut messages, false, *hash_size, *hash_alg, *image_filter);
                                     }

--- a/czkawka_gui/src/connect_things/connect_settings.rs
+++ b/czkawka_gui/src/connect_things/connect_settings.rs
@@ -62,7 +62,7 @@ pub fn connect_settings(gui_data: &GuiData) {
         let button_settings_load_configuration = gui_data.settings.button_settings_load_configuration.clone();
         let scrolled_window_errors = gui_data.scrolled_window_errors.clone();
         button_settings_load_configuration.connect_clicked(move |_| {
-            load_configuration(true, &upper_notebook, &main_notebook, &settings, &text_view_errors, &scrolled_window_errors, Vec::new());
+            load_configuration(true, &upper_notebook, &main_notebook, &settings, &text_view_errors, &scrolled_window_errors, &Vec::new());
         });
     }
     // Connect reset configuration button

--- a/czkawka_gui/src/gui_structs/gui_data.rs
+++ b/czkawka_gui/src/gui_structs/gui_data.rs
@@ -139,9 +139,9 @@ impl GuiData {
         let shared_buttons: Rc<RefCell<_>> = Rc::new(RefCell::new(HashMap::<NotebookMainEnum, HashMap<BottomButtonsEnum, bool>>::new()));
 
         // Show by default only search button
-        for i in get_all_main_tabs().iter() {
+        for i in &get_all_main_tabs() {
             let mut temp_hashmap: HashMap<BottomButtonsEnum, bool> = Default::default();
-            for button_name in bottom_buttons.buttons_names.iter() {
+            for button_name in &bottom_buttons.buttons_names {
                 if *button_name == BottomButtonsEnum::Search {
                     temp_hashmap.insert(*button_name, true);
                 } else {
@@ -165,7 +165,7 @@ impl GuiData {
         let shared_broken_files_state: Rc<RefCell<_>> = Rc::new(RefCell::new(BrokenFiles::new()));
         let shared_bad_extensions_state: Rc<RefCell<_>> = Rc::new(RefCell::new(BadExtensions::new()));
 
-        let preview_path: Rc<RefCell<_>> = Rc::new(RefCell::new("".to_string()));
+        let preview_path: Rc<RefCell<_>> = Rc::new(RefCell::new(String::new()));
 
         //// Entry
         let entry_info: gtk4::Entry = builder.object("entry_info").unwrap();

--- a/czkawka_gui/src/help_functions.rs
+++ b/czkawka_gui/src/help_functions.rs
@@ -258,7 +258,7 @@ pub fn get_path_buf_from_vector_of_strings(vec_string: Vec<String>) -> Vec<PathB
 }
 
 pub fn print_text_messages_to_text_view(text_messages: &Messages, text_view: &TextView) {
-    let mut messages: String = String::from("");
+    let mut messages: String = String::new();
     if !text_messages.messages.is_empty() {
         messages += format!("############### {}({}) ###############\n", flg!("text_view_messages"), text_messages.messages.len()).as_str();
     }
@@ -395,9 +395,8 @@ pub fn clean_invalid_headers(model: &ListStore, column_header: i32, column_path:
     if let Some(first_iter) = model.iter_first() {
         let mut vec_tree_path_to_delete: Vec<gtk4::TreePath> = Vec::new();
         let mut current_iter = first_iter;
-        if !model.get::<bool>(&current_iter, column_header) {
-            panic!("First deleted element, should be a header"); // First element should be header
-        };
+        // First element should be header
+        assert!(model.get::<bool>(&current_iter, column_header), "First deleted element, should be a header");
 
         let mut next_iter;
         let mut next_next_iter;
@@ -405,9 +404,8 @@ pub fn clean_invalid_headers(model: &ListStore, column_header: i32, column_path:
         // Empty means default check type
         if model.get::<String>(&current_iter, column_path).is_empty() {
             'main: loop {
-                if !model.get::<bool>(&current_iter, column_header) {
-                    panic!("First deleted element, should be a header"); // First element should be header
-                };
+                // First element should be header
+                assert!(model.get::<bool>(&current_iter, column_header), "First deleted element, should be a header");
 
                 next_iter = current_iter;
                 if !model.iter_next(&next_iter) {
@@ -458,9 +456,8 @@ pub fn clean_invalid_headers(model: &ListStore, column_header: i32, column_path:
         // Non empty means that header points at reference folder
         else {
             'reference: loop {
-                if !model.get::<bool>(&current_iter, column_header) {
-                    panic!("First deleted element, should be a header"); // First element should be header
-                };
+                // First element should be header
+                assert!(model.get::<bool>(&current_iter, column_header), "First deleted element, should be a header");
 
                 next_iter = current_iter;
                 if !model.iter_next(&next_iter) {
@@ -614,8 +611,8 @@ pub fn get_max_file_name(file_name: &str, max_length: usize) -> String {
         let start_characters = 10;
         let difference = characters_in_filename - max_length;
         let second_part_start = start_characters + difference;
-        let mut string_pre = "".to_string();
-        let mut string_after = "".to_string();
+        let mut string_pre = String::new();
+        let mut string_after = String::new();
 
         for (index, character) in file_name.chars().enumerate() {
             if index < start_characters {

--- a/czkawka_gui/src/help_functions.rs
+++ b/czkawka_gui/src/help_functions.rs
@@ -253,7 +253,7 @@ pub fn get_string_from_list_store(tree_view: &TreeView, column_full_path: i32, c
     }
 }
 
-pub fn get_path_buf_from_vector_of_strings(vec_string: Vec<String>) -> Vec<PathBuf> {
+pub fn get_path_buf_from_vector_of_strings(vec_string: &[String]) -> Vec<PathBuf> {
     vec_string.iter().map(PathBuf::from).collect()
 }
 
@@ -338,7 +338,7 @@ pub fn get_dialog_box_child(dialog: &gtk4::Dialog) -> gtk4::Box {
     dialog.child().unwrap().downcast::<gtk4::Box>().unwrap()
 }
 
-pub fn change_dimension_to_krotka(dimensions: String) -> (u64, u64) {
+pub fn change_dimension_to_krotka(dimensions: &str) -> (u64, u64) {
     #[allow(clippy::single_char_pattern)]
     let vec = dimensions.split::<&str>("x").collect::<Vec<_>>();
     assert_eq!(vec.len(), 2); // 400x400 - should only have two elements, if have more, then something is not good
@@ -584,7 +584,7 @@ pub fn count_number_of_groups(tree_view: &TreeView, column_header: i32) -> u32 {
     number_of_selected_groups
 }
 
-pub fn resize_pixbuf_dimension(pixbuf: Pixbuf, requested_size: (i32, i32), interp_type: InterpType) -> Option<Pixbuf> {
+pub fn resize_pixbuf_dimension(pixbuf: &Pixbuf, requested_size: (i32, i32), interp_type: InterpType) -> Option<Pixbuf> {
     let current_ratio = pixbuf.width() as f32 / pixbuf.height() as f32;
     let mut new_size;
     match current_ratio.partial_cmp(&(requested_size.0 as f32 / requested_size.1 as f32)).unwrap() {
@@ -634,9 +634,8 @@ pub fn get_custom_label_from_widget<P: IsA<Widget>>(item: &P) -> gtk4::Label {
     while let Some(widget) = widgets_to_check.pop() {
         if let Ok(label) = widget.clone().downcast::<gtk4::Label>() {
             return label;
-        } else {
-            widgets_to_check.extend(get_all_direct_children(&widget));
         }
+        widgets_to_check.extend(get_all_direct_children(&widget));
     }
     panic!("Button doesn't have proper custom label child");
 }
@@ -647,9 +646,8 @@ pub fn get_custom_image_from_widget<P: IsA<Widget>>(item: &P) -> gtk4::Image {
     while let Some(widget) = widgets_to_check.pop() {
         if let Ok(image) = widget.clone().downcast::<gtk4::Image>() {
             return image;
-        } else {
-            widgets_to_check.extend(get_all_direct_children(&widget));
         }
+        widgets_to_check.extend(get_all_direct_children(&widget));
     }
     panic!("Button doesn't have proper custom label child");
 }

--- a/czkawka_gui/src/help_functions.rs
+++ b/czkawka_gui/src/help_functions.rs
@@ -867,8 +867,8 @@ mod test {
 
     #[test]
     fn test_change_dimension_to_krotka() {
-        assert_eq!(change_dimension_to_krotka("50x50".to_string()), (50, 50));
-        assert_eq!(change_dimension_to_krotka("6000x6000".to_string()), (6000, 6000));
+        assert_eq!(change_dimension_to_krotka("50x50"), (50, 50));
+        assert_eq!(change_dimension_to_krotka("6000x6000"), (6000, 6000));
     }
 
     #[gtk4::test]

--- a/czkawka_gui/src/initialize_gui.rs
+++ b/czkawka_gui/src/initialize_gui.rs
@@ -440,7 +440,7 @@ fn connect_event_mouse(gui_data: &GuiData) {
                 &text_view_errors,
                 &check_button_settings_show_preview,
                 &image_preview,
-                preview_path,
+                &preview_path,
                 nb_object.column_path,
                 nb_object.column_name,
             );
@@ -465,7 +465,7 @@ fn connect_event_mouse(gui_data: &GuiData) {
                 &text_view_errors,
                 &check_button_settings_show_preview,
                 &image_preview,
-                preview_path,
+                &preview_path,
                 nb_object.column_path,
                 nb_object.column_name,
             );
@@ -518,7 +518,7 @@ fn connect_event_buttons(gui_data: &GuiData) {
                 &text_view_errors,
                 &check_button_settings_show_preview,
                 &image_preview,
-                preview_path,
+                &preview_path,
                 nb_object.column_path,
                 nb_object.column_name,
             );
@@ -546,7 +546,7 @@ fn connect_event_buttons(gui_data: &GuiData) {
                 &text_view_errors,
                 &check_button_settings_show_preview_similar_images,
                 &image_preview,
-                preview_path,
+                &preview_path,
                 nb_object.column_path,
                 nb_object.column_name,
             );
@@ -559,7 +559,7 @@ fn show_preview(
     text_view_errors: &TextView,
     check_button_settings_show_preview: &CheckButton,
     image_preview: &Image,
-    preview_path: Rc<RefCell<String>>,
+    preview_path: &Rc<RefCell<String>>,
     column_path: i32,
     column_name: i32,
 ) {
@@ -669,7 +669,7 @@ fn show_preview(
                 }
             };
 
-            pixbuf = match resize_pixbuf_dimension(pixbuf, (800, 800), InterpType::Bilinear) {
+            pixbuf = match resize_pixbuf_dimension(&pixbuf, (800, 800), InterpType::Bilinear) {
                 None => {
                     add_text_to_text_view(
                         text_view_errors,

--- a/czkawka_gui/src/initialize_gui.rs
+++ b/czkawka_gui/src/initialize_gui.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::ops::Deref;
+
 use std::path::Path;
 use std::rc::Rc;
 
@@ -581,7 +581,7 @@ fn show_preview(
 
             {
                 let preview_path = preview_path.borrow();
-                let preview_path = preview_path.deref();
+                let preview_path = &*preview_path;
                 if file_name == preview_path {
                     return; // Preview is already created, no need to recreate it
                 }
@@ -697,7 +697,7 @@ fn show_preview(
         image_preview.hide();
         {
             let mut preview_path = preview_path.borrow_mut();
-            *preview_path = "".to_string();
+            *preview_path = String::new();
         }
     }
 }

--- a/czkawka_gui/src/language_functions.rs
+++ b/czkawka_gui/src/language_functions.rs
@@ -68,7 +68,7 @@ pub const LANGUAGES_ALL: [Language; 15] = [
     },
 ];
 
-pub fn get_language_from_combo_box_text(combo_box_text: String) -> Language {
+pub fn get_language_from_combo_box_text(combo_box_text: &str) -> Language {
     for lang in LANGUAGES_ALL {
         if lang.combo_box_text == combo_box_text {
             return lang;

--- a/czkawka_gui/src/main.rs
+++ b/czkawka_gui/src/main.rs
@@ -134,7 +134,7 @@ fn build_ui(application: &Application, arguments: &[OsString]) {
         &gui_data.settings,
         &gui_data.text_view_errors,
         &gui_data.scrolled_window_errors,
-        arguments.to_owned(),
+        arguments,
     );
     set_number_of_threads(gui_data.settings.scale_settings_number_of_threads.value().round() as usize);
     println!("Set thread number to {}", get_number_of_threads());

--- a/czkawka_gui/src/main.rs
+++ b/czkawka_gui/src/main.rs
@@ -65,13 +65,13 @@ mod tests;
 fn main() {
     let application = Application::new(None, ApplicationFlags::HANDLES_OPEN | ApplicationFlags::HANDLES_COMMAND_LINE);
     application.connect_command_line(move |app, cmdline| {
-        build_ui(app, cmdline.arguments());
+        build_ui(app, &cmdline.arguments());
         0
     });
     application.run_with_args(&env::args().collect::<Vec<_>>());
 }
 
-fn build_ui(application: &Application, arguments: Vec<OsString>) {
+fn build_ui(application: &Application, arguments: &[OsString]) {
     let mut gui_data: GuiData = GuiData::new_with_application(application);
 
     // Used for getting data from thread
@@ -134,7 +134,7 @@ fn build_ui(application: &Application, arguments: Vec<OsString>) {
         &gui_data.settings,
         &gui_data.text_view_errors,
         &gui_data.scrolled_window_errors,
-        arguments.clone(),
+        arguments.to_owned(),
     );
     set_number_of_threads(gui_data.settings.scale_settings_number_of_threads.value().round() as usize);
     println!("Set thread number to {}", get_number_of_threads());

--- a/czkawka_gui/src/opening_selecting_records.rs
+++ b/czkawka_gui/src/opening_selecting_records.rs
@@ -89,9 +89,9 @@ pub fn opening_double_click_function(gesture_click: &GestureClick, number_of_cli
     let nt_object = get_notebook_object_from_tree_view(&tree_view);
     if number_of_clicks == 2 {
         if gesture_click.current_button() == 1 {
-            common_open_function(&tree_view, nt_object.column_name, nt_object.column_path, OpenMode::PathAndName);
+            common_open_function(&tree_view, nt_object.column_name, nt_object.column_path, &OpenMode::PathAndName);
         } else if gesture_click.current_button() == 3 {
-            common_open_function(&tree_view, nt_object.column_name, nt_object.column_path, OpenMode::OnlyPath);
+            common_open_function(&tree_view, nt_object.column_name, nt_object.column_path, &OpenMode::OnlyPath);
         }
     }
 }
@@ -118,7 +118,7 @@ fn common_mark_function(tree_view: &gtk4::TreeView, column_selection: i32, colum
     }
 }
 
-fn common_open_function(tree_view: &gtk4::TreeView, column_name: i32, column_path: i32, opening_mode: OpenMode) {
+fn common_open_function(tree_view: &gtk4::TreeView, column_name: i32, column_path: i32, opening_mode: &OpenMode) {
     let selection = tree_view.selection();
     let (selected_rows, tree_model) = selection.selected_rows();
 
@@ -212,7 +212,7 @@ fn handle_tree_keypress_upper_directories(tree_view: &gtk4::TreeView, key_code: 
 fn handle_tree_keypress(tree_view: &gtk4::TreeView, key_code: u32, name_column: i32, path_column: i32, mark_column: i32, column_header: Option<i32>) {
     match key_code {
         KEY_ENTER => {
-            common_open_function(tree_view, name_column, path_column, OpenMode::PathAndName);
+            common_open_function(tree_view, name_column, path_column, &OpenMode::PathAndName);
         }
         KEY_SPACE => {
             common_mark_function(tree_view, mark_column, column_header);

--- a/czkawka_gui/src/saving_loading.rs
+++ b/czkawka_gui/src/saving_loading.rs
@@ -188,7 +188,7 @@ impl LoadSaveStruct {
     }
 
     // Bool, int, string
-    pub fn save_var<T: ToString>(&mut self, key: String, value: T) {
+    pub fn save_var<T: ToString>(&mut self, key: String, value: &T) {
         if self.loaded_items.contains_key(&key) {
             add_text_to_text_view(
                 &self.text_view,
@@ -523,175 +523,175 @@ pub fn save_configuration(manual_execution: bool, upper_notebook: &GuiUpperNoteb
         &upper_notebook.tree_view_excluded_directories.clone(),
         ColumnsExcludedDirectory::Path as i32,
     );
-    saving_struct.save_var(hashmap_ls.get(&LoadText::ExcludedItems).unwrap().to_string(), upper_notebook.entry_excluded_items.text());
+    saving_struct.save_var(hashmap_ls.get(&LoadText::ExcludedItems).unwrap().to_string(), &upper_notebook.entry_excluded_items.text());
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::AllowedExtensions).unwrap().to_string(),
-        upper_notebook.entry_allowed_extensions.text(),
+        &upper_notebook.entry_allowed_extensions.text(),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::MinimalFileSize).unwrap().to_string(),
-        upper_notebook.entry_general_minimal_size.text(),
+        &upper_notebook.entry_general_minimal_size.text(),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::MaximalFileSize).unwrap().to_string(),
-        upper_notebook.entry_general_maximal_size.text(),
+        &upper_notebook.entry_general_maximal_size.text(),
     );
 
     // Check buttons
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::SaveAtExit).unwrap().to_string(),
-        settings.check_button_settings_save_at_exit.is_active(),
+        &settings.check_button_settings_save_at_exit.is_active(),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::LoadAtStart).unwrap().to_string(),
-        settings.check_button_settings_load_at_start.is_active(),
+        &settings.check_button_settings_load_at_start.is_active(),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::ConfirmDeletionFiles).unwrap().to_string(),
-        settings.check_button_settings_confirm_deletion.is_active(),
+        &settings.check_button_settings_confirm_deletion.is_active(),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::ConfirmDeletionAllFilesInGroup).unwrap().to_string(),
-        settings.check_button_settings_confirm_group_deletion.is_active(),
+        &settings.check_button_settings_confirm_group_deletion.is_active(),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::ImagePreviewImage).unwrap().to_string(),
-        settings.check_button_settings_show_preview_similar_images.is_active(),
+        &settings.check_button_settings_show_preview_similar_images.is_active(),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::DuplicatePreviewImage).unwrap().to_string(),
-        settings.check_button_settings_show_preview_duplicates.is_active(),
+        &settings.check_button_settings_show_preview_duplicates.is_active(),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::HideHardLinks).unwrap().to_string(),
-        settings.check_button_settings_hide_hard_links.is_active(),
+        &settings.check_button_settings_hide_hard_links.is_active(),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::UseCache).unwrap().to_string(),
-        settings.check_button_settings_use_cache.is_active(),
+        &settings.check_button_settings_use_cache.is_active(),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::UseJsonCacheFile).unwrap().to_string(),
-        settings.check_button_settings_save_also_json.is_active(),
+        &settings.check_button_settings_save_also_json.is_active(),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::DeleteToTrash).unwrap().to_string(),
-        settings.check_button_settings_use_trash.is_active(),
+        &settings.check_button_settings_use_trash.is_active(),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::ImageDeleteOutdatedCacheEntries).unwrap().to_string(),
-        settings.check_button_settings_similar_images_delete_outdated_cache.is_active(),
+        &settings.check_button_settings_similar_images_delete_outdated_cache.is_active(),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::DuplicateDeleteOutdatedCacheEntries).unwrap().to_string(),
-        settings.check_button_settings_duplicates_delete_outdated_cache.is_active(),
+        &settings.check_button_settings_duplicates_delete_outdated_cache.is_active(),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::VideoDeleteOutdatedCacheEntries).unwrap().to_string(),
-        settings.check_button_settings_similar_videos_delete_outdated_cache.is_active(),
+        &settings.check_button_settings_similar_videos_delete_outdated_cache.is_active(),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::UsePrehashCache).unwrap().to_string(),
-        settings.check_button_duplicates_use_prehash_cache.is_active(),
+        &settings.check_button_duplicates_use_prehash_cache.is_active(),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::ShowBottomTextPanel).unwrap().to_string(),
-        settings.check_button_settings_show_text_view.is_active(),
+        &settings.check_button_settings_show_text_view.is_active(),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::GeneralIgnoreOtherFilesystems).unwrap().to_string(),
-        settings.check_button_settings_one_filesystem.is_active(),
+        &settings.check_button_settings_one_filesystem.is_active(),
     );
 
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::BrokenFilesArchive).unwrap().to_string(),
-        main_notebook.check_button_broken_files_archive.is_active(),
+        &main_notebook.check_button_broken_files_archive.is_active(),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::BrokenFilesImage).unwrap().to_string(),
-        main_notebook.check_button_broken_files_image.is_active(),
+        &main_notebook.check_button_broken_files_image.is_active(),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::BrokenFilesAudio).unwrap().to_string(),
-        main_notebook.check_button_broken_files_audio.is_active(),
+        &main_notebook.check_button_broken_files_audio.is_active(),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::BrokenFilesPdf).unwrap().to_string(),
-        main_notebook.check_button_broken_files_pdf.is_active(),
+        &main_notebook.check_button_broken_files_pdf.is_active(),
     );
 
     // Others
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::ThreadNumber).unwrap().to_string(),
-        settings.scale_settings_number_of_threads.value().round(),
+        &settings.scale_settings_number_of_threads.value().round(),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::MinimalCacheSize).unwrap().to_string(),
-        settings.entry_settings_cache_file_minimal_size.text(),
+        &settings.entry_settings_cache_file_minimal_size.text(),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::MinimalPrehashCacheSize).unwrap().to_string(),
-        settings.entry_settings_prehash_cache_file_minimal_size.text(),
+        &settings.entry_settings_prehash_cache_file_minimal_size.text(),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::Language).unwrap().to_string(),
-        get_language_from_combo_box_text(&settings.combo_box_settings_language.active_text().unwrap()).short_text,
+        &get_language_from_combo_box_text(&settings.combo_box_settings_language.active_text().unwrap()).short_text,
     );
 
     // Comboboxes main notebook
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::ComboBoxDuplicateHashType).unwrap().to_string(),
-        main_notebook.combo_box_duplicate_hash_type.active().unwrap_or(0),
+        &main_notebook.combo_box_duplicate_hash_type.active().unwrap_or(0),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::ComboBoxDuplicateCheckMethod).unwrap().to_string(),
-        main_notebook.combo_box_duplicate_check_method.active().unwrap_or(0),
+        &main_notebook.combo_box_duplicate_check_method.active().unwrap_or(0),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::ComboBoxImageResizeAlgorithm).unwrap().to_string(),
-        main_notebook.combo_box_image_resize_algorithm.active().unwrap_or(0),
+        &main_notebook.combo_box_image_resize_algorithm.active().unwrap_or(0),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::ComboBoxImageHashType).unwrap().to_string(),
-        main_notebook.combo_box_image_hash_algorithm.active().unwrap_or(0),
+        &main_notebook.combo_box_image_hash_algorithm.active().unwrap_or(0),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::ComboBoxImageHashSize).unwrap().to_string(),
-        main_notebook.combo_box_image_hash_size.active().unwrap_or(0),
+        &main_notebook.combo_box_image_hash_size.active().unwrap_or(0),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::ComboBoxBigFiles).unwrap().to_string(),
-        main_notebook.combo_box_big_files_mode.active().unwrap_or(0),
+        &main_notebook.combo_box_big_files_mode.active().unwrap_or(0),
     );
 
     // Other2
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::DuplicateNameCaseSensitive).unwrap().to_string(),
-        main_notebook.check_button_duplicate_case_sensitive_name.is_active(),
+        &main_notebook.check_button_duplicate_case_sensitive_name.is_active(),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::NumberOfBiggestFiles).unwrap().to_string(),
-        main_notebook.entry_big_files_number.text(),
+        &main_notebook.entry_big_files_number.text(),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::SimilarImagesSimilarity).unwrap().to_string(),
-        main_notebook.scale_similarity_similar_images.value(),
+        &main_notebook.scale_similarity_similar_images.value(),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::SimilarImagesIgnoreSameSize).unwrap().to_string(),
-        main_notebook.check_button_image_ignore_same_size.is_active(),
+        &main_notebook.check_button_image_ignore_same_size.is_active(),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::SimilarVideosSimilarity).unwrap().to_string(),
-        main_notebook.scale_similarity_similar_videos.value(),
+        &main_notebook.scale_similarity_similar_videos.value(),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::SimilarVideosIgnoreSameSize).unwrap().to_string(),
-        main_notebook.check_button_video_ignore_same_size.is_active(),
+        &main_notebook.check_button_video_ignore_same_size.is_active(),
     );
     saving_struct.save_var(
         hashmap_ls.get(&LoadText::MusicApproximateComparison).unwrap().to_string(),
-        main_notebook.check_button_music_approximate_comparison.is_active(),
+        &main_notebook.check_button_music_approximate_comparison.is_active(),
     );
 
     saving_struct.save_to_file(&text_view_errors);
@@ -704,7 +704,7 @@ pub fn load_configuration(
     settings: &GuiSettings,
     text_view_errors: &TextView,
     scrolled_window_errors: &ScrolledWindow,
-    arguments: Vec<OsString>,
+    arguments: &[OsString],
 ) {
     let text_view_errors = text_view_errors.clone();
 

--- a/czkawka_gui/src/saving_loading.rs
+++ b/czkawka_gui/src/saving_loading.rs
@@ -113,7 +113,7 @@ impl LoadSaveStruct {
             return if item.len() == 1 {
                 item[0].clone()
             } else if item.is_empty() {
-                "".to_string()
+                String::new()
             } else {
                 add_text_to_text_view(
                     &self.text_view,
@@ -312,7 +312,7 @@ impl LoadSaveStruct {
                 return;
             }
 
-            let mut header: String = "".to_string();
+            let mut header: String = String::new();
             let lines: Vec<String> = loaded_data.replace('\r', "").split('\n').map(String::from).collect::<Vec<String>>();
             for (index, line) in lines.iter().enumerate() {
                 let line = line.trim();
@@ -732,7 +732,7 @@ pub fn load_configuration(
         hashmap_ls.get(&LoadText::ExcludedItems).unwrap().clone(),
         upper_notebook.entry_excluded_items.text().to_string(),
     );
-    let allowed_extensions: String = loaded_entries.get_string(hashmap_ls.get(&LoadText::AllowedExtensions).unwrap().clone(), "".to_string());
+    let allowed_extensions: String = loaded_entries.get_string(hashmap_ls.get(&LoadText::AllowedExtensions).unwrap().clone(), String::new());
     let minimal_file_size: String = loaded_entries.get_integer_string(hashmap_ls.get(&LoadText::MinimalFileSize).unwrap().clone(), DEFAULT_MINIMAL_FILE_SIZE.to_string());
     let maximal_file_size: String = loaded_entries.get_integer_string(hashmap_ls.get(&LoadText::MaximalFileSize).unwrap().clone(), DEFAULT_MAXIMAL_FILE_SIZE.to_string());
 
@@ -999,7 +999,7 @@ pub fn reset_configuration(manual_clearing: bool, upper_notebook: &GuiUpperNoteb
                     add_text_to_text_view(&text_view_errors, "Failed to read current directory, setting C:\\ instead");
                     "C:\\".to_string()
                 } else {
-                    "".to_string()
+                    String::new()
                 }
             }
         };

--- a/czkawka_gui/src/taskbar_progress_dummy.rs
+++ b/czkawka_gui/src/taskbar_progress_dummy.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::upper_case_acronyms)]
+#![allow(clippy::needless_pass_by_value)]
 #![cfg(not(target_os = "windows"))]
 
 use std::convert::From;


### PR DESCRIPTION
Quite complicated command
```
cargo +1.65 clippy -- -Wclippy::pedantic -Aclippy::case_sensitive_file_extension_comparisons -Aclippy::match_wildcard_for_single_variants -Aclippy::cast_possible_wrap -Aclippy::trivially_copy_pass_by_ref -Aclippy::if_not_else -Aclippy::missing_errors_doc -Aclippy::cast_sign_loss -Aclippy::cast_possible_truncation -Aclippy::cast_lossless -Aclippy::default_trait_access -Aclippy::wildcard_imports -Aclippy::too_many_lines -Aclippy::unused_self -Aclippy::cast_precision_loss -Aclippy::missing_panics_doc -Aclippy::struct_excessive_bools -Aclippy::module_name_repetitions -Aclippy::implicit_hasher -Aclippy::inconsistent_struct_constructor
```
Looks that may very very little this change performance, since now a lot of things is passed by reference instead copying