### PR TITLE
Gtk 4.8 on Windows and console build

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: czkawka-windows-${{ github.sha }}
+          name: czkawka-windows-${{ github.sha }}-console
           path: |
             ./package
           if-no-files-found: error

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,7 +60,7 @@ jobs:
           find package -iname "*.dll" -or -iname "*.exe" -type f -exec mingw-strip {} +
 
           cd package/share
-          wget2 https://github.com/qarmin/czkawka/files/8880216/gtk4_theme.zip
+          wget2 https://github.com/qarmin/czkawka/files/10832192/gtk4_theme.zip
           unzip gtk4_theme.zip
           rm gtk4_theme.zip
           cd ../..
@@ -76,7 +76,7 @@ jobs:
   container_cli:
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/piegamesde/gtk4-cross:gtk-4.6
+      image: ghcr.io/piegamesde/gtk4-cross:gtk-4.8
     steps:
       - uses: actions/checkout@v1
       - name: Install additional dependencies
@@ -126,7 +126,7 @@ jobs:
           find package -iname "*.dll" -or -iname "*.exe" -type f -exec mingw-strip {} +
 
           cd package/share
-          wget2 https://github.com/qarmin/czkawka/files/8880216/gtk4_theme.zip
+          wget2 https://github.com/qarmin/czkawka/files/10832192/gtk4_theme.zip
           unzip gtk4_theme.zip
           rm gtk4_theme.zip
           cd ../..

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,6 +12,70 @@ jobs:
   container:
     runs-on: ubuntu-22.04
     container:
+      image: ghcr.io/piegamesde/gtk4-cross:gtk-4.8
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install additional dependencies
+        # gio is for the build script
+        run: dnf install wget2 unzip mingw64-bzip2.noarch mingw64-poppler mingw64-poppler-glib mingw32-python3 rust-gio-devel adwaita-icon-theme -y && dnf clean all -y
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: x86_64-pc-windows-gnu
+      - name: Cache ~/.cargo
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo
+          key: windows-dotcargo
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: windows-build-target
+      - name: Cross compile for Windows
+        run: |
+          #!/bin/bash
+          set -euo pipefail
+          export PKG_CONFIG_PATH=/usr/lib64/pkgconfig:/usr/share/pkgconfig:$MINGW_PREFIX/lib/pkgconfig/:/usr/x86_64-w64-mingw32/lib/pkgconfig/
+          cargo build --target=x86_64-pc-windows-gnu --release --locked
+          mkdir -p package
+          cp target/x86_64-pc-windows-gnu/release/czkawka_gui.exe package/
+          cp target/x86_64-pc-windows-gnu/release/czkawka_cli.exe package/
+      - name: Package
+        run: |
+          #!/bin/bash
+          set -euo pipefail
+          cp -t package $(pds -vv -f package/*.exe)
+          # Add gdbus which is recommended on Windows (why?)
+          cp $MINGW_PREFIX/bin/gdbus.exe package
+          # Handle the glib schema compilation as well
+          glib-compile-schemas $MINGW_PREFIX/share/glib-2.0/schemas/
+          mkdir -p package/share/glib-2.0/schemas/
+          cp -T $MINGW_PREFIX/share/glib-2.0/schemas/gschemas.compiled package/share/glib-2.0/schemas/gschemas.compiled
+          # Pixbuf stuff, in order to get SVGs (scalable icons) to load
+          mkdir -p package/lib/gdk-pixbuf-2.0
+          cp -rT $MINGW_PREFIX/lib/gdk-pixbuf-2.0 package/lib/gdk-pixbuf-2.0
+          cp -f -t package $(pds -vv -f $MINGW_PREFIX/lib/gdk-pixbuf-2.0/2.10.0/loaders/*)
+          find package -iname "*.dll" -or -iname "*.exe" -type f -exec mingw-strip {} +
+
+          cd package/share
+          wget2 https://github.com/qarmin/czkawka/files/8880216/gtk4_theme.zip
+          unzip gtk4_theme.zip
+          rm gtk4_theme.zip
+          cd ../..
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: czkawka-windows-${{ github.sha }}
+          path: |
+            ./package
+          if-no-files-found: error
+
+  # Provide option to log things to windows CLI
+  container_cli:
+    runs-on: ubuntu-22.04
+    container:
       image: ghcr.io/piegamesde/gtk4-cross:gtk-4.6
     steps:
       - uses: actions/checkout@v1
@@ -33,6 +97,8 @@ jobs:
         with:
           path: target
           key: windows-build-target
+      - name: Show console window on windows
+        run: sed -i 's|\#\!\[windows_subsystem|//#![windows_subsystem|' czkawka_gui/src/main.rs
       - name: Cross compile for Windows
         run: |
           #!/bin/bash

--- a/czkawka_gui/src/connect_things/connect_selection_of_directories.rs
+++ b/czkawka_gui/src/connect_things/connect_selection_of_directories.rs
@@ -48,7 +48,7 @@ pub fn connect_selection_of_directories(gui_data: &GuiData) {
             file_dialog_include_exclude_folder_selection.set_title(&flg!("exclude_folders_dialog_title"));
         });
     }
-    // Conect
+    // Connect
     {
         let notebook_upper = gui_data.upper_notebook.notebook_upper.clone();
         let tree_view_included_directories = gui_data.upper_notebook.tree_view_included_directories.clone();

--- a/instructions/Compilation.md
+++ b/instructions/Compilation.md
@@ -8,6 +8,7 @@ FFmpeg is not included here because it is not needed to build - it is dynamicall
 
 Support for heif images is optional and require to install libheif library.
 
+New versions of GTK fixes some bugs, so e.g. middle button selection will work only with GTK >=4.8.
 
 | Program | Min    | What for                                                                             |
 |---------|--------|--------------------------------------------------------------------------------------|
@@ -33,19 +34,14 @@ You need to install Rust via Homebrew, GTK Libraries and optionally heif library
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 brew install rustup
 rustup-init
-brew install gtk4 adwaita-icon-theme librsvg libheif
+brew install gtk4 adwaita-icon-theme librsvg libheif webp-pixbuf-loader
 ```
 
 ### Windows
 
-*Will be available in the future*
+Compiling Czkawka on Windows is possible, but due using GTK is very hard.
 
-For Linux-to-Windows cross-building instruction look at the CI.
-
-<!-- First you need to install Visual C++ components from Visual Studio installer - https://visualstudio.microsoft.com/downloads/
-Next install Rust from site https://rustup.rs/
-After that the latest GTK 4 runtime must be installed from(not available yet for GTK 4) https://github.com/tschoonj/GTK-for-Windows-Runtime-Environment-Installer/releases
--->
+In CI we use cross compilation which simplify a lot of things, so for now there is no instruction how to compile native binaries on Windows.
 
 ### Docker
 


### PR DESCRIPTION
Console build should help to find reason of strange crashes, that happens only on Windows.

Also on Windows(and mac) gtk is not pinned to certain version, so it is easy to bump version there to gtk 4.8(on mac this happens automatically via updating gtk package)

New theme - [gtk4_theme.zip](https://github.com/qarmin/czkawka/files/10832192/gtk4_theme.zip)
