### PR TITLE
Remove preview workaround in gui for webp/heif

### DIFF
--- a/czkawka_gui/src/connect_things/connect_button_compare.rs
+++ b/czkawka_gui/src/connect_things/connect_button_compare.rs
@@ -6,10 +6,6 @@ use gtk4::prelude::*;
 use gtk4::{Align, CheckButton, Image, ListStore, Orientation, ScrolledWindow, TreeIter, TreeModel, TreePath, TreeSelection, Widget};
 use image::DynamicImage;
 
-#[cfg(feature = "heif")]
-use czkawka_core::common::get_dynamic_image_from_heic;
-use czkawka_core::common::HEIC_EXTENSIONS;
-
 use crate::flg;
 use crate::gui_structs::gui_data::GuiData;
 use crate::help_functions::{
@@ -355,62 +351,15 @@ fn generate_cache_for_results(vector_with_path: Vec<(String, String, TreePath)>)
         let big_img = Image::new();
 
         let mut pixbuf = get_pixbuf_from_dynamic_image(&DynamicImage::new_rgb8(1, 1)).unwrap();
-        let name_lowercase = name.to_lowercase();
-        let is_heic = HEIC_EXTENSIONS.iter().any(|extension| name_lowercase.ends_with(extension));
-        let is_webp = name.to_lowercase().ends_with(".webp");
 
-        if is_heic || is_webp {
-            #[allow(clippy::never_loop)]
-            'czystka: loop {
-                #[cfg(feature = "heif")]
-                if is_heic {
-                    match get_dynamic_image_from_heic(&full_path) {
-                        Ok(t) => {
-                            match get_pixbuf_from_dynamic_image(&t) {
-                                Ok(t) => {
-                                    pixbuf = t;
-                                }
-                                Err(e) => {
-                                    println!("Failed to open image {full_path}, reason {e}");
-                                }
-                            };
-                        }
-                        Err(e) => {
-                            println!("Failed to open image {full_path}, reason {e}");
-                        }
-                    };
-                    break 'czystka;
-                }
-                if is_webp {
-                    match image::open(&full_path) {
-                        Ok(t) => {
-                            match get_pixbuf_from_dynamic_image(&t) {
-                                Ok(t) => {
-                                    pixbuf = t;
-                                }
-                                Err(e) => {
-                                    println!("Failed to open image {full_path}, reason {e}");
-                                }
-                            };
-                        }
-                        Err(e) => {
-                            println!("Failed to open image {full_path}, reason {e}");
-                        }
-                    };
-                    break 'czystka;
-                }
-                break 'czystka;
+        match Pixbuf::from_file(&full_path) {
+            Ok(t) => {
+                pixbuf = t;
             }
-        } else {
-            match Pixbuf::from_file(&full_path) {
-                Ok(t) => {
-                    pixbuf = t;
-                }
-                Err(e) => {
-                    println!("Failed to open image {full_path}, reason {e}");
-                }
-            };
-        }
+            Err(e) => {
+                println!("Failed to open image {full_path}, reason {e}");
+            }
+        };
 
         #[allow(clippy::never_loop)]
         loop {

--- a/czkawka_gui/src/initialize_gui.rs
+++ b/czkawka_gui/src/initialize_gui.rs
@@ -8,8 +8,6 @@ use gtk4::gdk_pixbuf::InterpType;
 use gtk4::prelude::*;
 use gtk4::{CheckButton, Image, SelectionMode, TextView, TreeView};
 
-#[cfg(feature = "heif")]
-use czkawka_core::common::get_dynamic_image_from_heic;
 use czkawka_core::common::{HEIC_EXTENSIONS, IMAGE_RS_EXTENSIONS, RAW_IMAGE_EXTENSIONS};
 use czkawka_core::similar_images::SIMILAR_VALUES;
 use czkawka_core::similar_videos::MAX_TOLERANCE;
@@ -574,85 +572,26 @@ fn show_preview(
                 }
             }
 
-            let is_heic;
-            let is_webp;
             if let Some(extension) = Path::new(&name).extension() {
                 let extension = format!(".{}", extension.to_string_lossy().to_lowercase());
-                is_heic = HEIC_EXTENSIONS.contains(&extension.as_str());
-                is_webp = ".webp" == extension;
-                if !RAW_IMAGE_EXTENSIONS.contains(&extension.as_str()) && !IMAGE_RS_EXTENSIONS.contains(&extension.as_str()) && !is_heic {
+                if !RAW_IMAGE_EXTENSIONS.contains(&extension.as_str()) && !IMAGE_RS_EXTENSIONS.contains(&extension.as_str()) && !HEIC_EXTENSIONS.contains(&extension.as_str()) {
                     break 'dir;
                 }
             } else {
                 break 'dir;
             }
-            let mut pixbuf = if is_heic || is_webp {
-                let image = if is_heic {
-                    #[cfg(feature = "heif")]
-                    match get_dynamic_image_from_heic(file_name) {
-                        Ok(t) => t,
-                        Err(e) => {
-                            add_text_to_text_view(
-                                text_view_errors,
-                                flg!(
-                                    "preview_image_opening_failure",
-                                    generate_translation_hashmap(vec![("name", file_name.to_string()), ("reason", e.to_string())])
-                                )
-                                .as_str(),
-                            );
-                            break 'dir;
-                        }
-                    }
-
-                    #[cfg(not(feature = "heif"))]
-                    panic!("")
-                } else if is_webp {
-                    match image::open(file_name) {
-                        Ok(t) => t,
-                        Err(e) => {
-                            add_text_to_text_view(
-                                text_view_errors,
-                                flg!(
-                                    "preview_image_opening_failure",
-                                    generate_translation_hashmap(vec![("name", file_name.to_string()), ("reason", e.to_string())])
-                                )
-                                .as_str(),
-                            );
-                            break 'dir;
-                        }
-                    }
-                } else {
-                    panic!("");
-                };
-
-                match get_pixbuf_from_dynamic_image(&image) {
-                    Ok(t) => t,
-                    Err(e) => {
-                        add_text_to_text_view(
-                            text_view_errors,
-                            flg!(
-                                "preview_image_opening_failure",
-                                generate_translation_hashmap(vec![("name", file_name.to_string()), ("reason", e.to_string())])
-                            )
-                            .as_str(),
-                        );
-                        break 'dir;
-                    }
-                }
-            } else {
-                match Pixbuf::from_file(file_name) {
-                    Ok(pixbuf) => pixbuf,
-                    Err(e) => {
-                        add_text_to_text_view(
-                            text_view_errors,
-                            flg!(
-                                "preview_image_opening_failure",
-                                generate_translation_hashmap(vec![("name", file_name.to_string()), ("reason", e.to_string())])
-                            )
-                            .as_str(),
-                        );
-                        break 'dir;
-                    }
+            let mut pixbuf = match Pixbuf::from_file(file_name) {
+                Ok(pixbuf) => pixbuf,
+                Err(e) => {
+                    add_text_to_text_view(
+                        text_view_errors,
+                        flg!(
+                            "preview_image_opening_failure",
+                            generate_translation_hashmap(vec![("name", file_name.to_string()), ("reason", e.to_string())])
+                        )
+                        .as_str(),
+                    );
+                    break 'dir;
                 }
             };
 

--- a/instructions/Compilation.md
+++ b/instructions/Compilation.md
@@ -6,6 +6,8 @@ If you only want the terminal version without a GUI, just skip all the packages 
 
 FFmpeg is not included here because it is not needed to build - it is dynamically loaded.
 
+Webp and heif pixbuf are needed to show preview of image files with this extensions.
+
 Support for heif images is optional and require to install libheif library.
 
 
@@ -18,7 +20,7 @@ Support for heif images is optional and require to install libheif library.
 ```shell
 sudo apt install -y curl git build-essential # Needed by Rust update tool
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh # Download the latest stable Rust
-sudo apt install -y libgtk-4-dev
+sudo apt install -y libgtk-4-dev webp-pixbuf-loader heif-gdk-pixbuf
 ```
 
 #### Fedora / CentOS / Rocky Linux
@@ -33,7 +35,7 @@ You need to install Rust via Homebrew, GTK Libraries and optionally heif library
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 brew install rustup
 rustup-init
-brew install gtk4 adwaita-icon-theme librsvg libheif
+brew install gtk4 adwaita-icon-theme librsvg libheif webp-pixbuf-loader
 ```
 
 ### Windows


### PR DESCRIPTION
This adds new dependencies - `heif-gdk-pixbuf` and `webp-pixbuf-loader` which are used to show previews in gui(someday, this should be integral part of gdk-pixbuf)

This speedup loading preview of files with such extensions.

I thought it would be possible to get rid of libheif completely, but it turns out that it is still used when checking similar images

The only blocker is now missing heif-pixbuf in homebrew repo - https://github.com/strukturag/libheif/blob/master/gdk-pixbuf/pixbufloader-heif.c