### PR TITLE
fix image for docker

### DIFF
--- a/misc/docker/Dockerfile
+++ b/misc/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11
+FROM ubuntu:22.04
 
 # curl is needed by Rust update tool
 RUN apt-get update \


### PR DESCRIPTION
It failed with Debian:

```bash
$ docker build ./misc/docker/ --tag cargo-gtk
Sending build context to Docker daemon  2.048kB
Step 1/5 : FROM debian:11
11: Pulling from library/debian
32fb02163b6b: Pull complete 
Digest: sha256:f81bf5a8b57d6aa1824e4edb9aea6bd5ef6240bcc7d86f303f197a2eb77c430f
Status: Downloaded newer image for debian:11
 ---> 72b624312240
Step 2/5 : RUN apt-get update     && apt-get install -y curl build-essential libgtk-4-dev     && apt-get clean ; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 ---> Running in c5f2e5d3ef7f
[…]
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package libgtk-4-dev
Removing intermediate container c5f2e5d3ef7f
 ---> 9fed4b11d4d3
Step 3/5 : RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y # Download the latest stable Rust
 ---> Running in ad09ad663498
/bin/sh: 1: curl: not found
Removing intermediate container ad09ad663498
 ---> 7601e0ae59b0
Step 4/5 : ENV PATH="/root/.cargo/bin:${PATH}"
 ---> Running in eb8db584e06c
Removing intermediate container eb8db584e06c
 ---> c87fe4013ba5
Step 5/5 : RUN cargo --version
 ---> Running in 0a676489e10b
/bin/sh: 1: cargo: not found
The command '/bin/sh -c cargo --version' returned a non-zero code: 127
```

Did Debian removed `libgtk-4-dev` from the repositories?

Ubuntu may require more disk storage than Debian but it will fix the build.