### PR TITLE
Fix Snap build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,7 @@ description: |
 grade: stable # must be 'stable' to release into candidate/stable channels
 confinement: strict # use 'strict' once you have the right plugs and slots
 compression: lzo
-icon: gui/czkawka.png
+
 license: MIT
 website: https://github.com/qarmin/czkawka
 issues: https://github.com/qarmin/czkawka/issues

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,12 +10,12 @@ confinement: strict # use 'strict' once you have the right plugs and slots
 compression: lzo
 
 parts:
-  user-part:
-    source: .
-    plugin: rust
-    build-packages: [cargo, rustc]
+  rust-deps:
+    plugin: nil
+    override-pull: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain 1.68.2
   czkawka:
     plugin: rust
+    after: [ rust-deps ]
     source: https://github.com/qarmin/czkawka.git
     build-packages:
       - curl

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,6 +8,11 @@ description: |
 grade: stable # must be 'stable' to release into candidate/stable channels
 confinement: strict # use 'strict' once you have the right plugs and slots
 compression: lzo
+icon: gui/czkawka.png
+license: MIT
+website: https://github.com/qarmin/czkawka
+issues: https://github.com/qarmin/czkawka/issues
+donation: https://github.com/sponsors/qarmin
 
 parts:
   rust-deps:


### PR DESCRIPTION
Rustc & cargo are now installed using the script provided by rust-lang.org. Their versions were bumped to 1.68.2. The (outdated) versions bundled to core22 are not used anymore.

Solution copied from https://forum.snapcraft.io/t/correct-snapcraft-syntax-for-rust-based-snap-on-core22/30947/5

Fixes https://github.com/qarmin/czkawka/issues/859