### PR TITLE
Exclude container stuff by default on Linux

### DIFF
--- a/czkawka_core/src/common_items.rs
+++ b/czkawka_core/src/common_items.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use crate::common::Common;
 
 #[cfg(target_family = "unix")]
-pub const DEFAULT_EXCLUDED_ITEMS: &str = "*/.git/*,*/node_modules/*,*/lost+found/*,*/Trash/*,*/.Trash-*/*,*/snap/*,/home/*/.cache/*";
+pub const DEFAULT_EXCLUDED_ITEMS: &str = "*/.git/*,*/node_modules/*,*/lost+found/*,*/Trash/*,*/.Trash-*/*,*/snap/*,/home/*/.cache/*,*/home/*/.local/share/containers/*";
 #[cfg(not(target_family = "unix"))]
 pub const DEFAULT_EXCLUDED_ITEMS: &str = "*\\.git\\*,*\\node_modules\\*,*\\lost+found\\*,*:\\windows\\*,*:\\$RECYCLE.BIN\\*,*:\\$SysReset\\*,*:\\System Volume Information\\*,*:\\OneDriveTemp\\*,*:\\hiberfil.sys,*:\\pagefile.sys,*:\\swapfile.sys";
 


### PR DESCRIPTION
STR:
1. Install/use podman or even better, Fedora Silverblue, where this is built-in.

You will see a lot of duplicates…

![image](https://github.com/qarmin/czkawka/assets/11966684/ad0f0c22-4a84-45e4-b037-8c0085183182)


This should fix it. Note I used `*/home` to allow `/var/home` where Fedora Silverblue mounts it's homedir (it is symbolic-linked to `/home`, but I don't know how this app handles that.)