### PR TITLE
Improve bug reporting template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,17 +7,32 @@ assignees: ''
 
 ---
 
-**Desktop (please complete the following information):**
+**Bug Description**
+...
 
-- Czkawka version<!--  e.g. 6.1.0 cli/gui -->:
-- OS version<!--  e.g Ubuntu 22.04, Windows 11, Mac 15.1 ARM -->:
-- Terminal output[optional]:
+**Steps to reproduce:**
+<!-- Please describe what you expected to see and what you saw instead. Also include screenshots or screencasts if needed. -->
+
+**Terminal output** (optional):
+
+<details>
+<summary>Debug log</summary>
+
+```
 
 <!--
 Add terminal output only if needed - if there are some errors or warnings or you have performance/freeze issues.  
 Very helpful in this situation will be logs from czkawka run with RUST_LOG environment variable set e.g. 
-`RUST_LOG=debug ./czkawka` which will print more detailed info about executed function
+`RUST_LOG=debug ./czkawka` or `flatpak run --env=RUST_LOG=debug com.github.qarmin.czkawka` if you use flatpak, which will print more detailed info about executed function.
 -->
 
-**Bug Description**
-...
+```
+
+</details>
+
+**System**
+
+- Czkawka version<!--  e.g. 6.1.0 cli/gui -->:
+- OS version<!--  e.g Ubuntu 22.04, Windows 11, Mac 15.1 ARM -->:
+
+<!-- If you use flatpak, please include the result of `flatpak info com.github.qarmin.czkawka`. -->


### PR DESCRIPTION
I tried some adjustments to the bug report template to include more details and structure the information in a better way.

Let me know what you think. I personally e.g. also like headings (`##`) more than this `**let's make this bold as a heading:**` thing, but I used/tried to keep it similar to your style.