### PR TITLE
Support hard links for similar images and videos with `-L`

### DIFF
--- a/czkawka_cli/src/commands.rs
+++ b/czkawka_cli/src/commands.rs
@@ -212,6 +212,8 @@ pub struct SimilarImagesArgs {
     #[clap(flatten)]
     pub delete_method: DMethod,
     #[clap(flatten)]
+    pub allow_hard_links: AllowHardLinks,
+    #[clap(flatten)]
     pub dry_run: DryRun,
     #[clap(
         short = 'g',
@@ -354,6 +356,8 @@ pub struct SimilarVideosArgs {
     pub common_cli_items: CommonCliItems,
     #[clap(flatten)]
     pub delete_method: DMethod,
+    #[clap(flatten)]
+    pub allow_hard_links: AllowHardLinks,
     #[clap(flatten)]
     pub dry_run: DryRun,
     #[clap(

--- a/czkawka_cli/src/main.rs
+++ b/czkawka_cli/src/main.rs
@@ -185,6 +185,7 @@ fn similar_images(similar_images: SimilarImagesArgs, stop_receiver: &Receiver<()
         hash_size,
         delete_method,
         dry_run,
+        allow_hard_links,
     } = similar_images;
 
     let mut item = SimilarImages::new();
@@ -198,6 +199,7 @@ fn similar_images(similar_images: SimilarImagesArgs, stop_receiver: &Receiver<()
     item.set_delete_method(delete_method.delete_method);
     item.set_dry_run(dry_run.dry_run);
     item.set_similarity(return_similarity_from_similarity_preset(&similarity_preset, hash_size));
+    item.set_ignore_hard_links(!allow_hard_links.allow_hard_links);
 
     item.find_similar_images(Some(stop_receiver), Some(progress_sender));
 
@@ -272,6 +274,7 @@ fn similar_videos(similar_videos: SimilarVideosArgs, stop_receiver: &Receiver<()
         maximal_file_size,
         delete_method,
         dry_run,
+        allow_hard_links,
     } = similar_videos;
 
     let mut item = SimilarVideos::new();
@@ -282,6 +285,7 @@ fn similar_videos(similar_videos: SimilarVideosArgs, stop_receiver: &Receiver<()
     item.set_tolerance(tolerance);
     item.set_delete_method(delete_method.delete_method);
     item.set_dry_run(dry_run.dry_run);
+    item.set_ignore_hard_links(!allow_hard_links.allow_hard_links);
 
     item.find_similar_videos(Some(stop_receiver), Some(progress_sender));
 


### PR DESCRIPTION
This ignores matches for files that have the same inode.

This only works on Unix.