### PR TITLE
Add add text too small to read on windows workaround link (+small readme fix)

### DIFF
--- a/czkawka_gui/README.md
+++ b/czkawka_gui/README.md
@@ -64,6 +64,7 @@ There exists mingw recipe which you can try to convert for your purposes - https
 Not all available features other components implemented here, so this is list of  limitations:
 - Snap versions not allows to use similar videos feature
 - Windows version not supports heif and webp files with prebuild binaries
+- On Windows, text may appear very small on high resolution displays, a workaround is to override DPI scaling for this app, see [#867#issuecomment-1416761308](https://github.com/qarmin/czkawka/issues/863#issuecomment-1416761308)
 - Prebuild binaries for mac arm not exists
 
 ## License

--- a/czkawka_gui/README.md
+++ b/czkawka_gui/README.md
@@ -64,7 +64,9 @@ There exists mingw recipe which you can try to convert for your purposes - https
 Not all available features other components implemented here, so this is list of  limitations:
 - Snap versions not allows to use similar videos feature
 - On Windows, prebuild binaries do not support heif and webp files
-- On Windows, text may appear very small on high resolution displays, a workaround is to override DPI scaling for this app, see [#867#issuecomment-1416761308](https://github.com/qarmin/czkawka/issues/863#issuecomment-1416761308)
+- On Windows, text may appear very small on high resolution displays, a solution is to manually change DPI scaling for this app, see :
+  - recommended fix: [#787#issuecomment-1292253437](https://github.com/qarmin/czkawka/issues/787#issuecomment-1292253437) (modify gtk.css),
+  - or this workaround: [#867#issuecomment-1416761308](https://github.com/qarmin/czkawka/issues/863#issuecomment-1416761308) (modify windows DPI settings for this app (this works too but the text is a bit blurry)).
 - Prebuild binaries for mac arm not exists
 
 ## License

--- a/czkawka_gui/README.md
+++ b/czkawka_gui/README.md
@@ -63,7 +63,7 @@ There exists mingw recipe which you can try to convert for your purposes - https
 ## Limitations
 Not all available features other components implemented here, so this is list of  limitations:
 - Snap versions not allows to use similar videos feature
-- Windows version not supports heif and webp files with prebuild binaries
+- On Windows, prebuild binaries do not support heif and webp files
 - On Windows, text may appear very small on high resolution displays, a workaround is to override DPI scaling for this app, see [#867#issuecomment-1416761308](https://github.com/qarmin/czkawka/issues/863#issuecomment-1416761308)
 - Prebuild binaries for mac arm not exists
 


### PR DESCRIPTION
credit goes to @Erijoda in https://github.com/qarmin/czkawka/issues/787#issuecomment-1292253437 and @linnik in https://github.com/qarmin/czkawka/issues/863#issuecomment-1416761308 for publicly providing the solutions beforehand, this just implements the aforementionned.

also adding a small readme fix at the same time.