### PR TITLE
Add new delete methods based on size

### DIFF
--- a/ci_tester/src/main.rs
+++ b/ci_tester/src/main.rs
@@ -43,18 +43,34 @@ fn main() {
         test_remove_duplicates_one_newest();
         test_remove_duplicates_all_expect_newest();
         test_remove_duplicates_all_expect_oldest();
+        test_remove_duplicates_one_smallest();
+        test_remove_duplicates_one_biggest();
+        test_remove_duplicates_all_expect_biggest();
+        test_remove_duplicates_all_expect_smallest();
         test_remove_same_music_tags_one_oldest();
         test_remove_same_music_tags_one_newest();
         test_remove_same_music_tags_all_expect_oldest();
         test_remove_same_music_tags_all_expect_newest();
+        test_remove_same_music_tags_one_smallest();
+        test_remove_same_music_tags_one_biggest();
+        test_remove_same_music_tags_all_expect_biggest();
+        test_remove_same_music_tags_all_expect_smallest();
         test_remove_same_music_content_one_oldest();
         test_remove_same_music_content_all_expect_oldest();
         test_remove_same_music_content_one_newest();
         test_remove_same_music_content_all_expect_newest();
+        test_remove_same_music_content_one_smallest();
+        test_remove_same_music_content_one_biggest();
+        test_remove_same_music_content_all_expect_biggest();
+        test_remove_same_music_content_all_expect_smallest();
         test_remove_videos_one_oldest();
         test_remove_videos_one_newest();
         test_remove_videos_all_expect_oldest();
         test_remove_videos_all_expect_newest();
+        test_remove_videos_one_smallest();
+        test_remove_videos_one_biggest();
+        test_remove_videos_all_expect_biggest();
+        test_remove_videos_all_expect_smallest();
     }
 
     println!("Completed checking");
@@ -81,6 +97,32 @@ fn test_remove_videos_all_expect_newest() {
     run_test(
         &["video", "-d", "TestFiles", "-D", "AEN"],
         vec!["Videos/V1.mp4", "Videos/V2.mp4", "Videos/V3.webm"],
+        vec![],
+        vec![],
+    );
+}
+fn test_remove_videos_one_smallest() {
+    info!("test_remove_videos_one_smallest");
+    run_test(&["video", "-d", "TestFiles", "-D", "OS"], vec!["Videos/V2.mp4"], vec![], vec![]);
+}
+fn test_remove_videos_one_biggest() {
+    info!("test_remove_videos_one_biggest");
+    run_test(&["video", "-d", "TestFiles", "-D", "OB"], vec!["Videos/V3.webm"], vec![], vec![]);
+}
+fn test_remove_videos_all_expect_smallest() {
+    info!("test_remove_videos_all_expect_smallest");
+    run_test(
+        &["video", "-d", "TestFiles", "-D", "AES"],
+        vec!["Videos/V1.mp4", "Videos/V3.webm", "Videos/V5.mp4"],
+        vec![],
+        vec![],
+    );
+}
+fn test_remove_videos_all_expect_biggest() {
+    info!("test_remove_videos_all_expect_biggest");
+    run_test(
+        &["video", "-d", "TestFiles", "-D", "AEB"],
+        vec!["Videos/V1.mp4", "Videos/V2.mp4", "Videos/V5.mp4"],
         vec![],
         vec![],
     );
@@ -124,6 +166,44 @@ fn test_remove_same_music_content_one_oldest() {
         vec![],
     );
 }
+fn test_remove_same_music_content_one_biggest() {
+    info!("test_remove_same_music_content_one_biggest");
+    run_test(
+        &["music", "-d", "TestFiles", "-s", "CONTENT", "-l", "2.0", "-D", "OB"],
+        vec!["Music/M3.flac"],
+        vec![],
+        vec![],
+    );
+}
+fn test_remove_same_music_content_all_expect_biggest() {
+    info!("test_remove_same_music_content_all_expect_biggest");
+    run_test(
+        &["music", "-d", "TestFiles", "-s", "CONTENT", "-l", "2.0", "-D", "AEB"],
+        vec!["Music/M1.mp3", "Music/M2.mp3", "Music/M5.mp3"],
+        vec![],
+        vec![],
+    );
+}
+
+fn test_remove_same_music_content_all_expect_smallest() {
+    info!("test_remove_same_music_content_all_expect_smallest");
+    run_test(
+        &["music", "-d", "TestFiles", "-s", "CONTENT", "-l", "2.0", "-D", "AES"],
+        vec!["Music/M1.mp3", "Music/M3.flac", "Music/M5.mp3"],
+        vec![],
+        vec![],
+    );
+}
+
+fn test_remove_same_music_content_one_smallest() {
+    info!("test_remove_same_music_content_one_smallest");
+    run_test(
+        &["music", "-d", "TestFiles", "-s", "CONTENT", "-l", "2.0", "-D", "OS"],
+        vec!["Music/M2.mp3"],
+        vec![],
+        vec![],
+    );
+}
 fn test_remove_same_music_tags_one_oldest() {
     info!("test_remove_same_music_one_oldest");
     run_test(&["music", "-d", "TestFiles", "-D", "OO"], vec!["Music/M5.mp3"], vec![], vec![]);
@@ -146,6 +226,32 @@ fn test_remove_same_music_tags_all_expect_newest() {
     run_test(
         &["music", "-d", "TestFiles", "-D", "AEN"],
         vec!["Music/M1.mp3", "Music/M3.flac", "Music/M5.mp3"],
+        vec![],
+        vec![],
+    );
+}
+fn test_remove_same_music_tags_one_smallest() {
+    info!("test_remove_same_music_one_smallest");
+    run_test(&["music", "-d", "TestFiles", "-D", "OS"], vec!["Music/M1.mp3"], vec![], vec![]);
+}
+fn test_remove_same_music_tags_one_biggest() {
+    info!("test_remove_same_music_one_biggest");
+    run_test(&["music", "-d", "TestFiles", "-D", "OB"], vec!["Music/M3.flac"], vec![], vec![]);
+}
+fn test_remove_same_music_tags_all_expect_smallest() {
+    info!("test_remove_same_music_all_expect_smallest");
+    run_test(
+        &["music", "-d", "TestFiles", "-D", "AES"],
+        vec!["Music/M2.mp3", "Music/M3.flac", "Music/M5.mp3"],
+        vec![],
+        vec![],
+    );
+}
+fn test_remove_same_music_tags_all_expect_biggest() {
+    info!("test_remove_same_music_all_expect_biggest");
+    run_test(
+        &["music", "-d", "TestFiles", "-D", "AEB"],
+        vec!["Music/M1.mp3", "Music/M2.mp3", "Music/M5.mp3"],
         vec![],
         vec![],
     );
@@ -183,6 +289,43 @@ fn test_remove_duplicates_one_oldest() {
     run_test(
         &["dup", "-d", "TestFiles", "-D", "OO"],
         vec!["Images/A2.jpg", "Music/M5.mp3", "Videos/V2.mp4"],
+        vec![],
+        vec![],
+    );
+}
+fn test_remove_duplicates_all_expect_smallest() {
+    info!("test_remove_duplicates_all_expect_smallest");
+    run_test(
+        &["dup", "-d", "TestFiles", "-D", "AES"],
+        vec!["Images/A2.jpg", "Images/A5.jpg", "Music/M2.mp3", "Music/M5.mp3", "Videos/V2.mp4", "Videos/V5.mp4"],
+        vec![],
+        vec![],
+    );
+}
+fn test_remove_duplicates_all_expect_biggest() {
+    info!("test_remove_duplicates_all_expect_biggest");
+    run_test(
+        &["dup", "-d", "TestFiles", "-D", "AEN"],
+        vec!["Images/A2.jpg", "Images/A5.jpg", "Music/M1.mp3", "Music/M5.mp3", "Videos/V1.mp4", "Videos/V2.mp4"],
+        vec![],
+        vec![],
+    );
+}
+
+fn test_remove_duplicates_one_biggest() {
+    info!("test_remove_duplicates_one_biggest");
+    run_test(
+        &["dup", "-d", "TestFiles", "-D", "ON"],
+        vec!["Images/A1.jpg", "Music/M2.mp3", "Videos/V5.mp4"],
+        vec![],
+        vec![],
+    );
+}
+fn test_remove_duplicates_one_smallest() {
+    info!("test_remove_duplicates_one_smallest");
+    run_test(
+        &["dup", "-d", "TestFiles", "-D", "OS"],
+        vec!["Images/A1.jpg", "Music/M1.mp3", "Videos/V1.mp4"],
         vec![],
         vec![],
     );

--- a/czkawka_cli/src/commands.rs
+++ b/czkawka_cli/src/commands.rs
@@ -450,8 +450,8 @@ pub struct DMethod {
         long,
         default_value = "NONE",
         value_parser = parse_delete_method,
-        help = "Delete method (AEN, AEO, ON, OO, HARD)",
-        long_help = "Methods to delete the files.\nAEN - All files except the newest,\nAEO - All files except the oldest,\nON - Only 1 file, the newest,\nOO - Only 1 file, the oldest\nHARD - create hard link\nNONE - not delete files"
+        help = "Delete method (AEN, AEO, ON, OO, AEB, AES, OE, OS, HARD)",
+        long_help = "Methods to delete the files.\nAEN - All files except the newest,\nAEO - All files except the oldest,\nON - Only 1 file, the newest,\nOO - Only 1 file, the oldest\nAEB - All files except the biggest,\nAES - All files except the smallest,\nOB - Only 1 file, the biggest,\nOS - Only 1 file, the smallest\nHARD - create hard link\nNONE - not delete files"
     )]
     pub delete_method: DeleteMethod,
 }
@@ -568,7 +568,11 @@ fn parse_delete_method(src: &str) -> Result<DeleteMethod, &'static str> {
         "hard" => Ok(DeleteMethod::HardLink),
         "on" => Ok(DeleteMethod::OneNewest),
         "oo" => Ok(DeleteMethod::OneOldest),
-        _ => Err("Couldn't parse the delete method (allowed: AEN, AEO, ON, OO, HARD)"),
+        "aeb" => Ok(DeleteMethod::AllExceptBiggest),
+        "aes" => Ok(DeleteMethod::AllExceptSmallest),
+        "ob" => Ok(DeleteMethod::OneBiggest),
+        "os" => Ok(DeleteMethod::OneSmallest),
+        _ => Err("Couldn't parse the delete method (allowed: AEN, AEO, ON, OO, HARD, AEB, AES, OB, OS)"),
     }
 }
 

--- a/czkawka_core/src/common.rs
+++ b/czkawka_core/src/common.rs
@@ -451,8 +451,11 @@ where
             let mut all_values = (*values).clone();
             let len = all_values.len();
 
-            // Sorted from oldest to newest - from smallest value to bigger
-            all_values.sort_unstable_by_key(ResultEntry::get_modified_date);
+            // Sorted from smallest to biggest or oldest to newest
+            all_values.sort_unstable_by_key(match delete_method {
+                DeleteMethod::AllExceptBiggest | DeleteMethod::AllExceptSmallest | DeleteMethod::OneBiggest | DeleteMethod::OneSmallest => ResultEntry::get_size,
+                _ => ResultEntry::get_modified_date,
+            });
 
             if delete_method == &DeleteMethod::HardLink {
                 let original_file = &all_values[0];
@@ -488,10 +491,10 @@ where
 
             let items = match delete_method {
                 DeleteMethod::Delete => &all_values,
-                DeleteMethod::AllExceptNewest => &all_values[..(len - 1)],
-                DeleteMethod::AllExceptOldest => &all_values[1..],
-                DeleteMethod::OneOldest => &all_values[..1],
-                DeleteMethod::OneNewest => &all_values[(len - 1)..],
+                DeleteMethod::AllExceptNewest | DeleteMethod::AllExceptBiggest => &all_values[..(len - 1)],
+                DeleteMethod::AllExceptOldest | DeleteMethod::AllExceptSmallest => &all_values[1..],
+                DeleteMethod::OneOldest | DeleteMethod::OneSmallest => &all_values[..1],
+                DeleteMethod::OneNewest | DeleteMethod::OneBiggest => &all_values[(len - 1)..],
                 DeleteMethod::HardLink | DeleteMethod::None => unreachable!("HardLink and None should be handled before"),
             };
 

--- a/czkawka_core/src/common_tool.rs
+++ b/czkawka_core/src/common_tool.rs
@@ -35,6 +35,10 @@ pub enum DeleteMethod {
     OneOldest,
     OneNewest,
     HardLink,
+    AllExceptBiggest,
+    AllExceptSmallest,
+    OneBiggest,
+    OneSmallest,
 }
 
 impl CommonToolData {


### PR DESCRIPTION
This adds 4 new delete methods:

- AEB: all except biggest
- AES: all except smallest
- OB: one biggest
- OS: one smallest

From a quick look at the issues it should implement #1118