### PR TITLE
doc: add link to Dockerized version

### DIFF
--- a/czkawka_gui/README.md
+++ b/czkawka_gui/README.md
@@ -10,6 +10,8 @@ Requirements depend on your platform.
 
 Prebuilt binaries are available here - https://github.com/qarmin/czkawka/releases/
 
+A Dockerized version, that can be accessed through a web browser or a VNC client, is available here - https://github.com/jlesage/docker-czkawka
+
 ### Linux
 
 #### Prebuild binaries


### PR DESCRIPTION
This is great to run the GUI version, it works on a headless server too.