### PR TITLE
Print error to stdout if reading a heic image fails

### DIFF
--- a/czkawka_core/src/similar_images.rs
+++ b/czkawka_core/src/similar_images.rs
@@ -355,7 +355,8 @@ impl SimilarImages {
             {
                 img = match get_dynamic_image_from_heic(&file_entry.path.to_string_lossy()) {
                     Ok(t) => t,
-                    Err(_) => {
+                    Err(e) => {
+                        println!("error reading {}: {}", file_entry.path.display(), e);
                         return;
                     }
                 };


### PR DESCRIPTION
I tried to de-duplicate similar heic images, but unfortunately they were skipped without any indication of an error. Printing the error to the console helps users resolving the error.