### PR TITLE
Use static runtime, make zsync file and use zstd compression

### DIFF
--- a/.github/workflows/linux_gui.yml
+++ b/.github/workflows/linux_gui.yml
@@ -135,18 +135,29 @@ jobs:
           pwd
           wget -c "https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh"
           wget -c "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
+          wget -c "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
           chmod +x linuxdeploy-plugin-gtk.sh
           chmod +x linuxdeploy-x86_64.AppImage
+          chmod +x appimagetool-x86_64.AppImage
           mkdir -p AppDir/usr/bin
           pwd
           cp target/release/czkawka_gui AppDir/usr/bin
-          ./linuxdeploy-x86_64.AppImage --appdir AppDir --plugin gtk --output appimage --icon-file data/icons/com.github.qarmin.czkawka.svg --desktop-file data/com.github.qarmin.czkawka.desktop
+          ./linuxdeploy-x86_64.AppImage --appdir AppDir --plugin gtk --icon-file data/icons/com.github.qarmin.czkawka.svg --desktop-file data/com.github.qarmin.czkawka.desktop
+          ./appimagetool --comp zstd --mksquashfs-opt -Xcompression-level --mksquashfs-opt 20 \
+            -u "gh-releases-zsync|$GITHUB_REPOSITORY_OWNER|czkawka|latest|*.AppImage.zsync" \
+            ./AppDir
 
       - name: Store Linux Appimage GUI
         uses: actions/upload-artifact@v4
         with:
           name: czkawka_gui-appimage-${{ runner.os }}-${{ matrix.toolchain }}
           path: Czkawka*.AppImage
+
+      - name: Store Linux Appimage GUI Zsync
+        uses: actions/upload-artifact@v4
+        with:
+          name: czkawka_gui-appimage-${{ runner.os }}-${{ matrix.toolchain }}.zsync
+          path: Czkawka*.AppImage.zsync
 
       - name: Minimal AppImage
         run: |


### PR DESCRIPTION
These changes get rid of the libfuse2 dependency and also result in a slightly smaller AppImage that also starts up faster.

Fixes #1347 

Adding the zsync files allows for delta updates with [AppImageUpdate](https://github.com/AppImageCommunity/AppImageUpdate)

Note that this will only work for the "alternative" AppImage, if you want the other appimage to get updates I'm not sure if it is possible to tell pkg2appimage to not create the appimage, it likely means extracting the appimage and rerunning it with appimagetool, it also means that the zsync info in both appimages has to change to prevent conflicts during updates, as right now appimageupdate will look for a `*.AppImage.zsync` when updating the AppImage, which as long as there is only one zsync file it isn't a problem.