### PR TITLE
increase hashing buffer size

### DIFF
--- a/czkawka_core/src/duplicate.rs
+++ b/czkawka_core/src/duplicate.rs
@@ -777,7 +777,7 @@ impl DuplicateFinder {
             .map(|(size, vec_file_entry)| {
                 let mut hashmap_with_hash: BTreeMap<String, Vec<DuplicateEntry>> = Default::default();
                 let mut errors: Vec<String> = Vec::new();
-                let mut buffer = [0u8; 1024 * 16];
+                let mut buffer = vec![0u8; 1024 * 1024 * 16];
 
                 atomic_counter.fetch_add(vec_file_entry.len(), Ordering::Relaxed);
                 for mut file_entry in vec_file_entry {


### PR DESCRIPTION
Hi guys, thanks for your project.
Full hashing was taking a lot of time on my HDD, and task manager reported read speed was kinda low, ~25MB/s so I suspected the small buffer might cause it.

Tested with 16MB buffer read speed increased to ~150MB/s which is what I would expect.
20 gb of duplicates is scanned in 3 minutes vs 13 on current release (without cache).

Interestingly if I run the same test on an NVMe then there's almost no difference: 17s vs 18s, ~2.4GB/s read speed. 
I guess windows is reading small blocks from the drive without doing a lot of readahead. Increasing the buffer is kind of a simple fix. 