### PR TITLE
fix: czkawka-gui window icon under Wayland

### DIFF
--- a/czkawka_gui/src/main.rs
+++ b/czkawka_gui/src/main.rs
@@ -69,6 +69,10 @@ mod tests;
 
 fn main() {
     let application = Application::new(None::<String>, ApplicationFlags::HANDLES_OPEN | ApplicationFlags::HANDLES_COMMAND_LINE);
+
+    #[cfg(target_os = "linux")]
+    glib::set_prgname(Some("com.github.qarmin.czkawka"));
+
     application.connect_command_line(move |app, cmdline| {
         setup_logger(false);
         print_version_mode();


### PR DESCRIPTION
Currently, when running czkawka-gui under Wayland, the window icon will fallback to default Wayland icon. Set application ID to fix this problem.