### PR TITLE
czkawka_gui: Show plural 'files'/'folders' in progress popup

### DIFF
--- a/czkawka_gui/i18n/en/czkawka_gui.ftl
+++ b/czkawka_gui/i18n/en/czkawka_gui.ftl
@@ -477,7 +477,10 @@ compute_found_broken_files = Found { $number_files } broken files
 compute_found_bad_extensions = Found { $number_files } files with invalid extensions
 
 # Progress window
-progress_scanning_general_file = Scanning {$file_number} file
+progress_scanning_general_file = {$file_number -> 
+        [one] Scanning {$file_number} file
+       *[other] Scanning {$file_number} files
+}
 
 progress_scanning_extension_of_files = Checking extension of {$file_checked}/{$all_files} file
 progress_scanning_broken_files = Checking {$file_checked}/{$all_files} file
@@ -488,7 +491,10 @@ progress_scanning_music_tags_end = Comparing tags of {$file_checked}/{$all_files
 progress_scanning_music_tags = Reading tags of {$file_checked}/{$all_files} music file
 progress_scanning_music_content_end = Comparing fingerprint of {$file_checked}/{$all_files} music file
 progress_scanning_music_content = Calculating fingerprint of {$file_checked}/{$all_files} music file
-progress_scanning_empty_folders = Scanning {$folder_number} folder
+progress_scanning_empty_folders = {$folder_number -> 
+        [one] Scanning {$folder_number} folder
+       *[other] Scanning {$folder_number} folders
+}
 progress_scanning_size = Scanning size of {$file_number} file
 progress_scanning_size_name = Scanning name and size of {$file_number} file
 progress_scanning_name = Scanning name of {$file_number} file


### PR DESCRIPTION
Currently, the progress popup shows "Scanning X file/folder", which is grammatically incorrect when X is plural. This pull request fixes that by showing "files"/folders" instead when there's more than 1.

Before:
![image](https://github.com/user-attachments/assets/d8e20a3a-f65f-4f12-bc92-2bd2ad4c52e2)
After:
![image](https://github.com/user-attachments/assets/3e358fd1-fec8-4c16-9f2b-e66a0df3267b)

(Note: First screenshot is from someone else, that's why the titlebar looks different)