### PR TITLE
Allow to disable similar videos, which are broken on 32 bit os

### DIFF
--- a/czkawka_cli/Cargo.toml
+++ b/czkawka_cli/Cargo.toml
@@ -23,8 +23,9 @@ ctrlc = { version = "3.4", features = ["termination"] }
 humansize = "2.1"
 
 [features]
-default = ["fast_image_resize"]
+default = ["fast_image_resize", "similar_videos"]
 heif = ["czkawka_core/heif"]
 libraw = ["czkawka_core/libraw"]
 libavif = ["czkawka_core/libavif"]
 fast_image_resize = ["czkawka_core/fast_image_resize"]
+similar_videos = ["czkawka_core/similar_videos"]

--- a/czkawka_cli/src/commands.rs
+++ b/czkawka_cli/src/commands.rs
@@ -73,6 +73,7 @@ pub enum Commands {
     )]
     BrokenFiles(BrokenFilesArgs),
     #[clap(name = "video", about = "Finds similar video files", after_help = "EXAMPLE:\n    czkawka videos -d /home/rafal -f results.txt")]
+    #[cfg(feature = "similar_videos")]
     SimilarVideos(SimilarVideosArgs),
     #[clap(
         name = "ext",
@@ -386,6 +387,7 @@ pub struct BrokenFilesArgs {
 }
 
 #[derive(Debug, clap::Args)]
+#[cfg(feature = "similar_videos")]
 pub struct SimilarVideosArgs {
     #[clap(flatten)]
     pub common_cli_items: CommonCliItems,
@@ -599,6 +601,7 @@ fn parse_hash_type(src: &str) -> Result<HashType, &'static str> {
     }
 }
 
+#[cfg(feature = "similar_videos")]
 fn parse_tolerance(src: &str) -> Result<i32, &'static str> {
     match src.parse::<i32>() {
         Ok(t) => {

--- a/czkawka_cli/src/main.rs
+++ b/czkawka_cli/src/main.rs
@@ -6,6 +6,8 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::thread;
 
+#[cfg(feature = "similar_videos")]
+use crate::commands::SimilarVideosArgs;
 use clap::Parser;
 use commands::Commands;
 use crossbeam_channel::{Receiver, Sender, unbounded};
@@ -23,13 +25,14 @@ use czkawka_core::tools::empty_folder::EmptyFolder;
 use czkawka_core::tools::invalid_symlinks::InvalidSymlinks;
 use czkawka_core::tools::same_music::{SameMusic, SameMusicParameters};
 use czkawka_core::tools::similar_images::{SimilarImages, SimilarImagesParameters, return_similarity_from_similarity_preset};
+#[cfg(feature = "similar_videos")]
 use czkawka_core::tools::similar_videos::{SimilarVideos, SimilarVideosParameters};
 use czkawka_core::tools::temporary::Temporary;
 use log::error;
 
 use crate::commands::{
     Args, BadExtensionsArgs, BiggestFilesArgs, BrokenFilesArgs, CommonCliItems, DuplicatesArgs, EmptyFilesArgs, EmptyFoldersArgs, InvalidSymlinksArgs, SameMusicArgs,
-    SimilarImagesArgs, SimilarVideosArgs, TemporaryArgs,
+    SimilarImagesArgs, TemporaryArgs,
 };
 use crate::progress::connect_progress;
 
@@ -67,6 +70,7 @@ fn main() {
                 Commands::SameMusic(same_music_args) => same_music(same_music_args, &stop_flag, &progress_sender),
                 Commands::InvalidSymlinks(invalid_symlinks_args) => invalid_symlinks(invalid_symlinks_args, &stop_flag, &progress_sender),
                 Commands::BrokenFiles(broken_files_args) => broken_files(broken_files_args, &stop_flag, &progress_sender),
+                #[cfg(feature = "similar_videos")]
                 Commands::SimilarVideos(similar_videos_args) => similar_videos(similar_videos_args, &stop_flag, &progress_sender),
                 Commands::BadExtensions(bad_extensions_args) => bad_extensions(bad_extensions_args, &stop_flag, &progress_sender),
             };
@@ -337,6 +341,7 @@ fn broken_files(broken_files: BrokenFilesArgs, stop_flag: &Arc<AtomicBool>, prog
     !common_cli_items.ignore_error_code_on_found && item.get_information().number_of_broken_files > 0
 }
 
+#[cfg(feature = "similar_videos")]
 fn similar_videos(similar_videos: SimilarVideosArgs, stop_flag: &Arc<AtomicBool>, progress_sender: &Sender<ProgressData>) -> bool {
     let SimilarVideosArgs {
         reference_directories,

--- a/czkawka_core/Cargo.toml
+++ b/czkawka_core/Cargo.toml
@@ -45,8 +45,8 @@ xxhash-rust = { version = "0.8", features = ["xxh3"] }
 tempfile = "3.13"
 
 # Video Duplicates
-vid_dup_finder_lib = "0.2"
-ffmpeg_cmdline_utils = "0.3"
+vid_dup_finder_lib = { version = "0.2", optional = true }
+ffmpeg_cmdline_utils = { version = "0.3", optional = true }
 
 # Saving/Loading Cache
 serde = "1.0"
@@ -103,8 +103,9 @@ name = "hash_calculation_benchmark"
 harness = false
 
 [features]
-default = ["fast_image_resize"]
+default = ["fast_image_resize", "similar_videos"]
 heif = ["dep:libheif-rs", "dep:libheif-sys"]
 libraw = ["dep:libraw-rs"]
 libavif = ["image/avif-native", "image/avif"]
 fast_image_resize = ["image_hasher/fast_resize_unstable"]
+similar_videos = ["vid_dup_finder_lib", "ffmpeg_cmdline_utils"]

--- a/czkawka_core/src/tools/mod.rs
+++ b/czkawka_core/src/tools/mod.rs
@@ -7,5 +7,6 @@ pub mod empty_folder;
 pub mod invalid_symlinks;
 pub mod same_music;
 pub mod similar_images;
+#[cfg(feature = "similar_videos")]
 pub mod similar_videos;
 pub mod temporary;

--- a/czkawka_gui/Cargo.toml
+++ b/czkawka_gui/Cargo.toml
@@ -60,8 +60,9 @@ rand = "0.9.0"
 winapi = { version = "0.3.9", features = ["combaseapi", "objbase", "shobjidl_core", "windef", "winerror", "wtypesbase", "winuser"] }
 
 [features]
-default = ["fast_image_resize"]
+default = ["fast_image_resize", "similar_videos"]
 heif = ["czkawka_core/heif"]
 libraw = ["czkawka_core/libraw"]
 libavif = ["czkawka_core/libavif"]
 fast_image_resize = ["czkawka_core/fast_image_resize"]
+similar_videos = ["czkawka_core/similar_videos"]

--- a/czkawka_gui/src/compute_results.rs
+++ b/czkawka_gui/src/compute_results.rs
@@ -19,6 +19,7 @@ use czkawka_core::tools::invalid_symlinks::InvalidSymlinks;
 use czkawka_core::tools::same_music::{MusicSimilarity, SameMusic};
 use czkawka_core::tools::similar_images;
 use czkawka_core::tools::similar_images::{ImagesEntry, SimilarImages};
+#[cfg(feature = "similar_videos")]
 use czkawka_core::tools::similar_videos::SimilarVideos;
 use czkawka_core::tools::temporary::Temporary;
 use fun_time::fun_time;
@@ -44,6 +45,7 @@ pub fn connect_compute_results(gui_data: &GuiData, result_receiver: Receiver<Mes
     let tree_view_empty_files_finder = gui_data.main_notebook.tree_view_empty_files_finder.clone();
     let tree_view_duplicate_finder = gui_data.main_notebook.tree_view_duplicate_finder.clone();
     let tree_view_similar_images_finder = gui_data.main_notebook.tree_view_similar_images_finder.clone();
+    #[cfg(feature = "similar_videos")]
     let tree_view_similar_videos_finder = gui_data.main_notebook.tree_view_similar_videos_finder.clone();
     let buttons_array = gui_data.bottom_buttons.buttons_array.clone();
     let text_view_errors = gui_data.text_view_errors.clone();
@@ -61,6 +63,7 @@ pub fn connect_compute_results(gui_data: &GuiData, result_receiver: Receiver<Mes
     let tree_view_bad_extensions = gui_data.main_notebook.tree_view_bad_extensions.clone();
     let shared_temporary_files_state = gui_data.shared_temporary_files_state.clone();
     let shared_similar_images_state = gui_data.shared_similar_images_state.clone();
+    #[cfg(feature = "similar_videos")]
     let shared_similar_videos_state = gui_data.shared_similar_videos_state.clone();
     let shared_bad_extensions_state = gui_data.shared_bad_extensions_state.clone();
     let tree_view_same_music_finder = gui_data.main_notebook.tree_view_same_music_finder.clone();
@@ -166,6 +169,7 @@ pub fn connect_compute_results(gui_data: &GuiData, result_receiver: Receiver<Mes
                             hash_size,
                         );
                     }
+                    #[cfg(feature = "similar_videos")]
                     Message::SimilarVideos(ff) => {
                         compute_similar_videos(
                             ff,
@@ -600,6 +604,7 @@ fn compute_same_music(
 }
 
 #[fun_time(message = "compute_similar_videos", level = "debug")]
+#[cfg(feature = "similar_videos")]
 fn compute_similar_videos(
     ff: SimilarVideos,
     entry_info: &Entry,
@@ -1374,6 +1379,7 @@ fn similar_images_add_to_list_store(
     list_store.set(&list_store.append(), &values);
 }
 
+#[cfg(feature = "similar_videos")]
 fn similar_videos_add_to_list_store(list_store: &ListStore, file: &str, directory: &str, size: u64, modified_date: u64, is_header: bool, is_reference_folder: bool) {
     const COLUMNS_NUMBER: usize = 11;
     let size_str;

--- a/czkawka_gui/src/connect_things/connect_button_save.rs
+++ b/czkawka_gui/src/connect_things/connect_button_save.rs
@@ -21,6 +21,7 @@ pub fn connect_button_save(gui_data: &GuiData) {
     let shared_temporary_files_state = gui_data.shared_temporary_files_state.clone();
     let shared_empty_files_state = gui_data.shared_empty_files_state.clone();
     let shared_similar_images_state = gui_data.shared_similar_images_state.clone();
+    #[cfg(feature = "similar_videos")]
     let shared_similar_videos_state = gui_data.shared_similar_videos_state.clone();
     let shared_same_music_state = gui_data.shared_same_music_state.clone();
     let shared_same_invalid_symlinks = gui_data.shared_same_invalid_symlinks.clone();
@@ -51,10 +52,13 @@ pub fn connect_button_save(gui_data: &GuiData) {
                 .borrow()
                 .as_ref()
                 .map(|x| x.save_all_in_one(&current_path, "results_similar_images")),
+            #[cfg(feature = "similar_videos")]
             NotebookMainEnum::SimilarVideos => shared_similar_videos_state
                 .borrow()
                 .as_ref()
                 .map(|x| x.save_all_in_one(&current_path, "results_similar_videos")),
+            #[cfg(not(feature = "similar_videos"))]
+            NotebookMainEnum::SimilarVideos => panic!("Similar videos not enabled"),
             NotebookMainEnum::SameMusic => shared_same_music_state.borrow().as_ref().map(|x| x.save_all_in_one(&current_path, "results_same_music")),
             NotebookMainEnum::Symlinks => shared_same_invalid_symlinks
                 .borrow()

--- a/czkawka_gui/src/connect_things/connect_button_search.rs
+++ b/czkawka_gui/src/connect_things/connect_button_search.rs
@@ -17,6 +17,7 @@ use czkawka_core::tools::empty_folder::EmptyFolder;
 use czkawka_core::tools::invalid_symlinks::InvalidSymlinks;
 use czkawka_core::tools::same_music::{MusicSimilarity, SameMusic, SameMusicParameters};
 use czkawka_core::tools::similar_images::{SimilarImages, SimilarImagesParameters};
+#[cfg(feature = "similar_videos")]
 use czkawka_core::tools::similar_videos::{SimilarVideos, SimilarVideosParameters};
 use czkawka_core::tools::temporary::Temporary;
 use fun_time::fun_time;
@@ -54,6 +55,11 @@ pub fn connect_button_search(gui_data: &GuiData, result_sender: Sender<Message>,
 
     let gui_data = gui_data.clone();
     buttons_search_clone.connect_clicked(move |_| {
+        #[cfg(not(feature = "similar_videos"))]
+        if to_notebook_main_enum(notebook_main.current_page().expect("Current page not set")) == NotebookMainEnum::SimilarVideos {
+            return;
+        }
+
         let loaded_commons = LoadedCommonItems::load_items(&gui_data);
 
         // Check if user selected all referenced folders
@@ -98,7 +104,10 @@ pub fn connect_button_search(gui_data: &GuiData, result_sender: Sender<Message>,
             NotebookMainEnum::BigFiles => big_files_search(&gui_data, loaded_commons, stop_flag, result_sender, &grid_progress, progress_sender),
             NotebookMainEnum::Temporary => temporary_files_search(&gui_data, loaded_commons, stop_flag, result_sender, &grid_progress, progress_sender),
             NotebookMainEnum::SimilarImages => similar_image_search(&gui_data, loaded_commons, stop_flag, result_sender, &grid_progress, progress_sender),
+            #[cfg(feature = "similar_videos")]
             NotebookMainEnum::SimilarVideos => similar_video_search(&gui_data, loaded_commons, stop_flag, result_sender, &grid_progress, progress_sender),
+            #[cfg(not(feature = "similar_videos"))]
+            NotebookMainEnum::SimilarVideos => panic!("SimilarVideos not implemented"),
             NotebookMainEnum::SameMusic => same_music_search(&gui_data, loaded_commons, stop_flag, result_sender, &grid_progress, progress_sender, &show_dialog),
             NotebookMainEnum::Symlinks => bad_symlinks_search(&gui_data, loaded_commons, stop_flag, result_sender, &grid_progress, progress_sender),
             NotebookMainEnum::BrokenFiles => broken_files_search(&gui_data, loaded_commons, stop_flag, result_sender, &grid_progress, progress_sender, &show_dialog),
@@ -591,6 +600,7 @@ fn similar_image_search(
         .expect("Failed to spawn SimilarImages thread");
 }
 
+#[cfg(feature = "similar_videos")]
 fn similar_video_search(
     gui_data: &GuiData,
     loaded_commons: LoadedCommonItems,

--- a/czkawka_gui/src/connect_things/connect_settings.rs
+++ b/czkawka_gui/src/connect_things/connect_settings.rs
@@ -2,9 +2,10 @@ use std::collections::BTreeMap;
 use std::default::Default;
 
 use czkawka_core::common::get_config_cache_path;
+#[cfg(feature = "similar_videos")]
+use czkawka_core::common_cache::get_similar_videos_cache_file;
 use czkawka_core::common_cache::{
-    get_duplicate_cache_file, get_similar_images_cache_file, get_similar_videos_cache_file, load_cache_from_file_generalized_by_path, load_cache_from_file_generalized_by_size,
-    save_cache_to_file_generalized,
+    get_duplicate_cache_file, get_similar_images_cache_file, load_cache_from_file_generalized_by_path, load_cache_from_file_generalized_by_size, save_cache_to_file_generalized,
 };
 use czkawka_core::common_messages::Messages;
 use czkawka_core::tools::duplicate::HashType;
@@ -207,6 +208,7 @@ pub fn connect_settings(gui_data: &GuiData) {
                 });
             });
         }
+        #[cfg(feature = "similar_videos")]
         {
             let button_settings_similar_videos_clear_cache = gui_data.settings.button_settings_similar_videos_clear_cache.clone();
             let settings_window = gui_data.settings.window_settings.clone();

--- a/czkawka_gui/src/gui_structs/gui_data.rs
+++ b/czkawka_gui/src/gui_structs/gui_data.rs
@@ -14,6 +14,7 @@ use czkawka_core::tools::empty_folder::EmptyFolder;
 use czkawka_core::tools::invalid_symlinks::InvalidSymlinks;
 use czkawka_core::tools::same_music::SameMusic;
 use czkawka_core::tools::similar_images::SimilarImages;
+#[cfg(feature = "similar_videos")]
 use czkawka_core::tools::similar_videos::SimilarVideos;
 use czkawka_core::tools::temporary::Temporary;
 use gdk4::gdk_pixbuf::Pixbuf;
@@ -88,7 +89,11 @@ pub struct GuiData {
     pub shared_temporary_files_state: SharedState<Temporary>,
     pub shared_big_files_state: SharedState<BigFile>,
     pub shared_similar_images_state: SharedState<SimilarImages>,
+    #[cfg(feature = "similar_videos")]
     pub shared_similar_videos_state: SharedState<SimilarVideos>,
+    #[cfg(not(feature = "similar_videos"))]
+    #[allow(dead_code)]
+    pub shared_similar_videos_state: SharedState<()>,
     pub shared_same_music_state: SharedState<SameMusic>,
     pub shared_same_invalid_symlinks: SharedState<InvalidSymlinks>,
     pub shared_broken_files_state: SharedState<BrokenFiles>,

--- a/czkawka_gui/src/gui_structs/gui_main_notebook.rs
+++ b/czkawka_gui/src/gui_structs/gui_main_notebook.rs
@@ -1,14 +1,13 @@
+use crate::flg;
+use crate::help_combo_box::{AUDIO_TYPE_CHECK_METHOD_COMBO_BOX, BIG_FILES_CHECK_METHOD_COMBO_BOX, DUPLICATES_CHECK_METHOD_COMBO_BOX, IMAGES_HASH_SIZE_COMBO_BOX};
+use crate::help_functions::{get_all_children_type_of, get_all_direct_children};
+use crate::notebook_enums::{NUMBER_OF_NOTEBOOK_MAIN_TABS, NotebookMainEnum};
 use czkawka_core::common_dir_traversal::CheckingMethod;
 use czkawka_core::localizer_core::{fnc_get_similarity_minimal, fnc_get_similarity_very_high};
 use czkawka_core::tools::big_file::SearchMode;
 use czkawka_core::tools::similar_images::{SIMILAR_VALUES, get_string_from_similarity};
 use gtk4::prelude::*;
 use gtk4::{Builder, CheckButton, ComboBoxText, Entry, EventControllerKey, GestureClick, Image, Label, Notebook, Scale, ScrolledWindow, TreeView, Widget};
-
-use crate::flg;
-use crate::help_combo_box::{AUDIO_TYPE_CHECK_METHOD_COMBO_BOX, BIG_FILES_CHECK_METHOD_COMBO_BOX, DUPLICATES_CHECK_METHOD_COMBO_BOX, IMAGES_HASH_SIZE_COMBO_BOX};
-use crate::help_functions::get_all_direct_children;
-use crate::notebook_enums::{NUMBER_OF_NOTEBOOK_MAIN_TABS, NotebookMainEnum};
 
 #[derive(Clone)]
 pub struct GuiMainNotebook {
@@ -486,6 +485,22 @@ impl GuiMainNotebook {
                 .downcast::<Label>()
                 .expect("Tab label must be a label")
                 .set_text(&fl_thing);
+
+            if main_enum == NotebookMainEnum::SimilarVideos as usize {
+                let v = get_all_children_type_of::<Label, _>(&self.notebook_main);
+
+                if !cfg!(feature = "similar_videos") {
+                    for child in v {
+                        if child.label() == fl_thing {
+                            let parent = child.parent().expect("Parent must exists");
+                            // parent.hide(); // Shows a lot of warnings and breaks a little layout
+                            parent.set_sensitive(false); // Still allows to select tab, but shows that it is disabled
+                            child.hide();
+                            break;
+                        }
+                    }
+                }
+            }
         }
 
         // Change names of columns

--- a/czkawka_gui/src/help_functions.rs
+++ b/czkawka_gui/src/help_functions.rs
@@ -16,6 +16,7 @@ use czkawka_core::tools::empty_folder::EmptyFolder;
 use czkawka_core::tools::invalid_symlinks::InvalidSymlinks;
 use czkawka_core::tools::same_music::SameMusic;
 use czkawka_core::tools::similar_images::SimilarImages;
+#[cfg(feature = "similar_videos")]
 use czkawka_core::tools::similar_videos::SimilarVideos;
 use czkawka_core::tools::temporary::Temporary;
 use gdk4::gdk_pixbuf::{InterpType, Pixbuf};
@@ -72,6 +73,7 @@ pub enum Message {
     BigFiles(BigFile),
     Temporary(Temporary),
     SimilarImages(SimilarImages),
+    #[cfg(feature = "similar_videos")]
     SimilarVideos(SimilarVideos),
     SameMusic(SameMusic),
     InvalidSymlinks(InvalidSymlinks),
@@ -715,6 +717,19 @@ pub fn get_all_boxes_from_widget<P: IsA<Widget>>(item: &P) -> Vec<gtk4::Box> {
         }
     }
     boxes
+}
+
+pub fn get_all_children_type_of<T: gtk4::prelude::ObjectType + gtk4::prelude::IsA<gtk4::Widget>, P: IsA<Widget>>(item: &P) -> Vec<T> {
+    let mut widgets_to_check = vec![item.clone().upcast::<Widget>()];
+    let mut items = Vec::new();
+
+    while let Some(widget) = widgets_to_check.pop() {
+        widgets_to_check.extend(get_all_direct_children(&widget));
+        if let Ok(bbox) = widget.clone().downcast::<T>() {
+            items.push(bbox);
+        }
+    }
+    items
 }
 
 pub fn get_all_direct_children<P: IsA<Widget>>(wid: &P) -> Vec<Widget> {

--- a/czkawka_gui/src/initialize_gui.rs
+++ b/czkawka_gui/src/initialize_gui.rs
@@ -3,6 +3,7 @@ use std::rc::Rc;
 
 use czkawka_core::common_image::get_dynamic_image_from_path;
 use czkawka_core::tools::similar_images::SIMILAR_VALUES;
+#[cfg(feature = "similar_videos")]
 use czkawka_core::tools::similar_videos::MAX_TOLERANCE;
 use gdk4::gdk_pixbuf::Pixbuf;
 use glib::types::Type;
@@ -89,6 +90,7 @@ pub fn initialize_gui(gui_data: &GuiData) {
             scale_set_min_max_values(&scale_similarity_similar_images, 0_f64, SIMILAR_VALUES[0][5] as f64, 15_f64, Some(1_f64));
         }
         // Set step increment
+        #[cfg(feature = "similar_videos")]
         {
             let scale_similarity_similar_videos = gui_data.main_notebook.scale_similarity_similar_videos.clone();
             scale_set_min_max_values(&scale_similarity_similar_videos, 0_f64, MAX_TOLERANCE as f64, 15_f64, Some(1_f64));


### PR DESCRIPTION
This adds a "Similar Videos" tool as an optional feature, enabled by default.

I don't think this PR should be merged into the main branch because:

- The "Similar Videos" tab cannot be clearly disabled in gtk
- It currently does not work with Krokiet
- Disabling it does not provide significant benefits (e.g., a lot of faster compilation speed)