### PR TITLE
Log path of failed video, same as failed images

### DIFF
--- a/czkawka_core/src/tools/similar_videos.rs
+++ b/czkawka_core/src/tools/similar_videos.rs
@@ -196,7 +196,8 @@ impl SimilarVideos {
         let vhash = match VideoHashBuilder::default().hash(file_entry.path.clone()) {
             Ok(t) => t,
             Err(e) => {
-                file_entry.error = format!("Failed to hash file, reason {e}");
+                let path = file_entry.path.to_string_lossy();
+                file_entry.error = format!("Failed to hash file {path}: reason {e}");
                 return file_entry;
             }
         };


### PR DESCRIPTION
When I scan for similar videos, I see some errors but no indicator of which files are problematic. I added the video file path to the error message, modeled after the similar message for errors on the similar image search.