### PR TITLE
Enable heif builds on Mac ARM

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -165,4 +165,43 @@ jobs:
             macos_czkawka_gui_arm
             macos_krokiet_arm
           token: ${{ secrets.PAT_REPOSITORY }}
-      # TODO - arm builds not works now with heif
+
+      - name: Build Release Heif
+        run: |
+          export LIBRARY_PATH=$LIBRARY_PATH:$(brew --prefix)/lib
+          cargo build --release --features heif
+
+      - name: Store MacOS CLI Heif
+        uses: actions/upload-artifact@v4
+        with:
+          name: czkawka_cli-${{ runner.os }}-heif-arm
+          path: target/release/czkawka_cli
+
+      - name: Store MacOS GUI Heif
+        uses: actions/upload-artifact@v4
+        with:
+          name: czkawka_gui-${{ runner.os }}-heif-arm
+          path: target/release/czkawka_gui
+
+      - name: Store MacOS Krokiet Heif
+        uses: actions/upload-artifact@v4
+        with:
+          name: krokiet-${{ runner.os }}-heif-arm
+          path: target/release/krokiet
+
+      - name: Prepare files to release 2
+        run: |
+          mv target/release/czkawka_cli macos_czkawka_cli_heif_arm
+          mv target/release/czkawka_gui macos_czkawka_gui_heif_arm
+          mv target/release/krokiet macos_krokiet_heif_arm
+
+      - name: Release 2
+        uses: softprops/action-gh-release@v2
+        if: ${{ github.ref == 'refs/heads/master' }}
+        with:
+          tag_name: "Nightly"
+          files: |
+            macos_czkawka_cli_heif_arm
+            macos_czkawka_gui_heif_arm
+            macos_krokiet_heif_arm
+          token: ${{ secrets.PAT_REPOSITORY }}


### PR DESCRIPTION
Enable heif builds on Mac ARM.
The heif library gets statically linked, therefore users need to e.g. `brew install libheif` before starting the created binaries.