### PR TITLE
Correct comic book extension for bad extension check

### DIFF
--- a/czkawka_core/src/tools/bad_extensions/workarounds.rs
+++ b/czkawka_core/src/tools/bad_extensions/workarounds.rs
@@ -126,7 +126,7 @@ pub(crate) const WORKAROUNDS: &[(&str, &str)] = &[
     ("xml", "xba"),       // Libreoffice
     ("xml", "xcd"),       // Libreoffice files
     ("zip", "apk"),       // Android apk
-    ("zip", "cbr"),       // Comics
+    ("zip", "cbz"),       // Comics
     ("zip", "dat"),       // Multiple - python, brave
     ("zip", "doc"),       // Word
     ("zip", "docx"),      // Word


### PR DESCRIPTION
.cbz - comic book **zip**
.cbr - comic book **rar**

Whether that is observed by all programs I don't know (if it is better to append than replace I can do this), but a zip file appearing as a cbr should be technically an error, and cbz files are not correctly detected as aliases