### PR TITLE
Update com.github.qarmin.czkawka.desktop

### DIFF
--- a/data/com.github.qarmin.czkawka.desktop
+++ b/data/com.github.qarmin.czkawka.desktop
@@ -9,11 +9,11 @@ Type=Application
 
 Name=Czkawka
 Name[it]=Singhiozzo
-Name[pt_BR]=Localizador de Arquivos Duplicados Czkawka
+Name[pt_BR]=Comparador de Arquivos Duplicados Czkawka
 
 Comment=Multi functional app to clean OS which allow to find duplicates, empty folders, similar files etc.
 Comment[it]=Programma multifunzionale per pulire il sistema, che permette di trovare file duplicati, cartelle vuote, file simili, ecc...
-Comment[pt_BR]=O ‘Czkawka’, que em idioma português significa ‘soluço’, é um programa que permite encontrar (buscar ou localizar ou pesquisar) arquivos duplicados, pastas ou diretórios vazios, arquivos equivalentes (semelhantes ou similares), criar arquivos de verificação da integridade (hash) de vários tipos de arquivos diferentes (por exemplo, arquivos de imagens, músicas, vídeos, etc.), mover para a lixeira os arquivos duplicados, excluir permanentemente os arquivos duplicados, etc., possibilita realizar a limpeza do sistema operacional
+Comment[pt_BR]=O ‘Czkawka’, que em idioma português significa ‘soluço’, é um programa que permite comparar e encontrar (buscar ou localizar ou pesquisar) arquivos duplicados, pastas ou diretórios vazios, arquivos equivalentes (semelhantes ou similares), criar arquivos de verificação da integridade (hash) de vários tipos de arquivos diferentes (por exemplo, arquivos de imagens, músicas, vídeos, etc.), mover para a lixeira os arquivos duplicados, excluir permanentemente os arquivos duplicados, etc., possibilita realizar a limpeza do sistema operacional
 Comment[zh_CN]=可用于清理文件副本、空文件夹、相似文件等的系统清理工具
 Comment[zh_TW]=可用於清理重複檔案、空資料夾、相似檔案等的系統清理工具
 


### PR DESCRIPTION
Witaj qarmin.

Proszę zaakceptować teksty w języku portugalskim brazylijskim (pt_BR) dla pliku „.desktop” programu Czkawka.

Uporządkowałem wpisy w pliku „.desktop” w następujący sposób:

- wpisy sterujące pliku „.desktop” są umieszczone na górze i w kolejności alfabetycznej.
- wpisy, które można przetłumaczyć: „Nazwa[identyfikator języka]=”, „Komentarz[identyfikator języka]=” i „Słowa kluczowe[identyfikator języka]=” są umieszczone po wpisie „Typ=Aplikacja” i w kolejności ważności dla tłumaczy-wolontariuszy.

Przetestowałem plik „.desktop” w systemie antiX 23.2 i tłumaczenia „pt_BR” działały idealnie.

Dziękuję za stworzenie, utrzymanie i aktualizację programu do lokalizowania duplikatów plików w Czkawka.

Dziękuję bardzo.

marcelocripe
(Oryginalny tekst w języku portugalskim brazylijskim)

- - - - -

Olá, qarmin.

Por favor, aceite os textos do idioma português do Brasil (pt_BR) para o arquivo ".desktop" do programa Czkawka.

Eu organizei as entradas do arquivo ".desktop" da seguinte maneira:

- as entradas de controle do arquivo ".desktop" estão posicionadas na parte superior e em ordem alfabética.
- as entradas que podem ser traduzidas "Name[identificador do idioma]=", "Comment[identificador do idioma]=" e "Keywords[identificador do idioma]=" estão posicionadas após a entrada "Type=Application" e em ordem de importância para os tradutores voluntários.

Eu testei o arquivo ".desktop" no antiX 23.2 e funcionou perfeitamente as traduções "pt_BR".

Eu agradeço por você criar, manter e atualizar o programa localizador de arquivos duplicados Czkawka.

Muito obrigado.

marcelocripe
(Texto original em idioma Português do Brasil)