### PR TITLE
Use Slint 1.15.0 also in Krokiet/Cargo.toml (not just flatpak)

### DIFF
--- a/krokiet/Cargo.toml
+++ b/krokiet/Cargo.toml
@@ -35,7 +35,7 @@ rust-embed = { version = "8.5", features = ["debug-embed"] }
 # Try to use only needed features from https://github.com/slint-ui/slint/blob/master/api/rs/slint/Cargo.toml#L23-L31
 #slint = { path = "/home/rafal/test/slint/api/rs/slint/", default-features = false, features = ["std",
 #slint = { git = "https://github.com/slint-ui/slint.git", default-features = false, features = [
-slint = { version = "=1.14.1", default-features = false, features = [
+slint = { version = "=1.15.0", default-features = false, features = [
     "std",
     "backend-winit",
     "compat-1-2"
@@ -46,7 +46,7 @@ rodio = { version = "0.21.1", default-features = false, features = ["playback", 
 [build-dependencies]
 #slint-build = { path = "/home/rafal/test/slint/api/rs/build/"}
 #slint-build = { git = "https://github.com/slint-ui/slint.git" }
-slint-build = "=1.14.1"
+slint-build = "=1.15.0"
 
 [features]
 default = ["winit_femtovg", "winit_software"]


### PR DESCRIPTION
replaced by https://github.com/qarmin/czkawka/pull/1780
please cancel / close this one and merge the other one instead