### PR TITLE
Fixed panic occurring after similar videos analyze

### DIFF
--- a/czkawka_gui/src/notebook_info.rs
+++ b/czkawka_gui/src/notebook_info.rs
@@ -216,7 +216,7 @@ pub static NOTEBOOKS_INFO: [NotebookObject; CZKAWKA_GTK_TOOL_NUMBER] = [
         tree_view_name: "tree_view_similar_images_finder",
     },
     NotebookObject {
-        name: "Similar Images",
+        name: "Similar Videos",
         notebook_type: NotebookMainEnum::SimilarVideos,
         available_modes: &[
             PopoverTypes::All,
@@ -244,6 +244,7 @@ pub static NOTEBOOKS_INFO: [NotebookObject; CZKAWKA_GTK_TOOL_NUMBER] = [
             Type::STRING, // Codec
             Type::STRING, // Bitrate
             Type::STRING, // Dimensions
+            Type::STRING, // Duration
             Type::STRING, // Name
             Type::STRING, // Path
             Type::STRING, // Modification


### PR DESCRIPTION
Added missing Duration column to similar videos notebook, fixing panic that was occurring after analyzing videos.

Here is the panic I was getting with Czkawka 11.0.0, compiled under Alpine Linux:

```
02:21:09.346 [ERROR] log_panics: thread 'main' panicked at 'got values for 16 columns but only 15 columns exist': /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/gtk4-0.11.0-alpha.3/src/list_store.rs:132
   0: log_panics::Config::install_panic_hook::{{closure}}
             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/log-panics-2.1.0/src/lib.rs:115:29
   1: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/alloc/src/boxed.rs:2220:9
      std::panicking::panic_with_hook
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:833:13
   2: std::panicking::panic_handler::{{closure}}
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:698:13
   3: std::sys::backtrace::__rust_end_short_backtrace
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/sys/backtrace.rs:176:18
   4: __rustc::rust_begin_unwind
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:689:5
   5: core::panicking::panic_fmt
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/core/src/panicking.rs:80:14
   6: gtk4::list_store::<impl gtk4::auto::list_store::ListStore>::set
             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/gtk4-0.11.0-alpha.3/src/list_store.rs:132:13
   7: czkawka_gui::helpers::list_store_operations::append_row_to_list_store
             at /tmp/czkawka/czkawka_gui/src/helpers/list_store_operations.rs:252:16
      czkawka_gui::compute_results::similar_videos_add_to_list_store
             at /tmp/czkawka/czkawka_gui/src/compute_results.rs:1059:5
   8: czkawka_gui::compute_results::compute_similar_videos::{{closure}}
             at /tmp/czkawka/czkawka_gui/src/compute_results.rs:480:17
      czkawka_gui::compute_results::compute_similar_videos
             at /tmp/czkawka/czkawka_gui/src/compute_results.rs:403:1
   9: czkawka_gui::compute_results::connect_compute_results::{{closure}}
             at /tmp/czkawka/czkawka_gui/src/compute_results.rs:136:51
      glib::main_context_futures::<impl glib::auto::main_context::MainContext>::spawn_local_with_priority::{{closure}}
             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/glib-0.22.0-alpha.2/src/main_context_futures.rs:594:24
  10: glib::main_context_futures::TaskSource::poll::{{closure}}::{{closure}}
             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/glib-0.22.0-alpha.2/src/main_context_futures.rs:263:56
      core::ops::function::FnOnce::call_once
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/core/src/ops/function.rs:250:5
      <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/core/src/panic/unwind_safe.rs:274:9
      std::panicking::catch_unwind::do_call
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:581:40
      std::panicking::catch_unwind
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:544:19
      std::panic::catch_unwind
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panic.rs:359:14
      glib::main_context_futures::TaskSource::poll::{{closure}}
             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/glib-0.22.0-alpha.2/src/main_context_futures.rs:262:35
      glib::main_context::<impl glib::auto::main_context::MainContext>::with_thread_default
             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/glib-0.22.0-alpha.2/src/main_context.rs:165:12
  11: glib::main_context_futures::TaskSource::poll
             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/glib-0.22.0-alpha.2/src/main_context_futures.rs:254:14
      glib::main_context_futures::TaskSource::dispatch
             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/glib-0.22.0-alpha.2/src/main_context_futures.rs:76:45
  12: <unknown>
  13: <unknown>
  14: g_main_context_iteration
  15: g_application_run
  16: gio::application::ApplicationExtManual::run_with_args
             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/gio-0.22.0-alpha.3/src/application.rs:25:13
  17: czkawka_gui::main
             at /tmp/czkawka/czkawka_gui/src/main.rs:112:17
  18: core::ops::function::FnOnce::call_once
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/core/src/ops/function.rs:250:5
      std::sys::backtrace::__rust_begin_short_backtrace
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/sys/backtrace.rs:160:18
  19: std::rt::lang_start::{{closure}}
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/rt.rs:206:18
  20: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/core/src/ops/function.rs:287:21
      std::panicking::catch_unwind::do_call
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:581:40
      std::panicking::catch_unwind
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:544:19
      std::panic::catch_unwind
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panic.rs:359:14
      std::rt::lang_start_internal::{{closure}}
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/rt.rs:175:24
      std::panicking::catch_unwind::do_call
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:581:40
      std::panicking::catch_unwind
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:544:19
      std::panic::catch_unwind
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panic.rs:359:14
      std::rt::lang_start_internal
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/rt.rs:171:5
  21: main
  22: <unknown>
```