### PR TITLE
Removed warning log message displayed for non-existing excluded directories

### DIFF
--- a/czkawka_core/src/common/directories.rs
+++ b/czkawka_core/src/common/directories.rs
@@ -79,7 +79,7 @@ impl Directories {
                 break;
             }
 
-            let (dir, msg) = Self::canonicalize_and_clear_path(&path, false);
+            let (dir, msg) = Self::canonicalize_and_clear_path(&path, is_excluded);
 
             messages.extend_with_another_messages(msg);
 


### PR DESCRIPTION
Removed warning log message displayed for non-existing excluded directories.

When scanning, the following log message is displayed:
```
############### WARNINGS(1) ###############
Provided path must exist, ignoring /snap
```
Such warnings were not displayed prior version 11.0.0.