### PR TITLE
Fixed panic that was occurring when double-clicking on a folder from the included or excluded directory list.

### DIFF
--- a/czkawka_gui/src/gui_structs/gui_upper_notebook.rs
+++ b/czkawka_gui/src/gui_structs/gui_upper_notebook.rs
@@ -78,14 +78,14 @@ impl GuiUpperNotebook {
                     "scrolled_window_included_directories",
                     NotebookUpperEnum::IncludedDirectories,
                     UpperTreeViewEnum::IncludedDirectories,
-                    "tree_view_included_directories",
+                    "tree_view_upper_included_directories",
                 ),
                 UpperSubView::new(
                     builder,
                     "scrolled_window_excluded_directories",
                     NotebookUpperEnum::ExcludedDirectories,
                     UpperTreeViewEnum::ExcludedDirectories,
-                    "tree_view_excluded_directories",
+                    "tree_view_upper_excluded_directories",
                 ),
             ],
         };


### PR DESCRIPTION
Fixed panic that was occurring when double-clicking on a folder from the included or excluded directory list.

Problem introduced in v11.0.0.

Here is the panic:
```
04:10:56.628 [ERROR] log_panics: thread 'main' panicked at 'tree_view_excluded_directories': czkawka_gui/src/help_functions.rs:108
   0: log_panics::Config::install_panic_hook::{{closure}}
             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/log-panics-2.1.0/src/lib.rs:115:29
   1: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/alloc/src/boxed.rs:2220:9
      std::panicking::panic_with_hook
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:833:13
   2: std::panicking::panic_handler::{{closure}}
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:698:13
   3: std::sys::backtrace::__rust_end_short_backtrace
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/sys/backtrace.rs:176:18
   4: __rustc::rust_begin_unwind
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:689:5
   5: core::panicking::panic_fmt
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/core/src/panicking.rs:80:14
   6: core::panicking::panic_display
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/core/src/panicking.rs:259:5
   7: czkawka_gui::help_functions::get_notebook_upper_enum_from_tree_view
             at /tmp/czkawka/czkawka_gui/src/help_functions.rs:108:14
   8: czkawka_gui::opening_selecting_records::opening_double_click_function_directories
             at /tmp/czkawka/czkawka_gui/src/opening_selecting_records.rs:60:15
   9: core::ops::function::Fn::call
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/core/src/ops/function.rs:79:5
      gtk4::auto::gesture_click::GestureClick::connect_pressed::pressed_trampoline
             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/gtk4-0.11.0-alpha.3/src/auto/gesture_click.rs:49:17
  10: <unknown>
  11: <unknown>
  12: <unknown>
  13: g_signal_emit_valist
  14: g_signal_emit
  15: <unknown>
  16: g_cclosure_marshal_VOID__BOXEDv
  17: <unknown>
  18: <unknown>
  19: g_signal_emit_valist
  20: g_signal_emit
  21: <unknown>
  22: <unknown>
  23: <unknown>
  24: <unknown>
  25: <unknown>
  26: <unknown>
  27: <unknown>
  28: <unknown>
  29: <unknown>
  30: g_closure_invoke
  31: <unknown>
  32: <unknown>
  33: g_signal_emit_valist
  34: g_signal_emit
  35: <unknown>
  36: <unknown>
  37: <unknown>
  38: <unknown>
  39: g_main_context_iteration
  40: g_application_run
  41: gio::application::ApplicationExtManual::run_with_args
             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/gio-0.22.0-alpha.3/src/application.rs:25:13
  42: czkawka_gui::main
             at /tmp/czkawka/czkawka_gui/src/main.rs:112:17
  43: core::ops::function::FnOnce::call_once
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/core/src/ops/function.rs:250:5
      std::sys::backtrace::__rust_begin_short_backtrace
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/sys/backtrace.rs:160:18
  44: std::rt::lang_start::{{closure}}
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/rt.rs:206:18
  45: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/core/src/ops/function.rs:287:21
      std::panicking::catch_unwind::do_call
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:581:40
      std::panicking::catch_unwind
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:544:19
      std::panic::catch_unwind
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panic.rs:359:14
      std::rt::lang_start_internal::{{closure}}
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/rt.rs:175:24
      std::panicking::catch_unwind::do_call
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:581:40
      std::panicking::catch_unwind
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:544:19
      std::panic::catch_unwind
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panic.rs:359:14
      std::rt::lang_start_internal
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/rt.rs:171:5
  46: main
  47: <unknown>
04:10:57.160 [ERROR] log_panics: thread 'main' panicked at 'panic in a function that cannot unwind': library/core/src/panicking.rs:225
   0: log_panics::Config::install_panic_hook::{{closure}}
             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/log-panics-2.1.0/src/lib.rs:115:29
   1: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/alloc/src/boxed.rs:2220:9
      std::panicking::panic_with_hook
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:833:13
   2: std::panicking::panic_handler::{{closure}}
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:691:13
   3: std::sys::backtrace::__rust_end_short_backtrace
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/sys/backtrace.rs:176:18
   4: __rustc::rust_begin_unwind
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:689:5
   5: core::panicking::panic_nounwind_fmt::runtime
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/core/src/panicking.rs:122:22
      core::panicking::panic_nounwind_fmt
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/core/src/intrinsics/mod.rs:2449:9
   6: core::panicking::panic_nounwind
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/core/src/panicking.rs:225:5
   7: core::panicking::panic_cannot_unwind
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/core/src/panicking.rs:337:5
   8: gtk4::auto::gesture_click::GestureClick::connect_pressed::pressed_trampoline
             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/gtk4-0.11.0-alpha.3/src/auto/gesture_click.rs:40:9
   9: <unknown>
  10: <unknown>
  11: <unknown>
  12: g_signal_emit_valist
  13: g_signal_emit
  14: <unknown>
  15: g_cclosure_marshal_VOID__BOXEDv
  16: <unknown>
  17: <unknown>
  18: g_signal_emit_valist
  19: g_signal_emit
  20: <unknown>
  21: <unknown>
  22: <unknown>
  23: <unknown>
  24: <unknown>
  25: <unknown>
  26: <unknown>
  27: <unknown>
  28: <unknown>
  29: g_closure_invoke
  30: <unknown>
  31: <unknown>
  32: g_signal_emit_valist
  33: g_signal_emit
  34: <unknown>
  35: <unknown>
  36: <unknown>
  37: <unknown>
  38: g_main_context_iteration
  39: g_application_run
  40: gio::application::ApplicationExtManual::run_with_args
             at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/gio-0.22.0-alpha.3/src/application.rs:25:13
  41: czkawka_gui::main
             at /tmp/czkawka/czkawka_gui/src/main.rs:112:17
  42: core::ops::function::FnOnce::call_once
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/core/src/ops/function.rs:250:5
      std::sys::backtrace::__rust_begin_short_backtrace
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/sys/backtrace.rs:160:18
  43: std::rt::lang_start::{{closure}}
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/rt.rs:206:18
  44: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/core/src/ops/function.rs:287:21
      std::panicking::catch_unwind::do_call
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:581:40
      std::panicking::catch_unwind
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:544:19
      std::panic::catch_unwind
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panic.rs:359:14
      std::rt::lang_start_internal::{{closure}}
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/rt.rs:175:24
      std::panicking::catch_unwind::do_call
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:581:40
      std::panicking::catch_unwind
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panicking.rs:544:19
      std::panic::catch_unwind
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/panic.rs:359:14
      std::rt::lang_start_internal
             at /rustc/01f6ddf7588f42ae2d7eb0a2f21d44e8e96674cf/library/std/src/rt.rs:171:5
  45: main
  46: <unknown>
thread caused non-unwinding panic. aborting.
```