### PR TITLE
Repair failing re-direct

### DIFF
--- a/krokiet/ui/about.slint
+++ b/krokiet/ui/about.slint
@@ -66,7 +66,7 @@ export component About inherits VerticalLayout {
         Button {
             text <=> Translations.translation_text;
             clicked => {
-                Callabler.open_link("https://crwd.in/czkawka");
+                Callabler.open_link("https://crowdin.com/project/czkawka");
             }
         }
     }


### PR DESCRIPTION
Current hyperlink doesn't forward to the project page. New one does.