### PR TITLE
Add fuzzy filename matching for duplicate detection

### DIFF
--- a/czkawka_cli/src/commands.rs
+++ b/czkawka_cli/src/commands.rs
@@ -169,10 +169,17 @@ pub struct DuplicatesArgs {
         long,
         default_value = "HASH",
         value_parser = parse_checking_method_duplicate,
-        help = "Search method (NAME, SIZE, HASH)",
-        long_help = "Methods to search files.\nNAME - Fast but rarely usable,\nSIZE - Fast but not accurate, checking by the file's size,\nHASH - The slowest method, checking by the hash of the entire file"
+        help = "Search method (NAME, FUZZY_NAME, SIZE, SIZE_NAME, HASH)",
+        long_help = "Methods to search files.\nNAME - Fast but rarely usable, finds files with identical names,\nFUZZY_NAME - Finds files with similar names using Jaro-Winkler distance,\nSIZE - Fast but not accurate, checking by the file's size,\nSIZE_NAME - Checks by both file size and name,\nHASH - The slowest method, checking by the hash of the entire file"
     )]
     pub search_method: CheckingMethod,
+    #[clap(
+        long,
+        default_value = "0.85",
+        help = "Name similarity threshold for FUZZY_NAME mode (0.0–1.0)",
+        long_help = "Minimum Jaro-Winkler similarity score (0.0–1.0) for two filenames to be considered similar. Higher values require closer matches. Only used with FUZZY_NAME search method."
+    )]
+    pub name_similarity_threshold: f64,
     #[clap(flatten)]
     pub delete_method: DMethod,
     #[clap(
@@ -1081,10 +1088,11 @@ fn parse_tolerance(src: &str) -> Result<i32, &'static str> {
 fn parse_checking_method_duplicate(src: &str) -> Result<CheckingMethod, &'static str> {
     match src.to_ascii_lowercase().as_str() {
         "name" => Ok(CheckingMethod::Name),
+        "fuzzy_name" => Ok(CheckingMethod::FuzzyName),
         "size" => Ok(CheckingMethod::Size),
         "size_name" => Ok(CheckingMethod::SizeName),
         "hash" => Ok(CheckingMethod::Hash),
-        _ => Err("Couldn't parse the search method (allowed: NAME, SIZE, HASH)"),
+        _ => Err("Couldn't parse the search method (allowed: NAME, FUZZY_NAME, SIZE, SIZE_NAME, HASH)"),
     }
 }
 

--- a/czkawka_cli/src/main.rs
+++ b/czkawka_cli/src/main.rs
@@ -122,6 +122,7 @@ fn duplicates(duplicates: DuplicatesArgs, stop_flag: &Arc<AtomicBool>, progress_
         maximal_file_size,
         minimal_cached_file_size,
         search_method,
+        name_similarity_threshold,
         delete_method,
         hash_type,
         allow_hard_links,
@@ -137,7 +138,8 @@ fn duplicates(duplicates: DuplicatesArgs, stop_flag: &Arc<AtomicBool>, progress_
         minimal_cached_file_size,
         minimal_prehash_cache_file_size,
         case_sensitive_name_comparison.case_sensitive_name_comparison,
-    );
+    )
+    .with_name_similarity_threshold(name_similarity_threshold);
     let mut tool = DuplicateFinder::new(params);
 
     set_common_settings(&mut tool, &common_cli_items, Some(reference_directories.reference_directories.as_ref()));

--- a/czkawka_core/Cargo.toml
+++ b/czkawka_core/Cargo.toml
@@ -97,6 +97,7 @@ open = "5.3"
 
 log-panics = { version = "2.1.0", features = ["with-backtrace"] }
 deunicode = "1.6.2"
+strsim = "0.11"
 glibc_musl_version = "0.1.0"
 
 rand = "0.10.0"

--- a/czkawka_core/src/common/model.rs
+++ b/czkawka_core/src/common/model.rs
@@ -37,6 +37,7 @@ pub enum CheckingMethod {
     #[default]
     None,
     Name,
+    FuzzyName,
     SizeName,
     Size,
     Hash,

--- a/czkawka_core/src/common/progress_data.rs
+++ b/czkawka_core/src/common/progress_data.rs
@@ -176,7 +176,7 @@ impl ProgressData {
 
         let tool_type_checking_method: Option<ToolType> = match self.checking_method {
             CheckingMethod::AudioTags | CheckingMethod::AudioContent => Some(ToolType::SameMusic),
-            CheckingMethod::Name | CheckingMethod::SizeName | CheckingMethod::Size | CheckingMethod::Hash => Some(ToolType::Duplicate),
+            CheckingMethod::Name | CheckingMethod::FuzzyName | CheckingMethod::SizeName | CheckingMethod::Size | CheckingMethod::Hash => Some(ToolType::Duplicate),
             CheckingMethod::None => None,
         };
         if let Some(tool_type) = tool_type_checking_method {

--- a/czkawka_core/src/tools/duplicate/core.rs
+++ b/czkawka_core/src/tools/duplicate/core.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -11,6 +11,7 @@ use humansize::{BINARY, format_size};
 use indexmap::IndexMap;
 use log::debug;
 use rayon::prelude::*;
+use strsim;
 
 use crate::common::cache::{CACHE_DUPLICATE_VERSION, load_cache_from_file_generalized_by_size, save_cache_to_file_generalized};
 use crate::common::dir_traversal::{DirTraversalBuilder, DirTraversalResult};
@@ -32,10 +33,12 @@ impl DuplicateFinder {
             files_with_identical_size: Default::default(),
             files_with_identical_size_names: Default::default(),
             files_with_identical_hashes: Default::default(),
+            files_with_fuzzy_names: Default::default(),
             files_with_identical_names_referenced: Default::default(),
             files_with_identical_size_names_referenced: Default::default(),
             files_with_identical_size_referenced: Default::default(),
             files_with_identical_hashes_referenced: Default::default(),
+            files_with_fuzzy_names_referenced: Default::default(),
             params,
         }
     }
@@ -110,6 +113,132 @@ impl DuplicateFinder {
                 WorkContinueStatus::Continue
             }
             DirTraversalResult::Stopped => WorkContinueStatus::Stop,
+        }
+    }
+
+    #[fun_time(message = "check_files_fuzzy_name", level = "debug")]
+    pub(crate) fn check_files_fuzzy_name(&mut self, stop_flag: &Arc<AtomicBool>, progress_sender: Option<&Sender<ProgressData>>) -> WorkContinueStatus {
+        // Collect all files grouped by extension for performance (files with different extensions rarely match)
+        let group_by_func = |fe: &FileEntry| fe.path.extension().map(|e| e.to_string_lossy().to_lowercase()).unwrap_or_default();
+
+        let result = DirTraversalBuilder::new()
+            .common_data(&self.common_data)
+            .group_by(group_by_func)
+            .stop_flag(stop_flag)
+            .progress_sender(progress_sender)
+            .checking_method(CheckingMethod::FuzzyName)
+            .build()
+            .run();
+
+        match result {
+            DirTraversalResult::SuccessFiles { grouped_file_entries, warnings } => {
+                self.common_data.text_messages.warnings.extend(warnings);
+
+                let threshold = self.get_params().name_similarity_threshold;
+                let case_sensitive = self.get_params().case_sensitive_name_comparison;
+                let mut all_groups: Vec<Vec<DuplicateEntry>> = Vec::new();
+
+                for (_ext, files) in grouped_file_entries {
+                    if files.len() < 2 {
+                        continue;
+                    }
+                    if check_if_stop_received(stop_flag) {
+                        return WorkContinueStatus::Stop;
+                    }
+
+                    let names: Vec<String> = files
+                        .iter()
+                        .map(|fe| {
+                            let name = fe
+                                .path
+                                .file_stem()
+                                .unwrap_or_else(|| panic!("Found invalid file_stem \"{}\"", fe.path.to_string_lossy()))
+                                .to_string_lossy();
+                            if case_sensitive { name.to_string() } else { name.to_lowercase() }
+                        })
+                        .collect();
+
+                    // Union-Find for grouping similar filenames
+                    let n = files.len();
+                    let mut parent: Vec<usize> = (0..n).collect();
+
+                    fn find(parent: &mut Vec<usize>, i: usize) -> usize {
+                        if parent[i] != i {
+                            parent[i] = find(parent, parent[i]);
+                        }
+                        parent[i]
+                    }
+
+                    fn union(parent: &mut Vec<usize>, a: usize, b: usize) {
+                        let ra = find(parent, a);
+                        let rb = find(parent, b);
+                        if ra != rb {
+                            parent[ra] = rb;
+                        }
+                    }
+
+                    for i in 0..n {
+                        for j in (i + 1)..n {
+                            let similarity = strsim::jaro_winkler(&names[i], &names[j]);
+                            if similarity >= threshold {
+                                union(&mut parent, i, j);
+                            }
+                        }
+                    }
+
+                    // Collect groups
+                    let mut groups: HashMap<usize, Vec<usize>> = HashMap::new();
+                    for i in 0..n {
+                        let root = find(&mut parent, i);
+                        groups.entry(root).or_default().push(i);
+                    }
+
+                    for (_root, indices) in groups {
+                        if indices.len() > 1 {
+                            let group: Vec<DuplicateEntry> = indices.into_iter().map(|idx| FileEntry::into_duplicate_entry(files[idx].clone())).collect();
+                            all_groups.push(group);
+                        }
+                    }
+                }
+
+                self.files_with_fuzzy_names = all_groups;
+
+                if self.common_data.use_reference_folders {
+                    let groups = mem::take(&mut self.files_with_fuzzy_names);
+                    self.files_with_fuzzy_names_referenced = groups
+                        .into_iter()
+                        .filter_map(|vec_file_entry| {
+                            let (mut files_from_referenced_folders, normal_files): (Vec<_>, Vec<_>) = vec_file_entry
+                                .into_iter()
+                                .partition(|e| self.common_data.directories.is_in_referenced_directory(e.get_path()));
+
+                            if normal_files.is_empty() {
+                                None
+                            } else {
+                                files_from_referenced_folders.pop().map(|file| (file, normal_files))
+                            }
+                        })
+                        .collect();
+                }
+
+                self.calculate_fuzzy_name_stats();
+                WorkContinueStatus::Continue
+            }
+            DirTraversalResult::Stopped => WorkContinueStatus::Stop,
+        }
+    }
+
+    fn calculate_fuzzy_name_stats(&mut self) {
+        if self.common_data.use_reference_folders {
+            for (_fe, vector) in &self.files_with_fuzzy_names_referenced {
+                self.information.number_of_duplicated_files_by_fuzzy_name += vector.len();
+                self.information.number_of_groups_by_fuzzy_name += 1;
+            }
+        } else {
+            for vector in &self.files_with_fuzzy_names {
+                self.information.number_of_duplicated_files_by_fuzzy_name += vector.len() - 1;
+                self.information.number_of_groups_by_fuzzy_name += 1;
+            }
         }
     }
 

--- a/czkawka_core/src/tools/duplicate/core.rs
+++ b/czkawka_core/src/tools/duplicate/core.rs
@@ -117,6 +117,7 @@ impl DuplicateFinder {
     }
 
     #[fun_time(message = "check_files_fuzzy_name", level = "debug")]
+    #[allow(clippy::indexing_slicing)] // Union-find indices are always in-bounds (0..n over Vecs of size n)
     pub(crate) fn check_files_fuzzy_name(&mut self, stop_flag: &Arc<AtomicBool>, progress_sender: Option<&Sender<ProgressData>>) -> WorkContinueStatus {
         // Collect all files grouped by extension for performance (files with different extensions rarely match)
         let group_by_func = |fe: &FileEntry| fe.path.extension().map(|e| e.to_string_lossy().to_lowercase()).unwrap_or_default();

--- a/czkawka_core/src/tools/duplicate/mod.rs
+++ b/czkawka_core/src/tools/duplicate/mod.rs
@@ -76,6 +76,8 @@ pub struct Info {
     pub number_of_duplicated_files_by_name: usize,
     pub number_of_groups_by_size_name: usize,
     pub number_of_duplicated_files_by_size_name: usize,
+    pub number_of_groups_by_fuzzy_name: usize,
+    pub number_of_duplicated_files_by_fuzzy_name: usize,
     pub lost_space_by_size: u64,
     pub lost_space_by_hash: u64,
     pub scanning_time: Duration,
@@ -89,6 +91,7 @@ pub struct DuplicateFinderParameters {
     pub minimal_cache_file_size: u64,
     pub minimal_prehash_cache_file_size: u64,
     pub case_sensitive_name_comparison: bool,
+    pub name_similarity_threshold: f64,
 }
 
 impl DuplicateFinderParameters {
@@ -107,7 +110,12 @@ impl DuplicateFinderParameters {
             minimal_cache_file_size,
             minimal_prehash_cache_file_size,
             case_sensitive_name_comparison,
+            name_similarity_threshold: 0.85,
         }
+    }
+    pub fn with_name_similarity_threshold(mut self, threshold: f64) -> Self {
+        self.name_similarity_threshold = threshold.clamp(0.0, 1.0);
+        self
     }
 }
 
@@ -122,6 +130,8 @@ pub struct DuplicateFinder {
     files_with_identical_size: BTreeMap<u64, Vec<DuplicateEntry>>,
     // File Size, next grouped by file size, next grouped by hash
     files_with_identical_hashes: BTreeMap<u64, Vec<Vec<DuplicateEntry>>>,
+    // Fuzzy name groups: group_id -> Vec<DuplicateEntry>
+    files_with_fuzzy_names: Vec<Vec<DuplicateEntry>>,
     // File Size, File Entry
     files_with_identical_names_referenced: BTreeMap<String, (DuplicateEntry, Vec<DuplicateEntry>)>,
     // File (Size, Name), File Entry
@@ -130,6 +140,8 @@ pub struct DuplicateFinder {
     files_with_identical_size_referenced: BTreeMap<u64, (DuplicateEntry, Vec<DuplicateEntry>)>,
     // File Size, next grouped by file size, next grouped by hash
     files_with_identical_hashes_referenced: BTreeMap<u64, Vec<(DuplicateEntry, Vec<DuplicateEntry>)>>,
+    // Fuzzy name groups with reference: (reference, Vec<DuplicateEntry>)
+    files_with_fuzzy_names_referenced: Vec<(DuplicateEntry, Vec<DuplicateEntry>)>,
     params: DuplicateFinderParameters,
 }
 
@@ -217,6 +229,14 @@ impl DuplicateFinder {
 
     pub fn get_files_with_identical_size_names_referenced(&self) -> &BTreeMap<(u64, String), (DuplicateEntry, Vec<DuplicateEntry>)> {
         &self.files_with_identical_size_names_referenced
+    }
+
+    pub fn get_files_with_fuzzy_names(&self) -> &Vec<Vec<DuplicateEntry>> {
+        &self.files_with_fuzzy_names
+    }
+
+    pub fn get_files_with_fuzzy_names_referenced(&self) -> &Vec<(DuplicateEntry, Vec<DuplicateEntry>)> {
+        &self.files_with_fuzzy_names_referenced
     }
 }
 

--- a/czkawka_core/src/tools/duplicate/traits.rs
+++ b/czkawka_core/src/tools/duplicate/traits.rs
@@ -25,6 +25,7 @@ impl DeletingItems for DuplicateFinder {
 
         let files_to_delete = match self.get_params().check_method {
             CheckingMethod::Name => self.files_with_identical_names.values().cloned().collect::<Vec<_>>(),
+            CheckingMethod::FuzzyName => self.files_with_fuzzy_names.clone(),
             CheckingMethod::SizeName => self.files_with_identical_size_names.values().cloned().collect::<Vec<_>>(),
             CheckingMethod::Hash => self.files_with_identical_hashes.values().flatten().cloned().collect::<Vec<_>>(),
             CheckingMethod::Size => self.files_with_identical_size.values().cloned().collect::<Vec<_>>(),
@@ -48,6 +49,12 @@ impl Search for DuplicateFinder {
             match self.get_params().check_method {
                 CheckingMethod::Name => {
                     self.common_data.stopped_search = self.check_files_name(stop_flag, progress_sender) == WorkContinueStatus::Stop;
+                    if self.common_data.stopped_search {
+                        return;
+                    }
+                }
+                CheckingMethod::FuzzyName => {
+                    self.common_data.stopped_search = self.check_files_fuzzy_name(stop_flag, progress_sender) == WorkContinueStatus::Stop;
                     if self.common_data.stopped_search {
                         return;
                     }
@@ -123,6 +130,7 @@ impl DebugPrint for DuplicateFinder {
         println!("Hashed files list size - {}", self.files_with_identical_hashes.len());
         println!("Files with identical names - {}", self.files_with_identical_names.len());
         println!("Files with identical size names - {}", self.files_with_identical_size_names.len());
+        println!("Files with fuzzy names - {}", self.files_with_fuzzy_names.len());
         println!("Files with identical names referenced - {}", self.files_with_identical_names_referenced.len());
         println!("Files with identical size names referenced - {}", self.files_with_identical_size_names_referenced.len());
         println!("Files with identical size referenced - {}", self.files_with_identical_size_referenced.len());
@@ -176,6 +184,48 @@ impl PrintResults for DuplicateFinder {
                     }
                 } else {
                     write!(writer, "Not found any files with same names.")?;
+                }
+            }
+            CheckingMethod::FuzzyName => {
+                if !self.files_with_fuzzy_names.is_empty() {
+                    writeln!(
+                        writer,
+                        "-------------------------------------------------Files with similar names-------------------------------------------------"
+                    )?;
+                    writeln!(
+                        writer,
+                        "Found {} files in {} groups with similar names (threshold: {:.0}%)",
+                        self.information.number_of_duplicated_files_by_fuzzy_name,
+                        self.information.number_of_groups_by_fuzzy_name,
+                        self.params.name_similarity_threshold * 100.0,
+                    )?;
+                    for vector in &self.files_with_fuzzy_names {
+                        writeln!(writer, "\n---- {} files", vector.len())?;
+                        for j in vector {
+                            writeln!(writer, "\"{}\"", j.path.to_string_lossy())?;
+                        }
+                    }
+                } else if !self.files_with_fuzzy_names_referenced.is_empty() {
+                    writeln!(
+                        writer,
+                        "-------------------------------------------------Files with similar names in referenced folders-------------------------------------------------"
+                    )?;
+                    writeln!(
+                        writer,
+                        "Found {} files in {} groups with similar names (threshold: {:.0}%)",
+                        self.information.number_of_duplicated_files_by_fuzzy_name,
+                        self.information.number_of_groups_by_fuzzy_name,
+                        self.params.name_similarity_threshold * 100.0,
+                    )?;
+                    for (file_entry, vector) in &self.files_with_fuzzy_names_referenced {
+                        writeln!(writer, "\n---- {} files", vector.len())?;
+                        writeln!(writer, "Reference file - \"{}\"", file_entry.path.to_string_lossy())?;
+                        for j in vector {
+                            writeln!(writer, "\"{}\"", j.path.to_string_lossy())?;
+                        }
+                    }
+                } else {
+                    write!(writer, "Not found any files with similar names.")?;
                 }
             }
             CheckingMethod::SizeName => {
@@ -317,6 +367,7 @@ impl PrintResults for DuplicateFinder {
         if self.get_use_reference() {
             match self.get_params().check_method {
                 CheckingMethod::Name => self.save_results_to_file_as_json_internal(file_name, &self.files_with_identical_names_referenced, pretty_print),
+                CheckingMethod::FuzzyName => self.save_results_to_file_as_json_internal(file_name, &self.files_with_fuzzy_names_referenced, pretty_print),
                 CheckingMethod::SizeName => {
                     self.save_results_to_file_as_json_internal(file_name, &self.files_with_identical_size_names_referenced.values().collect::<Vec<_>>(), pretty_print)
                 }
@@ -327,6 +378,7 @@ impl PrintResults for DuplicateFinder {
         } else {
             match self.get_params().check_method {
                 CheckingMethod::Name => self.save_results_to_file_as_json_internal(file_name, &self.files_with_identical_names, pretty_print),
+                CheckingMethod::FuzzyName => self.save_results_to_file_as_json_internal(file_name, &self.files_with_fuzzy_names, pretty_print),
                 CheckingMethod::SizeName => self.save_results_to_file_as_json_internal(file_name, &self.files_with_identical_size_names.values().collect::<Vec<_>>(), pretty_print),
                 CheckingMethod::Size => self.save_results_to_file_as_json_internal(file_name, &self.files_with_identical_size, pretty_print),
                 CheckingMethod::Hash => self.save_results_to_file_as_json_internal(file_name, &self.files_with_identical_hashes, pretty_print),
@@ -358,6 +410,7 @@ impl CommonData for DuplicateFinder {
     fn found_any_items(&self) -> bool {
         self.get_information().number_of_duplicated_files_by_hash > 0
             || self.get_information().number_of_duplicated_files_by_name > 0
+            || self.get_information().number_of_duplicated_files_by_fuzzy_name > 0
             || self.get_information().number_of_duplicated_files_by_size > 0
             || self.get_information().number_of_duplicated_files_by_size_name > 0
     }


### PR DESCRIPTION
## Summary
- Add a new `FUZZY_NAME` checking method to the duplicate finder using Jaro-Winkler string similarity
- New `check_files_fuzzy_name()` groups files whose basename similarity exceeds a configurable threshold (default 0.85)
- CLI flags: `--search-method fuzzy-name` and `--name-similarity-threshold`
- Adds `strsim` dependency for Jaro-Winkler distance calculation

## Test plan
- [ ] Run `czkawka_cli dup -d <dir> -m fuzzy-name` and verify similar filenames are grouped
- [ ] Verify `--name-similarity-threshold` adjusts matching sensitivity
- [ ] Confirm no regressions in existing duplicate detection methods
- [ ] `cargo check -p czkawka_core -p czkawka_cli` passes

Closes #1854

🤖 Generated with [Claude Code](https://claude.com/claude-code)