### PR TITLE
Add --no-self-compare flag to exclude intra-directory duplicates

### DIFF
--- a/czkawka_cli/src/commands.rs
+++ b/czkawka_cli/src/commands.rs
@@ -188,6 +188,13 @@ pub struct DuplicatesArgs {
     pub case_sensitive_name_comparison: CaseSensitiveNameComparison,
     #[clap(flatten)]
     pub allow_hard_links: AllowHardLinks,
+    #[clap(
+        long,
+        default_value = "false",
+        help = "Don't compare files within the same included directory",
+        long_help = "When enabled, files within the same included directory are not compared against each other. Only files across different included directories are considered duplicates. Useful for comparing a 'known good' archive against a messy folder without finding duplicates within the archive itself."
+    )]
+    pub no_self_compare: bool,
 }
 
 #[derive(Debug, clap::Args)]

--- a/czkawka_cli/src/main.rs
+++ b/czkawka_cli/src/main.rs
@@ -128,6 +128,7 @@ fn duplicates(duplicates: DuplicatesArgs, stop_flag: &Arc<AtomicBool>, progress_
         case_sensitive_name_comparison,
         minimal_prehash_cache_file_size,
         use_prehash_cache,
+        no_self_compare,
     } = duplicates;
 
     let params = DuplicateFinderParameters::new(
@@ -137,7 +138,8 @@ fn duplicates(duplicates: DuplicatesArgs, stop_flag: &Arc<AtomicBool>, progress_
         minimal_cached_file_size,
         minimal_prehash_cache_file_size,
         case_sensitive_name_comparison.case_sensitive_name_comparison,
-    );
+    )
+    .with_no_self_compare(no_self_compare);
     let mut tool = DuplicateFinder::new(params);
 
     set_common_settings(&mut tool, &common_cli_items, Some(reference_directories.reference_directories.as_ref()));

--- a/czkawka_core/src/common/directories.rs
+++ b/czkawka_core/src/common/directories.rs
@@ -249,6 +249,11 @@ impl Directories {
         self.reference_directories.iter().any(|e| path.starts_with(e)) || self.reference_files.iter().any(|e| e.as_path() == path)
     }
 
+    /// Returns the index of the included directory that contains the given path, or None.
+    pub(crate) fn included_directory_index(&self, path: &Path) -> Option<usize> {
+        self.included_directories.iter().position(|d| path.starts_with(d))
+    }
+
     pub(crate) fn is_excluded_dir(&self, path: &Path) -> bool {
         #[cfg(target_family = "windows")]
         let path = crate::common::normalize_windows_path(path);

--- a/czkawka_core/src/tools/duplicate/core.rs
+++ b/czkawka_core/src/tools/duplicate/core.rs
@@ -796,11 +796,11 @@ impl DuplicateFinder {
         let dirs = &self.common_data.directories;
 
         let all_from_same_dir = |entries: &[DuplicateEntry]| -> bool {
-            if entries.len() <= 1 {
+            let Some(first) = entries.first() else {
                 return true;
-            }
-            let first_idx = dirs.included_directory_index(entries[0].path.as_path());
-            entries[1..].iter().all(|e| dirs.included_directory_index(e.path.as_path()) == first_idx)
+            };
+            let first_idx = dirs.included_directory_index(first.path.as_path());
+            entries.iter().skip(1).all(|e| dirs.included_directory_index(e.path.as_path()) == first_idx)
         };
 
         // Filter name groups
@@ -810,7 +810,7 @@ impl DuplicateFinder {
         // Filter size+name groups
         self.files_with_identical_size_names.retain(|_k, v| !all_from_same_dir(v));
         // Filter hash groups (nested: size -> vec of hash groups)
-        for (_size, hash_groups) in &mut self.files_with_identical_hashes {
+        for hash_groups in self.files_with_identical_hashes.values_mut() {
             hash_groups.retain(|group| !all_from_same_dir(group));
         }
         self.files_with_identical_hashes.retain(|_k, v| !v.is_empty());

--- a/czkawka_core/src/tools/duplicate/core.rs
+++ b/czkawka_core/src/tools/duplicate/core.rs
@@ -788,6 +788,33 @@ impl DuplicateFinder {
 
         WorkContinueStatus::Continue
     }
+
+    /// Filter out duplicate groups where all files come from the same included directory.
+    /// This implements "no self-compare": files within the same directory are not considered
+    /// duplicates of each other, only files across different directories.
+    pub(crate) fn filter_same_directory_groups(&mut self) {
+        let dirs = &self.common_data.directories;
+
+        let all_from_same_dir = |entries: &[DuplicateEntry]| -> bool {
+            if entries.len() <= 1 {
+                return true;
+            }
+            let first_idx = dirs.included_directory_index(entries[0].path.as_path());
+            entries[1..].iter().all(|e| dirs.included_directory_index(e.path.as_path()) == first_idx)
+        };
+
+        // Filter name groups
+        self.files_with_identical_names.retain(|_k, v| !all_from_same_dir(v));
+        // Filter size groups
+        self.files_with_identical_size.retain(|_k, v| !all_from_same_dir(v));
+        // Filter size+name groups
+        self.files_with_identical_size_names.retain(|_k, v| !all_from_same_dir(v));
+        // Filter hash groups (nested: size -> vec of hash groups)
+        for (_size, hash_groups) in &mut self.files_with_identical_hashes {
+            hash_groups.retain(|group| !all_from_same_dir(group));
+        }
+        self.files_with_identical_hashes.retain(|_k, v| !v.is_empty());
+    }
 }
 
 pub fn get_duplicate_cache_file(type_of_hash: HashType, is_prehash: bool) -> String {

--- a/czkawka_core/src/tools/duplicate/mod.rs
+++ b/czkawka_core/src/tools/duplicate/mod.rs
@@ -89,6 +89,7 @@ pub struct DuplicateFinderParameters {
     pub minimal_cache_file_size: u64,
     pub minimal_prehash_cache_file_size: u64,
     pub case_sensitive_name_comparison: bool,
+    pub no_self_compare: bool,
 }
 
 impl DuplicateFinderParameters {
@@ -107,7 +108,12 @@ impl DuplicateFinderParameters {
             minimal_cache_file_size,
             minimal_prehash_cache_file_size,
             case_sensitive_name_comparison,
+            no_self_compare: false,
         }
+    }
+    pub fn with_no_self_compare(mut self, enabled: bool) -> Self {
+        self.no_self_compare = enabled;
+        self
     }
 }
 

--- a/czkawka_core/src/tools/duplicate/traits.rs
+++ b/czkawka_core/src/tools/duplicate/traits.rs
@@ -76,6 +76,11 @@ impl Search for DuplicateFinder {
                 }
                 _ => panic!(),
             }
+            // Filter out groups where all files come from the same included directory
+            if self.get_params().no_self_compare {
+                self.filter_same_directory_groups();
+            }
+
             if self.delete_files(stop_flag, progress_sender) == WorkContinueStatus::Stop {
                 self.common_data.stopped_search = true;
             }


### PR DESCRIPTION
## Summary
- Add `--no-self-compare` CLI flag to filter out duplicate groups where all files are in the same directory
- Useful when scanning multiple directories and only wanting cross-directory duplicates
- New `filter_same_directory_groups()` post-processing filter applied after grouping

## Test plan
- [ ] Run `czkawka_cli dup -d /dir1 -d /dir2 --no-self-compare` and verify only cross-directory groups appear
- [ ] Verify without the flag, all groups (including same-directory) still appear
- [ ] `cargo check -p czkawka_core -p czkawka_cli` passes

Closes #1859

🤖 Generated with [Claude Code](https://claude.com/claude-code)