### PR TITLE
Expose similarity confidence scores for music fingerprint matches

### DIFF
--- a/czkawka_core/src/tools/same_music/core.rs
+++ b/czkawka_core/src/tools/same_music/core.rs
@@ -426,7 +426,16 @@ impl SameMusic {
                         Err(e) => return Some(Err(flc!("core_error_comparing_fingerprints", reason = e.to_string()))),
                     };
                     segments.retain(|s| s.duration(configuration) > minimum_segment_duration && s.score < maximum_difference);
-                    if segments.is_empty() { None } else { Some(Ok((e_string, e_entry))) }
+                    if segments.is_empty() {
+                        None
+                    } else {
+                        let best_score = segments
+                            .iter()
+                            .map(|s| s.score)
+                            .min_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+                            .unwrap_or(0.0);
+                        Some(Ok((e_string, e_entry, best_score)))
+                    }
                 })
                 .flatten()
                 .partition_map(|res| match res {
@@ -436,12 +445,14 @@ impl SameMusic {
 
             self.common_data.text_messages.errors.extend(errors);
 
-            collected_similar_items.retain(|(path, _entry)| !used_paths.contains(path));
+            collected_similar_items.retain(|(path, _entry, _score)| !used_paths.contains(path));
             if !collected_similar_items.is_empty() {
                 let mut music_entries = Vec::new();
-                for (path, entry) in collected_similar_items {
+                for (path, entry, score) in collected_similar_items {
                     used_paths.insert(path);
-                    music_entries.push(entry.clone());
+                    let mut entry = entry.clone();
+                    entry.similarity_score = score;
+                    music_entries.push(entry);
                 }
                 used_paths.insert(f_string);
                 music_entries.push(f_entry);

--- a/czkawka_core/src/tools/same_music/mod.rs
+++ b/czkawka_core/src/tools/same_music/mod.rs
@@ -44,6 +44,9 @@ pub struct MusicEntry {
     pub length: u32,
     pub genre: String,
     pub bitrate: u32,
+    /// Best fingerprint match score (lower = more similar). 0 for tag-based matches.
+    #[serde(default)]
+    pub similarity_score: f64,
 }
 
 impl ResultEntry for MusicEntry {
@@ -72,6 +75,7 @@ impl FileEntry {
             length: 0,
             genre: String::new(),
             bitrate: 0,
+            similarity_score: 0.0,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add `similarity_score` field (f64) to `MusicEntry` from rusty_chromaprint fingerprint matching
- Gives users visibility into how closely tracks match when using audio fingerprinting
- Score is populated during the comparison phase and included in results output

## Test plan
- [ ] Run similar music scan with fingerprint method and verify scores appear in output
- [ ] `cargo check -p czkawka_core` passes

Closes #1860

🤖 Generated with [Claude Code](https://claude.com/claude-code)