### PR TITLE
Add fuzzy Jaro-Winkler tag matching for similar music detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1693,6 +1693,7 @@ dependencies = [
  "serde",
  "serde_json",
  "static_assertions",
+ "strsim 0.11.1",
  "symphonia",
  "tempfile",
  "tokio",

--- a/czkawka_cli/src/commands.rs
+++ b/czkawka_cli/src/commands.rs
@@ -381,6 +381,28 @@ pub struct SameMusicArgs {
         long_help = "Maximum allowed difference between audio segments (0.0-10.0). Value 0.0 will find only identical segments, while 10.0 will find segments that are barely similar. Lower values mean stricter matching."
     )]
     pub maximum_difference: f64,
+    #[clap(
+        long,
+        help = "Use fuzzy (Jaro-Winkler) comparison for tag matching",
+        long_help = "When enabled, music tags are compared using Jaro-Winkler string similarity instead of exact matching. This catches variations like 'Beatles' vs 'The Beatles' or small typos in tag values. Only applies to TAGS search method."
+    )]
+    pub fuzzy_tag_comparison: bool,
+    #[clap(
+        long,
+        value_parser = parse_tag_similarity_threshold,
+        default_value = "0.85",
+        help = "Similarity threshold for fuzzy tag matching (0.0-1.0)",
+        long_help = "Minimum Jaro-Winkler similarity score for two tag values to be considered a match. 1.0 means exact match, 0.0 matches everything. Recommended range: 0.80-0.95. Only used when --fuzzy-tag-comparison is enabled."
+    )]
+    pub tag_similarity_threshold: f64,
+}
+
+fn parse_tag_similarity_threshold(src: &str) -> Result<f64, String> {
+    match src.parse::<f64>() {
+        Ok(v) if (0.0..=1.0).contains(&v) => Ok(v),
+        Ok(v) => Err(format!("Tag similarity threshold {v} is not in valid range 0.0-1.0")),
+        Err(e) => Err(format!("Cannot parse tag similarity threshold: {e}")),
+    }
 }
 
 fn parse_maximum_difference(src: &str) -> Result<f64, String> {

--- a/czkawka_cli/src/main.rs
+++ b/czkawka_cli/src/main.rs
@@ -252,9 +252,11 @@ fn same_music(same_music: SameMusicArgs, stop_flag: &Arc<AtomicBool>, progress_s
         search_method,
         approximate_comparison,
         compare_fingerprints_only_with_similar_titles,
+        fuzzy_tag_comparison,
+        tag_similarity_threshold,
     } = same_music;
 
-    let params = SameMusicParameters::new(
+    let mut params = SameMusicParameters::new(
         music_similarity,
         approximate_comparison,
         search_method,
@@ -262,6 +264,8 @@ fn same_music(same_music: SameMusicArgs, stop_flag: &Arc<AtomicBool>, progress_s
         maximum_difference,
         compare_fingerprints_only_with_similar_titles,
     );
+    params.fuzzy_tag_comparison = fuzzy_tag_comparison;
+    params.tag_similarity_threshold = tag_similarity_threshold;
     let mut tool = SameMusic::new(params);
 
     set_common_settings(&mut tool, &common_cli_items, Some(reference_directories.reference_directories.as_ref()));

--- a/czkawka_core/Cargo.toml
+++ b/czkawka_core/Cargo.toml
@@ -103,6 +103,7 @@ rand = "0.10.0"
 
 ashpd = { version = "0.13.2", optional = true, features = ["trash"] }
 tokio = { version = "1.49.0", optional = true }
+strsim = "0.11.1"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 trash = "5.1"

--- a/czkawka_core/src/tools/same_music/core.rs
+++ b/czkawka_core/src/tools/same_music/core.rs
@@ -506,22 +506,70 @@ impl SameMusic {
         get_item: fn(&MusicEntry) -> String,
         approximate_comparison: bool,
     ) -> Vec<Vec<MusicEntry>> {
+        let fuzzy = self.params.fuzzy_tag_comparison;
+        let threshold = self.params.tag_similarity_threshold;
+
         let mut new_duplicates: Vec<_> = Default::default();
         let old_duplicates_len = old_duplicates.len();
         for vec_file_entry in old_duplicates {
-            let mut hash_map: BTreeMap<String, Vec<MusicEntry>> = Default::default();
-            for file_entry in vec_file_entry {
-                let mut thing = get_item(&file_entry).trim().to_lowercase();
-                if approximate_comparison {
-                    thing = get_simplified_name(&thing);
+            if fuzzy {
+                // Fuzzy mode: pairwise Jaro-Winkler comparison, union-find clustering
+                let normalized: Vec<String> = vec_file_entry.iter().map(|fe| normalize_tag(&get_item(fe))).collect();
+                let n = normalized.len();
+                // Simple union-find
+                let mut parent: Vec<usize> = (0..n).collect();
+                fn find(parent: &mut [usize], mut i: usize) -> usize {
+                    while parent[i] != i {
+                        parent[i] = parent[parent[i]];
+                        i = parent[i];
+                    }
+                    i
                 }
-                if !thing.is_empty() {
-                    hash_map.entry(thing).or_default().push(file_entry);
+                for i in 0..n {
+                    if normalized[i].is_empty() {
+                        continue;
+                    }
+                    for j in (i + 1)..n {
+                        if normalized[j].is_empty() {
+                            continue;
+                        }
+                        let sim = strsim::jaro_winkler(&normalized[i], &normalized[j]);
+                        if sim >= threshold {
+                            let ri = find(&mut parent, i);
+                            let rj = find(&mut parent, j);
+                            parent[ri] = rj;
+                        }
+                    }
                 }
-            }
-            for (_title, vec_file_entry) in hash_map {
-                if vec_file_entry.len() > 1 {
-                    new_duplicates.push(vec_file_entry);
+                // Collect clusters
+                let mut clusters: BTreeMap<usize, Vec<MusicEntry>> = Default::default();
+                for (i, entry) in vec_file_entry.into_iter().enumerate() {
+                    if !normalized[i].is_empty() {
+                        let root = find(&mut parent, i);
+                        clusters.entry(root).or_default().push(entry);
+                    }
+                }
+                for (_root, group) in clusters {
+                    if group.len() > 1 {
+                        new_duplicates.push(group);
+                    }
+                }
+            } else {
+                // Exact mode: hash-based grouping
+                let mut hash_map: BTreeMap<String, Vec<MusicEntry>> = Default::default();
+                for file_entry in vec_file_entry {
+                    let mut thing = get_item(&file_entry).trim().to_lowercase();
+                    if approximate_comparison {
+                        thing = get_simplified_name(&thing);
+                    }
+                    if !thing.is_empty() {
+                        hash_map.entry(thing).or_default().push(file_entry);
+                    }
+                }
+                for (_title, vec_file_entry) in hash_map {
+                    if vec_file_entry.len() > 1 {
+                        new_duplicates.push(vec_file_entry);
+                    }
                 }
             }
         }
@@ -529,6 +577,21 @@ impl SameMusic {
 
         new_duplicates
     }
+}
+
+/// Normalize a music tag for fuzzy comparison: lowercase, strip common
+/// prefixes ("the ", "a ", "an "), collapse whitespace, strip non-alphanumeric.
+fn normalize_tag(s: &str) -> String {
+    let s = s.trim().to_lowercase();
+    let s = s.strip_prefix("the ").unwrap_or(&s);
+    let s = s.strip_prefix("a ").unwrap_or(s);
+    let s = s.strip_prefix("an ").unwrap_or(s);
+    s.chars()
+        .filter(|c| c.is_alphanumeric() || c.is_whitespace())
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 // TODO this should be taken from rusty-chromaprint repo, not reimplemented here

--- a/czkawka_core/src/tools/same_music/mod.rs
+++ b/czkawka_core/src/tools/same_music/mod.rs
@@ -96,6 +96,11 @@ pub struct SameMusicParameters {
     pub minimum_segment_duration: f32,
     pub maximum_difference: f64,
     pub compare_fingerprints_only_with_similar_titles: bool,
+    /// When true, use fuzzy (Jaro-Winkler) comparison for tag matching
+    /// instead of exact grouping. Only applies to AudioTags mode.
+    pub fuzzy_tag_comparison: bool,
+    /// Similarity threshold for fuzzy tag matching (0.0–1.0, default 0.85).
+    pub tag_similarity_threshold: f64,
 }
 
 impl SameMusicParameters {
@@ -116,6 +121,8 @@ impl SameMusicParameters {
             minimum_segment_duration,
             maximum_difference,
             compare_fingerprints_only_with_similar_titles,
+            fuzzy_tag_comparison: false,
+            tag_similarity_threshold: 0.85,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add fuzzy string comparison for music tag matching using Jaro-Winkler distance (strsim crate)
- Allows detecting similar (but not exact) artist/title/album tags
- CLI flags: `--fuzzy-tag-comparison` and `--tag-similarity-threshold` (default 0.85)

## Test plan
- [ ] Run similar music scan with `--fuzzy-tag-comparison` and verify fuzzy matches are found
- [ ] Verify `--tag-similarity-threshold` adjusts matching sensitivity
- [ ] Confirm no regressions in exact tag matching mode
- [ ] `cargo check -p czkawka_core -p czkawka_cli` passes

Closes #1864

🤖 Generated with [Claude Code](https://claude.com/claude-code)