### PR TITLE
Optimize CLI: BTreeMap to HashMap, bounded channel, LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ overflow-checks = true
 # But it is used to optimize release builds(and probably also in CI, where time is not so important as in local development)
 # Fat lto, generates a lot smaller executable than thin lto
 # Also using codegen-units = 1, to generate smaller binaries
-#lto = "fat"
-#codegen-units = 1
+lto = "fat"
+codegen-units = 1
 
 # Optimize all dependencies except application/workspaces, even in debug builds to get reasonable performance e.g. when opening images
 [profile.dev.package."*"] # OPT PACKAGES

--- a/czkawka_cli/src/main.rs
+++ b/czkawka_cli/src/main.rs
@@ -5,7 +5,7 @@ use std::thread;
 
 use clap::Parser;
 use commands::Commands;
-use crossbeam_channel::{Receiver, Sender, unbounded};
+use crossbeam_channel::{Receiver, Sender, bounded};
 use czkawka_core::common::config_cache_path::{print_infos_and_warnings, set_config_cache_path};
 use czkawka_core::common::consts::DEFAULT_THREAD_SIZE;
 use czkawka_core::common::image::register_image_decoding_hooks;
@@ -65,7 +65,7 @@ fn main() {
         debug!("Running command - {command:?}");
     }
 
-    let (progress_sender, progress_receiver): (Sender<ProgressData>, Receiver<ProgressData>) = unbounded();
+    let (progress_sender, progress_receiver): (Sender<ProgressData>, Receiver<ProgressData>) = bounded(256);
     let stop_flag = Arc::new(AtomicBool::new(false));
     let store_flag_cloned = stop_flag.clone();
 

--- a/czkawka_core/src/common/cache.rs
+++ b/czkawka_core/src/common/cache.rs
@@ -2,7 +2,7 @@
 
 mod cleaning;
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::io::{BufReader, BufWriter};
 use std::path::Path;
 use std::{fs, mem};
@@ -45,7 +45,7 @@ fn get_cache_size(file_name: &Path) -> String {
 }
 
 #[fun_time(message = "save_cache_to_file_generalized", level = "debug")]
-pub fn save_cache_to_file_generalized<T>(cache_file_name: &str, hashmap: &BTreeMap<String, T>, save_also_as_json: bool, minimum_file_size: u64) -> Messages
+pub fn save_cache_to_file_generalized<T>(cache_file_name: &str, hashmap: &HashMap<String, T>, save_also_as_json: bool, minimum_file_size: u64) -> Messages
 where
     T: Serialize + ResultEntry + Sized + Send + Sync,
 {
@@ -90,10 +90,10 @@ where
 }
 
 pub(crate) fn extract_loaded_cache<T>(
-    loaded_hash_map: &BTreeMap<String, T>,
-    files_to_check: BTreeMap<String, T>,
-    records_already_cached: &mut BTreeMap<String, T>,
-    non_cached_files_to_check: &mut BTreeMap<String, T>,
+    loaded_hash_map: &HashMap<String, T>,
+    files_to_check: HashMap<String, T>,
+    records_already_cached: &mut HashMap<String, T>,
+    non_cached_files_to_check: &mut HashMap<String, T>,
 ) where
     T: Clone,
 {
@@ -107,7 +107,7 @@ pub(crate) fn extract_loaded_cache<T>(
 }
 
 #[fun_time(message = "load_cache_from_file_generalized_by_path", level = "debug")]
-pub fn load_cache_from_file_generalized_by_path<T>(cache_file_name: &str, delete_outdated_cache: bool, used_files: &BTreeMap<String, T>) -> (Messages, Option<BTreeMap<String, T>>)
+pub fn load_cache_from_file_generalized_by_path<T>(cache_file_name: &str, delete_outdated_cache: bool, used_files: &HashMap<String, T>) -> (Messages, Option<HashMap<String, T>>)
 where
     for<'a> T: Deserialize<'a> + ResultEntry + Sized + Send + Sync + Clone,
 {
@@ -130,14 +130,14 @@ where
         return (text_messages, None);
     };
 
-    debug!("Converting cache Vec<T> into BTreeMap<String, T>");
+    debug!("Converting cache Vec<T> into HashMap<String, T>");
     let number_of_entries = vec_loaded_entries.len();
     let start_time = std::time::Instant::now();
-    let map_loaded_entries: BTreeMap<String, T> = vec_loaded_entries
+    let map_loaded_entries: HashMap<String, T> = vec_loaded_entries
         .into_iter()
         .map(|file_entry| (file_entry.get_path().to_string_lossy().into_owned(), file_entry))
         .collect();
-    debug!("Converted cache Vec<T>({number_of_entries} results) into BTreeMap<String, T> in {:?}", start_time.elapsed());
+    debug!("Converted cache Vec<T>({number_of_entries} results) into HashMap<String, T> in {:?}", start_time.elapsed());
 
     (text_messages, Some(map_loaded_entries))
 }
@@ -289,9 +289,9 @@ where
 
 pub(crate) fn load_and_split_cache_generalized_by_path<C: CommonData, K>(
     cache_file_name: &str,
-    mut items_to_check: BTreeMap<String, K>,
+    mut items_to_check: HashMap<String, K>,
     common_data: &mut C,
-) -> (BTreeMap<String, K>, BTreeMap<String, K>, BTreeMap<String, K>)
+) -> (HashMap<String, K>, HashMap<String, K>, HashMap<String, K>)
 where
     for<'a> K: Deserialize<'a> + ResultEntry + Sized + Send + Sync + Clone,
 {
@@ -301,8 +301,8 @@ where
 
     let loaded_hash_map;
 
-    let mut records_already_cached: BTreeMap<String, K> = Default::default();
-    let mut non_cached_files_to_check: BTreeMap<String, K> = Default::default();
+    let mut records_already_cached: HashMap<String, K> = Default::default();
+    let mut non_cached_files_to_check: HashMap<String, K> = Default::default();
 
     let (messages, loaded_items) = load_cache_from_file_generalized_by_path::<K>(cache_file_name, common_data.get_delete_outdated_cache(), &items_to_check);
     common_data.get_text_messages_mut().extend_with_another_messages(messages);
@@ -325,14 +325,14 @@ where
     (loaded_hash_map, records_already_cached, non_cached_files_to_check)
 }
 
-pub(crate) fn save_and_connect_cache_generalized_by_path<C: CommonData, K>(cache_file_name: &str, vec_file_entry: &[K], loaded_hash_map: BTreeMap<String, K>, common_data: &mut C)
+pub(crate) fn save_and_connect_cache_generalized_by_path<C: CommonData, K>(cache_file_name: &str, vec_file_entry: &[K], loaded_hash_map: HashMap<String, K>, common_data: &mut C)
 where
     K: Serialize + ResultEntry + Sized + Send + Sync + Clone,
 {
     if !common_data.get_use_cache() {
         return;
     }
-    let mut all_results: BTreeMap<String, K> = Default::default();
+    let mut all_results: HashMap<String, K> = Default::default();
 
     for file_entry in vec_file_entry.iter().cloned() {
         all_results.insert(file_entry.get_path().to_string_lossy().to_string(), file_entry);
@@ -347,7 +347,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::collections::HashMap;
     use std::fs;
     use std::path::PathBuf;
     use std::sync::Once;
@@ -408,17 +408,17 @@ mod tests {
 
     #[test]
     fn test_extract_loaded_cache() {
-        let mut loaded_cache = BTreeMap::new();
+        let mut loaded_cache = HashMap::new();
         loaded_cache.insert("file1".to_string(), TestEntry::new("/tmp/file1", 100, 1000, 10));
         loaded_cache.insert("file2".to_string(), TestEntry::new("/tmp/file2", 200, 2000, 20));
 
-        let mut files_to_check = BTreeMap::new();
+        let mut files_to_check = HashMap::new();
         files_to_check.insert("file1".to_string(), TestEntry::new("/tmp/file1", 100, 1000, 10));
         files_to_check.insert("file3".to_string(), TestEntry::new("/tmp/file3", 300, 3000, 30));
         files_to_check.insert("file2".to_string(), TestEntry::new("/tmp/file2", 200, 2000, 20));
 
-        let mut records_already_cached = BTreeMap::new();
-        let mut non_cached_files_to_check = BTreeMap::new();
+        let mut records_already_cached = HashMap::new();
+        let mut non_cached_files_to_check = HashMap::new();
 
         extract_loaded_cache(&loaded_cache, files_to_check, &mut records_already_cached, &mut non_cached_files_to_check);
 
@@ -433,13 +433,13 @@ mod tests {
 
     #[test]
     fn test_extract_loaded_cache_empty() {
-        let loaded_cache: BTreeMap<String, TestEntry> = BTreeMap::new();
-        let mut files_to_check = BTreeMap::new();
+        let loaded_cache: HashMap<String, TestEntry> = HashMap::new();
+        let mut files_to_check = HashMap::new();
         files_to_check.insert("file1".to_string(), TestEntry::new("/tmp/file1", 100, 1000, 10));
         files_to_check.insert("file2".to_string(), TestEntry::new("/tmp/file2", 200, 2000, 20));
 
-        let mut records_already_cached = BTreeMap::new();
-        let mut non_cached_files_to_check = BTreeMap::new();
+        let mut records_already_cached = HashMap::new();
+        let mut non_cached_files_to_check = HashMap::new();
 
         extract_loaded_cache(&loaded_cache, files_to_check, &mut records_already_cached, &mut non_cached_files_to_check);
 
@@ -449,16 +449,16 @@ mod tests {
 
     #[test]
     fn test_extract_loaded_cache_all_cached() {
-        let mut loaded_cache = BTreeMap::new();
+        let mut loaded_cache = HashMap::new();
         loaded_cache.insert("file1".to_string(), TestEntry::new("/tmp/file1", 100, 1000, 10));
         loaded_cache.insert("file2".to_string(), TestEntry::new("/tmp/file2", 200, 2000, 20));
 
-        let mut files_to_check = BTreeMap::new();
+        let mut files_to_check = HashMap::new();
         files_to_check.insert("file1".to_string(), TestEntry::new("/tmp/file1", 100, 1000, 10));
         files_to_check.insert("file2".to_string(), TestEntry::new("/tmp/file2", 200, 2000, 20));
 
-        let mut records_already_cached = BTreeMap::new();
-        let mut non_cached_files_to_check = BTreeMap::new();
+        let mut records_already_cached = HashMap::new();
+        let mut non_cached_files_to_check = HashMap::new();
 
         extract_loaded_cache(&loaded_cache, files_to_check, &mut records_already_cached, &mut non_cached_files_to_check);
 
@@ -474,7 +474,7 @@ mod tests {
         fs::write(&temp_file, "test content").unwrap();
         let metadata = fs::metadata(&temp_file).unwrap();
 
-        let mut cache_to_save = BTreeMap::new();
+        let mut cache_to_save = HashMap::new();
         cache_to_save.insert(
             temp_file.to_string_lossy().to_string(),
             TestEntry::new(temp_file.to_str().unwrap(), metadata.len(), metadata.modified().unwrap().elapsed().unwrap().as_secs(), 42),
@@ -524,7 +524,7 @@ mod tests {
         ));
 
         // Convert to flat map for saving
-        let mut flat_cache = BTreeMap::new();
+        let mut flat_cache = HashMap::new();
         for entries in cache_to_save.values() {
             for entry in entries {
                 flat_cache.insert(entry.path.to_string_lossy().to_string(), entry.clone());
@@ -552,7 +552,7 @@ mod tests {
         let temp_file = temp_dir.path().join("test_file.txt");
         fs::write(&temp_file, "test").unwrap();
 
-        let mut cache_to_save = BTreeMap::new();
+        let mut cache_to_save = HashMap::new();
         cache_to_save.insert("small_file".to_string(), TestEntry::new("/tmp/small", 10, 1000, 1));
         cache_to_save.insert("large_file".to_string(), TestEntry::new("/tmp/large", 1000, 2000, 2));
 
@@ -581,7 +581,7 @@ mod tests {
         fs::write(&temp_file, "test content").unwrap();
         let metadata = fs::metadata(&temp_file).unwrap();
 
-        let mut cache_to_save = BTreeMap::new();
+        let mut cache_to_save = HashMap::new();
         cache_to_save.insert(
             temp_file.to_string_lossy().to_string(),
             TestEntry::new(temp_file.to_str().unwrap(), metadata.len(), metadata.modified().unwrap().elapsed().unwrap().as_secs(), 42),
@@ -597,7 +597,7 @@ mod tests {
 
         // Create new files_to_check with updated metadata
         let new_metadata = fs::metadata(&temp_file).unwrap();
-        let mut files_to_check = BTreeMap::new();
+        let mut files_to_check = HashMap::new();
         files_to_check.insert(
             temp_file.to_string_lossy().to_string(),
             TestEntry::new(
@@ -621,7 +621,7 @@ mod tests {
     fn test_load_nonexistent_cache() {
         setup_cache_path();
         let cache_name = format!("nonexistent_cache_{}", std::process::id());
-        let files_to_check: BTreeMap<String, TestEntry> = BTreeMap::new();
+        let files_to_check: HashMap<String, TestEntry> = HashMap::new();
 
         let (messages, loaded_cache) = load_cache_from_file_generalized_by_path::<TestEntry>(&cache_name, false, &files_to_check);
 
@@ -636,7 +636,7 @@ mod tests {
         let temp_file = temp_dir.path().join("test_file.txt");
         fs::write(&temp_file, "test content").unwrap();
 
-        let mut cache_to_save = BTreeMap::new();
+        let mut cache_to_save = HashMap::new();
         cache_to_save.insert("test_key".to_string(), TestEntry::new("/tmp/test", 100, 1000, 42));
 
         // Save cache with JSON enabled

--- a/czkawka_core/src/common/dir_traversal.rs
+++ b/czkawka_core/src/common/dir_traversal.rs
@@ -268,7 +268,7 @@ where
                 }
             }
         }
-        file_results.sort_by_cached_key(|fe| fe.path.to_string_lossy().to_string());
+        file_results.sort_unstable_by(|a, b| a.path.cmp(&b.path));
         for fe in file_results {
             let key = (self.group_by)(&fe);
             grouped_file_entries.entry(key).or_default().push(fe);
@@ -350,7 +350,7 @@ where
             for (segment, warnings, mut fe_result) in segments {
                 folders_to_check.extend(segment);
                 all_warnings.extend(warnings);
-                fe_result.sort_by_cached_key(|fe| fe.path.to_string_lossy().to_string());
+                fe_result.sort_unstable_by(|a, b| a.path.cmp(&b.path));
                 for fe in fe_result {
                     let key = (self.group_by)(&fe);
                     grouped_file_entries.entry(key).or_default().push(fe);

--- a/czkawka_core/src/tools/broken_files/core.rs
+++ b/czkawka_core/src/tools/broken_files/core.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::fs::File;
 use std::path::Path;
 use std::process::Command;
@@ -243,12 +243,12 @@ impl BrokenFiles {
     }
 
     #[fun_time(message = "load_cache", level = "debug")]
-    fn load_cache(&mut self) -> (BTreeMap<String, BrokenEntry>, BTreeMap<String, BrokenEntry>, BTreeMap<String, BrokenEntry>) {
+    fn load_cache(&mut self) -> (HashMap<String, BrokenEntry>, HashMap<String, BrokenEntry>, HashMap<String, BrokenEntry>) {
         load_and_split_cache_generalized_by_path(&get_broken_files_cache_file(), mem::take(&mut self.files_to_check), self)
     }
 
     #[fun_time(message = "save_to_cache", level = "debug")]
-    fn save_to_cache(&mut self, vec_file_entry: &[BrokenEntry], loaded_hash_map: BTreeMap<String, BrokenEntry>) {
+    fn save_to_cache(&mut self, vec_file_entry: &[BrokenEntry], loaded_hash_map: HashMap<String, BrokenEntry>) {
         save_and_connect_cache_generalized_by_path(&get_broken_files_cache_file(), vec_file_entry, loaded_hash_map, self);
     }
 

--- a/czkawka_core/src/tools/broken_files/mod.rs
+++ b/czkawka_core/src/tools/broken_files/mod.rs
@@ -5,7 +5,7 @@ pub mod core;
 mod tests;
 pub mod traits;
 
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -88,7 +88,7 @@ impl BrokenFilesParameters {
 pub struct BrokenFiles {
     common_data: CommonToolData,
     information: Info,
-    files_to_check: BTreeMap<String, BrokenEntry>,
+    files_to_check: HashMap<String, BrokenEntry>,
     broken_files: Vec<BrokenEntry>,
     params: BrokenFilesParameters,
 }

--- a/czkawka_core/src/tools/duplicate/core.rs
+++ b/czkawka_core/src/tools/duplicate/core.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -8,7 +8,6 @@ use std::{mem, thread};
 use crossbeam_channel::Sender;
 use fun_time::fun_time;
 use humansize::{BINARY, format_size};
-use indexmap::IndexMap;
 use log::debug;
 use rayon::prelude::*;
 
@@ -367,11 +366,11 @@ impl DuplicateFinder {
     fn prehash_save_cache_at_exit(
         &mut self,
         loaded_hash_map: BTreeMap<u64, Vec<DuplicateEntry>>,
-        pre_hash_results: Vec<(u64, BTreeMap<String, Vec<DuplicateEntry>>, Vec<String>)>,
+        pre_hash_results: Vec<(u64, HashMap<String, Vec<DuplicateEntry>>, Vec<String>)>,
     ) {
         if self.get_params().use_prehash_cache {
             // All results = records already cached + computed results
-            let mut save_cache_to_hashmap: BTreeMap<String, DuplicateEntry> = Default::default();
+            let mut save_cache_to_hashmap: HashMap<String, DuplicateEntry> = Default::default();
 
             for (size, vec_file_entry) in loaded_hash_map {
                 if size >= self.get_params().minimal_prehash_cache_file_size {
@@ -437,11 +436,11 @@ impl DuplicateFinder {
 
         debug!("Starting calculating prehash");
         #[expect(clippy::type_complexity)]
-        let pre_hash_results: Vec<(u64, BTreeMap<String, Vec<DuplicateEntry>>, Vec<String>)> = non_cached_files_to_check
+        let pre_hash_results: Vec<(u64, HashMap<String, Vec<DuplicateEntry>>, Vec<String>)> = non_cached_files_to_check
             .into_par_iter()
-            .with_max_len(3) // Vectors and BTreeMaps for really big inputs, leave some jobs to 0 thread, to avoid that I minimized max tasks for each thread to 3, which improved performance
+            .with_max_len(3) // Vectors and HashMaps for really big inputs, leave some jobs to 0 thread, to avoid that I minimized max tasks for each thread to 3, which improved performance
             .map(|(size, vec_file_entry)| {
-                let mut hashmap_with_hash: BTreeMap<String, Vec<DuplicateEntry>> = Default::default();
+                let mut hashmap_with_hash: HashMap<String, Vec<DuplicateEntry>> = Default::default();
                 let mut errors: Vec<String> = Vec::new();
 
                 THREAD_BUFFER.with_borrow_mut(|buffer| {
@@ -513,16 +512,26 @@ impl DuplicateFinder {
 
         for (size, mut vec_file_entry) in used_map {
             if let Some(cached_vec_file_entry) = loaded_hash_map.get(&size) {
-                // TODO maybe hashmap is not needed when using < 4 elements
-                let mut cached_path_entries: IndexMap<&Path, DuplicateEntry> = IndexMap::new();
-                for file_entry in cached_vec_file_entry {
-                    cached_path_entries.insert(&file_entry.path, file_entry.clone());
-                }
-                for file_entry in vec_file_entry {
-                    if let Some(cached_file_entry) = cached_path_entries.swap_remove(file_entry.path.as_path()) {
-                        records_already_cached.entry(size).or_default().push(cached_file_entry);
-                    } else {
-                        non_cached_files_to_check.entry(size).or_default().push(file_entry);
+                if cached_vec_file_entry.len() < 4 {
+                    // For very small groups, linear scan is faster than building a map
+                    for file_entry in vec_file_entry {
+                        if let Some(cached) = cached_vec_file_entry.iter().find(|ce| ce.path == file_entry.path) {
+                            records_already_cached.entry(size).or_default().push(cached.clone());
+                        } else {
+                            non_cached_files_to_check.entry(size).or_default().push(file_entry);
+                        }
+                    }
+                } else {
+                    let mut cached_path_entries: HashMap<&Path, DuplicateEntry> = HashMap::with_capacity(cached_vec_file_entry.len());
+                    for file_entry in cached_vec_file_entry {
+                        cached_path_entries.insert(&file_entry.path, file_entry.clone());
+                    }
+                    for file_entry in vec_file_entry {
+                        if let Some(cached_file_entry) = cached_path_entries.remove(file_entry.path.as_path()) {
+                            records_already_cached.entry(size).or_default().push(cached_file_entry);
+                        } else {
+                            non_cached_files_to_check.entry(size).or_default().push(file_entry);
+                        }
                     }
                 }
             } else {
@@ -576,7 +585,7 @@ impl DuplicateFinder {
     fn full_hashing_save_cache_at_exit(
         &mut self,
         records_already_cached: BTreeMap<u64, Vec<DuplicateEntry>>,
-        full_hash_results: &mut Vec<(u64, BTreeMap<String, Vec<DuplicateEntry>>, Vec<String>)>,
+        full_hash_results: &mut Vec<(u64, HashMap<String, Vec<DuplicateEntry>>, Vec<String>)>,
         loaded_hash_map: BTreeMap<u64, Vec<DuplicateEntry>>,
     ) {
         if !self.common_data.use_cache {
@@ -593,7 +602,7 @@ impl DuplicateFinder {
                 }
             }
             // Size doesn't exists add results to files
-            let mut temp_hashmap: BTreeMap<String, Vec<DuplicateEntry>> = Default::default();
+            let mut temp_hashmap: HashMap<String, Vec<DuplicateEntry>> = Default::default();
             for file_entry in vec_file_entry {
                 temp_hashmap.entry(file_entry.hash.clone()).or_default().push(file_entry);
             }
@@ -601,7 +610,7 @@ impl DuplicateFinder {
         }
 
         // Must save all results to file, old loaded from file with all currently counted results
-        let mut all_results: BTreeMap<String, DuplicateEntry> = Default::default();
+        let mut all_results: HashMap<String, DuplicateEntry> = Default::default();
         for (_size, vec_file_entry) in loaded_hash_map {
             for file_entry in vec_file_entry {
                 all_results.insert(file_entry.path.to_string_lossy().to_string(), file_entry);
@@ -659,11 +668,11 @@ impl DuplicateFinder {
             "Starting full hashing of {} files",
             non_cached_files_to_check.iter().map(|(_size, v)| v.len() as u64).sum::<u64>()
         );
-        let mut full_hash_results: Vec<(u64, BTreeMap<String, Vec<DuplicateEntry>>, Vec<String>)> = non_cached_files_to_check
+        let mut full_hash_results: Vec<(u64, HashMap<String, Vec<DuplicateEntry>>, Vec<String>)> = non_cached_files_to_check
             .into_par_iter()
             .with_max_len(3)
             .map(|(size, vec_file_entry)| {
-                let mut hashmap_with_hash: BTreeMap<String, Vec<DuplicateEntry>> = Default::default();
+                let mut hashmap_with_hash: HashMap<String, Vec<DuplicateEntry>> = Default::default();
                 let mut errors: Vec<String> = Vec::new();
 
                 THREAD_BUFFER.with_borrow_mut(|buffer| {

--- a/czkawka_core/src/tools/exif_remover/core.rs
+++ b/czkawka_core/src/tools/exif_remover/core.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -23,7 +23,7 @@ use crate::tools::exif_remover::{ExifEntry, ExifRemover, ExifRemoverParameters, 
 
 impl ExifRemover {
     pub fn new(params: ExifRemoverParameters) -> Self {
-        let mut additional_excluded_tags = BTreeMap::new();
+        let mut additional_excluded_tags = std::collections::BTreeMap::new();
 
         let tiff_disabled_tags = vec![
             "ImageWidth",
@@ -92,7 +92,7 @@ impl ExifRemover {
         &mut self,
         _stop_flag: &Arc<AtomicBool>,
         progress_sender: Option<&Sender<ProgressData>>,
-    ) -> (BTreeMap<String, ExifEntry>, BTreeMap<String, ExifEntry>, BTreeMap<String, ExifEntry>) {
+    ) -> (HashMap<String, ExifEntry>, HashMap<String, ExifEntry>, HashMap<String, ExifEntry>) {
         let progress_handler = prepare_thread_handler_common(progress_sender, CurrentStage::ExifRemoverCacheLoading, 0, self.get_test_type(), 0);
         let res = load_and_split_cache_generalized_by_path(&get_exif_remover_cache_file(), mem::take(&mut self.files_to_check), self);
 
@@ -104,7 +104,7 @@ impl ExifRemover {
     fn save_to_cache(
         &mut self,
         vec_file_entry: &[ExifEntry],
-        loaded_hash_map: BTreeMap<String, ExifEntry>,
+        loaded_hash_map: HashMap<String, ExifEntry>,
         _stop_flag: &Arc<AtomicBool>,
         progress_sender: Option<&Sender<ProgressData>>,
     ) {

--- a/czkawka_core/src/tools/exif_remover/mod.rs
+++ b/czkawka_core/src/tools/exif_remover/mod.rs
@@ -3,7 +3,7 @@ pub mod core;
 mod tests;
 pub mod traits;
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -66,7 +66,7 @@ pub struct ExifRemover {
     common_data: CommonToolData,
     information: Info,
     exif_files: Vec<ExifEntry>,
-    files_to_check: BTreeMap<String, ExifEntry>,
+    files_to_check: HashMap<String, ExifEntry>,
     params: ExifRemoverParameters,
     additional_excluded_tags: BTreeMap<&'static str, Vec<&'static str>>,
 }

--- a/czkawka_core/src/tools/same_music/core.rs
+++ b/czkawka_core/src/tools/same_music/core.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs::File;
 use std::path::Path;
 use std::sync::Arc;
@@ -74,12 +74,12 @@ impl SameMusic {
     }
 
     #[fun_time(message = "load_cache", level = "debug")]
-    fn load_cache(&mut self, checking_tags: bool) -> (BTreeMap<String, MusicEntry>, BTreeMap<String, MusicEntry>, BTreeMap<String, MusicEntry>) {
+    fn load_cache(&mut self, checking_tags: bool) -> (HashMap<String, MusicEntry>, HashMap<String, MusicEntry>, HashMap<String, MusicEntry>) {
         load_and_split_cache_generalized_by_path(&get_similar_music_cache_file(checking_tags), mem::take(&mut self.music_to_check), self)
     }
 
     #[fun_time(message = "save_cache", level = "debug")]
-    fn save_cache(&mut self, vec_file_entry: &[MusicEntry], loaded_hash_map: BTreeMap<String, MusicEntry>, checking_tags: bool) {
+    fn save_cache(&mut self, vec_file_entry: &[MusicEntry], loaded_hash_map: HashMap<String, MusicEntry>, checking_tags: bool) {
         save_and_connect_cache_generalized_by_path(&get_similar_music_cache_file(checking_tags), vec_file_entry, loaded_hash_map, self);
     }
 
@@ -312,6 +312,10 @@ impl SameMusic {
 
         progress_handler.join_thread();
 
+        // Sort entries within each group by path for deterministic results
+        for group in &mut old_duplicates {
+            group.sort_unstable_by(|a, b| a.path.cmp(&b.path));
+        }
         self.duplicated_music_entries = old_duplicates;
 
         if self.common_data.use_reference_folders {
@@ -457,6 +461,9 @@ impl SameMusic {
             return WorkContinueStatus::Continue;
         }
 
+        // Sort for deterministic grouping regardless of HashMap/cache iteration order
+        self.music_entries.sort_unstable_by(|a, b| a.path.cmp(&b.path));
+
         let grouped_files_to_check = self.split_fingerprints_to_check();
         let base_files_number = grouped_files_to_check.iter().map(|g| g.base_files.len()).sum::<usize>();
 
@@ -474,6 +481,10 @@ impl SameMusic {
 
         progress_handler.join_thread();
 
+        // Sort entries within each group by path for deterministic results
+        for group in &mut duplicated_music_entries {
+            group.sort_unstable_by(|a, b| a.path.cmp(&b.path));
+        }
         self.duplicated_music_entries = duplicated_music_entries;
 
         if self.common_data.use_reference_folders {

--- a/czkawka_core/src/tools/same_music/mod.rs
+++ b/czkawka_core/src/tools/same_music/mod.rs
@@ -5,7 +5,7 @@ pub mod traits;
 #[cfg(test)]
 mod tests;
 
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -123,7 +123,7 @@ impl SameMusicParameters {
 pub struct SameMusic {
     common_data: CommonToolData,
     information: Info,
-    music_to_check: BTreeMap<String, MusicEntry>,
+    music_to_check: HashMap<String, MusicEntry>,
     music_entries: Vec<MusicEntry>,
     duplicated_music_entries: Vec<Vec<MusicEntry>>,
     duplicated_music_entries_referenced: Vec<(MusicEntry, Vec<MusicEntry>)>,

--- a/czkawka_core/src/tools/similar_images/core.rs
+++ b/czkawka_core/src/tools/similar_images/core.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -73,7 +73,7 @@ impl SimilarImages {
     }
 
     #[fun_time(message = "hash_images_load_cache", level = "debug")]
-    fn hash_images_load_cache(&mut self) -> (BTreeMap<String, ImagesEntry>, BTreeMap<String, ImagesEntry>, BTreeMap<String, ImagesEntry>) {
+    fn hash_images_load_cache(&mut self) -> (HashMap<String, ImagesEntry>, HashMap<String, ImagesEntry>, HashMap<String, ImagesEntry>) {
         load_and_split_cache_generalized_by_path(
             &get_similar_images_cache_file(self.get_params().hash_size, self.get_params().hash_alg, self.get_params().image_filter),
             mem::take(&mut self.images_to_check),
@@ -82,7 +82,7 @@ impl SimilarImages {
     }
 
     #[fun_time(message = "save_to_cache", level = "debug")]
-    fn save_to_cache(&mut self, vec_file_entry: &[ImagesEntry], loaded_hash_map: BTreeMap<String, ImagesEntry>) {
+    fn save_to_cache(&mut self, vec_file_entry: &[ImagesEntry], loaded_hash_map: HashMap<String, ImagesEntry>) {
         save_and_connect_cache_generalized_by_path(
             &get_similar_images_cache_file(self.get_params().hash_size, self.get_params().hash_alg, self.get_params().image_filter),
             vec_file_entry,
@@ -282,24 +282,24 @@ impl SimilarImages {
                             *similarity != 0 && !hashes_parents.contains_key(*compared_hash) && !hashes_with_multiple_images.contains(*compared_hash)
                         })
                         .filter(|(similarity, compared_hash)| {
-                            if let Some((_, other_similarity_with_parent)) = hashes_similarity.get(*compared_hash) {
-                                // If current hash is more similar to other hash than to current parent hash, then skip check earlier
-                                // Because there is no way to be more similar to other hash than to current parent hash
-                                if *similarity >= *other_similarity_with_parent {
-                                    return false;
-                                }
+                            if let Some((_, other_similarity_with_parent)) = hashes_similarity.get(*compared_hash)
+                                && *similarity >= *other_similarity_with_parent
+                            {
+                                return false;
                             }
                             true
                         })
                         .collect::<Vec<_>>();
 
-                    // Sort by tolerance
+                    if found_items.is_empty() && !hashes_with_multiple_images.contains(hash_to_check) {
+                        return Some(None);
+                    }
+
                     found_items.sort_unstable_by_key(|f| f.0);
-                    Some((hash_to_check, found_items))
+                    Some(Some((hash_to_check, found_items)))
                 })
                 .while_some()
-                // TODO - this filter move to into_par_iter above
-                .filter(|(original_hash, vec_similar_hashes)| !vec_similar_hashes.is_empty() || hashes_with_multiple_images.contains(*original_hash))
+                .flatten()
                 .collect::<Vec<_>>();
 
             if check_if_stop_received(stop_flag) {

--- a/czkawka_core/src/tools/similar_images/mod.rs
+++ b/czkawka_core/src/tools/similar_images/mod.rs
@@ -6,7 +6,7 @@ pub use core::return_similarity_from_similarity_preset;
 #[cfg(test)]
 mod tests;
 
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -121,7 +121,7 @@ pub struct SimilarImages {
     similar_referenced_vectors: Vec<(ImagesEntry, Vec<ImagesEntry>)>,
     // Hashmap with image hashes and Vector with names of files
     image_hashes: IndexMap<ImHash, Vec<ImagesEntry>>,
-    images_to_check: BTreeMap<String, ImagesEntry>,
+    images_to_check: HashMap<String, ImagesEntry>,
     params: SimilarImagesParameters,
 }
 

--- a/czkawka_core/src/tools/similar_videos/core.rs
+++ b/czkawka_core/src/tools/similar_videos/core.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeSet, HashMap};
 use std::mem;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -258,7 +258,7 @@ impl SimilarVideos {
     }
 
     #[fun_time(message = "save_cache", level = "debug")]
-    fn save_cache(&mut self, vec_file_entry: &[VideosEntry], loaded_hash_map: BTreeMap<String, VideosEntry>) {
+    fn save_cache(&mut self, vec_file_entry: &[VideosEntry], loaded_hash_map: HashMap<String, VideosEntry>) {
         save_and_connect_cache_generalized_by_path(
             &get_similar_videos_cache_file(self.params.skip_forward_amount, self.params.duration, self.params.crop_detect),
             vec_file_entry,
@@ -268,7 +268,7 @@ impl SimilarVideos {
     }
 
     #[fun_time(message = "load_cache_at_start", level = "debug")]
-    fn load_cache_at_start(&mut self) -> (BTreeMap<String, VideosEntry>, BTreeMap<String, VideosEntry>, BTreeMap<String, VideosEntry>) {
+    fn load_cache_at_start(&mut self) -> (HashMap<String, VideosEntry>, HashMap<String, VideosEntry>, HashMap<String, VideosEntry>) {
         load_and_split_cache_generalized_by_path(
             &get_similar_videos_cache_file(self.params.skip_forward_amount, self.params.duration, self.params.crop_detect),
             mem::take(&mut self.videos_to_check),

--- a/czkawka_core/src/tools/similar_videos/mod.rs
+++ b/czkawka_core/src/tools/similar_videos/mod.rs
@@ -4,7 +4,7 @@ pub mod traits;
 #[cfg(test)]
 mod tests;
 
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::ops::RangeInclusive;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -136,8 +136,8 @@ pub struct SimilarVideos {
     information: Info,
     similar_vectors: Vec<Vec<VideosEntry>>,
     similar_referenced_vectors: Vec<(VideosEntry, Vec<VideosEntry>)>,
-    videos_hashes: BTreeMap<Vec<u8>, Vec<VideosEntry>>,
-    videos_to_check: BTreeMap<String, VideosEntry>,
+    videos_hashes: HashMap<Vec<u8>, Vec<VideosEntry>>,
+    videos_to_check: HashMap<String, VideosEntry>,
     params: SimilarVideosParameters,
 }
 

--- a/czkawka_core/src/tools/video_optimizer/core.rs
+++ b/czkawka_core/src/tools/video_optimizer/core.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::mem;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -349,25 +349,25 @@ impl VideoOptimizer {
     fn load_video_transcode_cache(
         &mut self,
     ) -> (
-        BTreeMap<String, VideoTranscodeEntry>,
-        BTreeMap<String, VideoTranscodeEntry>,
-        BTreeMap<String, VideoTranscodeEntry>,
+        HashMap<String, VideoTranscodeEntry>,
+        HashMap<String, VideoTranscodeEntry>,
+        HashMap<String, VideoTranscodeEntry>,
     ) {
         load_and_split_cache_generalized_by_path(&get_video_transcode_cache_file(), mem::take(&mut self.video_transcode_test_entries), self)
     }
 
     #[fun_time(message = "load_video_crop_cache", level = "debug")]
-    fn load_video_crop_cache(&mut self, params: &VideoCropParams) -> (BTreeMap<String, VideoCropEntry>, BTreeMap<String, VideoCropEntry>, BTreeMap<String, VideoCropEntry>) {
+    fn load_video_crop_cache(&mut self, params: &VideoCropParams) -> (HashMap<String, VideoCropEntry>, HashMap<String, VideoCropEntry>, HashMap<String, VideoCropEntry>) {
         load_and_split_cache_generalized_by_path(&get_video_crop_cache_file(params), mem::take(&mut self.video_crop_test_entries), self)
     }
 
     #[fun_time(message = "save_video_transcode_cache", level = "debug")]
-    fn save_video_transcode_cache(&mut self, vec_file_entry: &[VideoTranscodeEntry], loaded_hash_map: BTreeMap<String, VideoTranscodeEntry>) {
+    fn save_video_transcode_cache(&mut self, vec_file_entry: &[VideoTranscodeEntry], loaded_hash_map: HashMap<String, VideoTranscodeEntry>) {
         save_and_connect_cache_generalized_by_path(&get_video_transcode_cache_file(), vec_file_entry, loaded_hash_map, self);
     }
 
     #[fun_time(message = "save_video_crop_cache", level = "debug")]
-    fn save_video_crop_cache(&mut self, vec_file_entry: &[VideoCropEntry], params: &VideoCropParams, loaded_hash_map: BTreeMap<String, VideoCropEntry>) {
+    fn save_video_crop_cache(&mut self, vec_file_entry: &[VideoCropEntry], params: &VideoCropParams, loaded_hash_map: HashMap<String, VideoCropEntry>) {
         save_and_connect_cache_generalized_by_path(&get_video_crop_cache_file(params), vec_file_entry, loaded_hash_map, self);
     }
 

--- a/czkawka_core/src/tools/video_optimizer/mod.rs
+++ b/czkawka_core/src/tools/video_optimizer/mod.rs
@@ -3,7 +3,7 @@ pub mod core;
 mod tests;
 pub mod traits;
 
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -317,8 +317,8 @@ pub enum VideoOptimizerEntry {
 pub struct VideoOptimizer {
     common_data: CommonToolData,
     information: Info,
-    video_transcode_test_entries: BTreeMap<String, VideoTranscodeEntry>,
-    video_crop_test_entries: BTreeMap<String, VideoCropEntry>,
+    video_transcode_test_entries: HashMap<String, VideoTranscodeEntry>,
+    video_crop_test_entries: HashMap<String, VideoCropEntry>,
     video_transcode_result_entries: Vec<VideoTranscodeEntry>,
     video_crop_result_entries: Vec<VideoCropEntry>,
     params: VideoOptimizerParameters,


### PR DESCRIPTION
## Summary
Performance optimizations across czkawka_core and czkawka_cli:

- **Build profile**: Enable LTO and `codegen-units=1` in release profile for smaller, faster binaries
- **Data structures**: Replace `BTreeMap` with `HashMap` throughout cache, duplicate finder, and tool modules (ordering not needed for these maps)
- **CLI channel**: Use `bounded(256)` progress channel instead of `unbounded` to reduce memory pressure
- **Determinism**: Sort same_music duplicate groups by path for consistent output regardless of HashMap iteration order

## Test plan
- [ ] `cargo check -p czkawka_core -p czkawka_cli` passes
- [ ] Run duplicate and music scans, verify results are correct
- [ ] Verify deterministic output ordering on repeated runs
- [ ] Build with `--release` and verify LTO takes effect

Closes #1872

🤖 Generated with [Claude Code](https://claude.com/claude-code)