### PR TITLE
Added `invert selection in group` feature to `krokiet` UI.

### DIFF
--- a/krokiet/i18n/ar/krokiet.ftl
+++ b/krokiet/i18n/ar/krokiet.ftl
@@ -188,6 +188,7 @@ sort_reverse = عكس الترتيب
 selection_all = حدد الكل
 selection_deselect_all = إلغاء تحديد الكل
 selection_invert_selection = عكس التحديد
+selection_invert_selection_in_group = عكس التحديد في المجموعة
 selection_the_biggest_size = حدد أكبر حجم
 selection_the_biggest_resolution = حدد أكبر دقة
 selection_the_smallest_size = حدد أصغر حجم

--- a/krokiet/i18n/bg/krokiet.ftl
+++ b/krokiet/i18n/bg/krokiet.ftl
@@ -191,6 +191,7 @@ sort_reverse = Обратен ред
 selection_all = Избери всички
 selection_deselect_all = Отключи всичко
 selection_invert_selection = Инверсия на избора
+selection_invert_selection_in_group = Инверсия на избора в група
 selection_the_biggest_size = Избери най-голям файл
 selection_the_biggest_resolution = Избери най-голямо резолюция
 selection_the_smallest_size = Избери най-малък файл

--- a/krokiet/i18n/cs/krokiet.ftl
+++ b/krokiet/i18n/cs/krokiet.ftl
@@ -188,6 +188,7 @@ sort_reverse = Obrácené pořadí
 selection_all = Vybrat vše
 selection_deselect_all = Zrušit výběr všeho
 selection_invert_selection = Invertovat výběr
+selection_invert_selection_in_group = Invertovat výběr ve skupině
 selection_the_biggest_size = Vybrat nejvyšší velikost
 selection_the_biggest_resolution = Vybrat nejvyšší rozlišení
 selection_the_smallest_size = Vybrat nejnižší velikost

--- a/krokiet/i18n/de/krokiet.ftl
+++ b/krokiet/i18n/de/krokiet.ftl
@@ -188,6 +188,7 @@ sort_reverse = Reihenfolge umkehren
 selection_all = Alles auswählen
 selection_deselect_all = Alle abwählen
 selection_invert_selection = Auswahl umkehren
+selection_invert_selection_in_group = Auswahl in Gruppe umkehren
 selection_the_biggest_size = Wählen Sie die größte Größe
 selection_the_biggest_resolution = Wählen Sie die größte Auflösung
 selection_the_smallest_size = Wählen Sie die kleinste Größe

--- a/krokiet/i18n/el/krokiet.ftl
+++ b/krokiet/i18n/el/krokiet.ftl
@@ -188,6 +188,7 @@ sort_reverse = Αντίστροφη σειρά
 selection_all = Επιλογή όλων
 selection_deselect_all = Αποεπιλογή όλων
 selection_invert_selection = Αντιστροφή επιλογής
+selection_invert_selection_in_group = Αντιστροφή επιλογής στην ομάδα
 selection_the_biggest_size = Επιλέξτε το μεγαλύτερο μέγεθος
 selection_the_biggest_resolution = Επιλέξτε τη μεγαλύτερη ανάλυση
 selection_the_smallest_size = Επιλέξτε το μικρότερο μέγεθος

--- a/krokiet/i18n/en/krokiet.ftl
+++ b/krokiet/i18n/en/krokiet.ftl
@@ -211,6 +211,7 @@ sort_reverse = Reverse order
 selection_all = Select all
 selection_deselect_all = Deselect all
 selection_invert_selection = Invert selection
+selection_invert_selection_in_group = Invert selection in group
 selection_the_biggest_size = Select the biggest size
 selection_the_biggest_resolution = Select the biggest resolution
 selection_the_smallest_size = Select the smallest size

--- a/krokiet/i18n/es-ES/krokiet.ftl
+++ b/krokiet/i18n/es-ES/krokiet.ftl
@@ -188,6 +188,7 @@ sort_reverse = Orden inversa
 selection_all = Seleccionar todo
 selection_deselect_all = Deseleccionar todo
 selection_invert_selection = Invertir selección
+selection_invert_selection_in_group = Invertir selección en grupo
 selection_the_biggest_size = Seleccione el tamaño más grande
 selection_the_biggest_resolution = Seleccione la resolución más grande
 selection_the_smallest_size = Selecciona el tamaño más pequeño

--- a/krokiet/i18n/fa/krokiet.ftl
+++ b/krokiet/i18n/fa/krokiet.ftl
@@ -188,6 +188,7 @@ sort_reverse = سیر opposition
 selection_all = انتخاب همه
 selection_deselect_all = تمامی را حذف کنید
 selection_invert_selection = انتخاب را دور زنید
+selection_invert_selection_in_group = انتخاب را در گروه برگردانید
 selection_the_biggest_size = حجم بزرگترین را انتخاب کنید
 selection_the_biggest_resolution = گزینه‌ی بزرگترین حلوله را انتخاب کنید
 selection_the_smallest_size = چویید حجم کوچکترین را

--- a/krokiet/i18n/fr/krokiet.ftl
+++ b/krokiet/i18n/fr/krokiet.ftl
@@ -188,6 +188,7 @@ sort_reverse = Inverser l'ordre
 selection_all = Tout sélectionner
 selection_deselect_all = Désélectionner tout
 selection_invert_selection = Inverser la sélection
+selection_invert_selection_in_group = Inverser la sélection dans le groupe
 selection_the_biggest_size = Sélectionnez la taille la plus grande
 selection_the_biggest_resolution = Sélectionnez la plus grande résolution
 selection_the_smallest_size = Sélectionnez la taille la plus petite

--- a/krokiet/i18n/hi/krokiet.ftl
+++ b/krokiet/i18n/hi/krokiet.ftl
@@ -190,6 +190,7 @@ sort_reverse = उल्टा क्रम
 selection_all = सभी का चयन करें।
 selection_deselect_all = सभी का चयन रद्द करें
 selection_invert_selection = चयन को उलटा करें
+selection_invert_selection_in_group = समूह में चयन उलटें
 selection_the_biggest_size = सबसे बड़ा आकार चुनें
 selection_the_biggest_resolution = सबसे बड़ा रिज़ॉल्यूशन चुनें
 selection_the_smallest_size = सबसे छोटा आकार चुनें

--- a/krokiet/i18n/id/krokiet.ftl
+++ b/krokiet/i18n/id/krokiet.ftl
@@ -190,6 +190,7 @@ sort_reverse = Urutan terbalik
 selection_all = Pilih Semua
 selection_deselect_all = Batalkan semua pilihan
 selection_invert_selection = Balikkan pilihan
+selection_invert_selection_in_group = Balikkan pilihan dalam grup
 selection_the_biggest_size = Pilih ukuran yang paling besar
 selection_the_biggest_resolution = Pilih resolusi terbesar
 selection_the_smallest_size = Pilih ukuran terkecil

--- a/krokiet/i18n/it/krokiet.ftl
+++ b/krokiet/i18n/it/krokiet.ftl
@@ -188,6 +188,7 @@ sort_reverse = Ordine inverso
 selection_all = Seleziona tutto
 selection_deselect_all = Deseleziona tutto
 selection_invert_selection = Inverti selezione
+selection_invert_selection_in_group = Inverti selezione nel gruppo
 selection_the_biggest_size = Seleziona la dimensione più grande
 selection_the_biggest_resolution = Seleziona la risoluzione più grande
 selection_the_smallest_size = Seleziona la dimensione più piccola

--- a/krokiet/i18n/ja/krokiet.ftl
+++ b/krokiet/i18n/ja/krokiet.ftl
@@ -192,6 +192,7 @@ sort_reverse = 順序を逆にする
 selection_all = すべて選択
 selection_deselect_all = すべての選択を解除
 selection_invert_selection = 選択を反転
+selection_invert_selection_in_group = グループ内で選択を反転
 selection_the_biggest_size = 最大サイズを選択
 selection_the_biggest_resolution = 最大解像度を選択
 selection_the_smallest_size = 最小サイズを選択

--- a/krokiet/i18n/ko/krokiet.ftl
+++ b/krokiet/i18n/ko/krokiet.ftl
@@ -191,6 +191,7 @@ sort_reverse = 역순 정렬
 selection_all = 전체 선택
 selection_deselect_all = 전체 선택 해제
 selection_invert_selection = 선택 반전
+selection_invert_selection_in_group = 그룹 내 선택 반전
 selection_the_biggest_size = 가장 큰 파일 선택
 selection_the_biggest_resolution = 가장 큰 해상도 선택
 selection_the_smallest_size = 가장 작은 파일 선택

--- a/krokiet/i18n/nl/krokiet.ftl
+++ b/krokiet/i18n/nl/krokiet.ftl
@@ -186,6 +186,7 @@ sort_reverse = Omgekeerde volgorde
 selection_all = Alles selecteren
 selection_deselect_all = Deselecteer alles
 selection_invert_selection = Selectie omkeren
+selection_invert_selection_in_group = Selectie in groep omkeren
 selection_the_biggest_size = Selecteer de grootste grootte
 selection_the_biggest_resolution = Selecteer de grootste resolutie
 selection_the_smallest_size = Selecteer de kleinste grootte

--- a/krokiet/i18n/no/krokiet.ftl
+++ b/krokiet/i18n/no/krokiet.ftl
@@ -188,6 +188,7 @@ sort_reverse = Motsatt rekkefølge
 selection_all = Velg alle
 selection_deselect_all = Fjern all merking
 selection_invert_selection = Inverter merking
+selection_invert_selection_in_group = Inverter merking i gruppe
 selection_the_biggest_size = Velg den største størrelsen
 selection_the_biggest_resolution = Velg den største oppløsningen
 selection_the_smallest_size = Velg den minste størrelsen

--- a/krokiet/i18n/pl/krokiet.ftl
+++ b/krokiet/i18n/pl/krokiet.ftl
@@ -188,6 +188,7 @@ sort_reverse = Odwróć kolejność
 selection_all = Zaznacz wszystko
 selection_deselect_all = Odznacz wszystko
 selection_invert_selection = Odwróć zaznaczenie
+selection_invert_selection_in_group = Odwróć zaznaczenie w grupie
 selection_the_biggest_size = Wybierz największe pliki
 selection_the_biggest_resolution = Wybierz największą rozdzielczość
 selection_the_smallest_size = Wybierz najmniejsze pliki

--- a/krokiet/i18n/pt-BR/krokiet.ftl
+++ b/krokiet/i18n/pt-BR/krokiet.ftl
@@ -186,6 +186,7 @@ sort_reverse = Ordenar inversamente
 selection_all = Selecionar todos
 selection_deselect_all = Desselecionar todos
 selection_invert_selection = Inverter a seleção
+selection_invert_selection_in_group = Inverter a seleção no grupo
 selection_the_biggest_size = Selecionar o maior tamanho
 selection_the_biggest_resolution = Selecionar a maior resolução
 selection_the_smallest_size = Selecionar o menor tamanho

--- a/krokiet/i18n/pt-PT/krokiet.ftl
+++ b/krokiet/i18n/pt-PT/krokiet.ftl
@@ -188,6 +188,7 @@ sort_reverse = Ordem inversa
 selection_all = Selecionar todos
 selection_deselect_all = Desmarcar todos
 selection_invert_selection = Inverter seleção
+selection_invert_selection_in_group = Inverter seleção no grupo
 selection_the_biggest_size = Selecione o maior tamanho
 selection_the_biggest_resolution = Selecione a maior resolução
 selection_the_smallest_size = Selecione o menor tamanho

--- a/krokiet/i18n/ro/krokiet.ftl
+++ b/krokiet/i18n/ro/krokiet.ftl
@@ -188,6 +188,7 @@ sort_reverse = Ordinea inversă
 selection_all = Selectează tot
 selection_deselect_all = Deselectează tot
 selection_invert_selection = Inversează selecția
+selection_invert_selection_in_group = Inversează selecția în grup
 selection_the_biggest_size = Selectaţi cea mai mare dimensiune
 selection_the_biggest_resolution = Selectează cea mai mare rezoluție
 selection_the_smallest_size = Selectaţi dimensiunea cea mai mică

--- a/krokiet/i18n/ru/krokiet.ftl
+++ b/krokiet/i18n/ru/krokiet.ftl
@@ -188,6 +188,7 @@ sort_reverse = Обратный порядок
 selection_all = Выбрать все
 selection_deselect_all = Отменить выбор
 selection_invert_selection = Инвертировать выделение
+selection_invert_selection_in_group = Инвертировать выделение в группе
 selection_the_biggest_size = Выберите наибольший размер
 selection_the_biggest_resolution = Выберите наибольшее разрешение
 selection_the_smallest_size = Выберите наименьший размер

--- a/krokiet/i18n/sv-SE/krokiet.ftl
+++ b/krokiet/i18n/sv-SE/krokiet.ftl
@@ -188,6 +188,7 @@ sort_reverse = Omvänd ordning
 selection_all = Markera alla
 selection_deselect_all = Avmarkera alla
 selection_invert_selection = Invertera markering
+selection_invert_selection_in_group = Invertera markering i grupp
 selection_the_biggest_size = Välj den största storleken
 selection_the_biggest_resolution = Välj den största upplösningen
 selection_the_smallest_size = Välj den minsta storleken

--- a/krokiet/i18n/tr/krokiet.ftl
+++ b/krokiet/i18n/tr/krokiet.ftl
@@ -188,6 +188,7 @@ sort_reverse = Ters Sırala
 selection_all = Tümünü Seç
 selection_deselect_all = Seçili olanları kaldırın
 selection_invert_selection = Seçimi Ters Çevir
+selection_invert_selection_in_group = Grupta seçimi ters çevir
 selection_the_biggest_size = En Büyük Büyüklükteki Dosyayı Seç
 selection_the_biggest_resolution = En Yüksek Çözünürlüğü Seç
 selection_the_smallest_size = En Küçük Büyüklükteki Dosyayı Seç

--- a/krokiet/i18n/uk/krokiet.ftl
+++ b/krokiet/i18n/uk/krokiet.ftl
@@ -188,6 +188,7 @@ sort_reverse = У зворотньому порядку
 selection_all = Виділити все
 selection_deselect_all = Зняти всі виділення
 selection_invert_selection = Інвертувати виділення
+selection_invert_selection_in_group = Інвертувати виділення в групі
 selection_the_biggest_size = Виберіть найбільший розмір
 selection_the_biggest_resolution = Виберіть найбільшу роздільну здатність
 selection_the_smallest_size = Оберіть найменший розмір

--- a/krokiet/i18n/vi/krokiet.ftl
+++ b/krokiet/i18n/vi/krokiet.ftl
@@ -188,6 +188,7 @@ sort_reverse = Đảo ngược thứ tự
 selection_all = Chọn tất cả
 selection_deselect_all = Bỏ chọn tất cả
 selection_invert_selection = Đảo ngược lựa chọn
+selection_invert_selection_in_group = Đảo ngược lựa chọn trong nhóm
 selection_the_biggest_size = Chọn kích thước lớn nhất
 selection_the_biggest_resolution = Chọn độ phân giải lớn nhất
 selection_the_smallest_size = Chọn kích thước nhỏ nhất

--- a/krokiet/i18n/zh-CN/krokiet.ftl
+++ b/krokiet/i18n/zh-CN/krokiet.ftl
@@ -188,6 +188,7 @@ sort_reverse = 反向顺序
 selection_all = 选择所有
 selection_deselect_all = 取消全选
 selection_invert_selection = 反转选择
+selection_invert_selection_in_group = 在组中反转选择
 selection_the_biggest_size = 选择最大的大小
 selection_the_biggest_resolution = 选择最大的分辨率
 selection_the_smallest_size = 选择最小尺寸

--- a/krokiet/i18n/zh-TW/krokiet.ftl
+++ b/krokiet/i18n/zh-TW/krokiet.ftl
@@ -188,6 +188,7 @@ sort_reverse = 反向排序
 selection_all = 選擇全部
 selection_deselect_all = 取消全部
 selection_invert_selection = 反向選擇
+selection_invert_selection_in_group = 在群組中反向選擇
 selection_the_biggest_size = 選擇最大檔案
 selection_the_biggest_resolution = 選擇最大解析度
 selection_the_smallest_size = 選擇最小檔案

--- a/krokiet/src/connect_select/mod.rs
+++ b/krokiet/src/connect_select/mod.rs
@@ -404,22 +404,24 @@ mod tests {
     fn invert_selection_in_group_only_changes_groups_with_selection() {
         let mut model = get_model_vec(7);
         model[1].header_row = true; // Group 1 header
-        // Group 1 (indices 0): items 0 - no selection initially
+        // Group 1 (indices 0): item 0 - no selection initially
         model[2].header_row = true; // Group 2 header
-        // Group 2 (indices 1): items 2, 3 - item 2 selected
-        model[2].checked = true;
+        // Group 2 (indices 3,4,5,6): items 3,4,5,6 - item 3 selected
+        model[3].checked = true;
         let model = create_model_from_model_vec(&model);
 
         let (checked_items, unchecked_items, new_model) = invert_selection_in_group(&model);
 
         // Group 1 has no selection, should remain unchanged
         assert!(!new_model.row_data(0).unwrap().checked);
-        // Group 2 has selection, should invert: item 2 checked->unchecked, item 3 unchecked->checked
-        assert!(!new_model.row_data(2).unwrap().checked);
-        assert!(new_model.row_data(3).unwrap().checked);
-        // Verify counts
-        assert_eq!(checked_items, 1); // item 3 was unchecked, now checked
-        assert_eq!(unchecked_items, 1); // item 2 was checked, now unchecked
+        // Group 2 has selection, should invert: item 3 checked->unchecked, others unchecked->checked
+        assert!(!new_model.row_data(3).unwrap().checked);
+        assert!(new_model.row_data(4).unwrap().checked);
+        assert!(new_model.row_data(5).unwrap().checked);
+        assert!(new_model.row_data(6).unwrap().checked);
+        // Verify counts: 3 items flipped from unchecked to checked, 1 from checked to unchecked
+        assert_eq!(checked_items, 3);
+        assert_eq!(unchecked_items, 1);
     }
 
     #[test]

--- a/krokiet/src/connect_select/mod.rs
+++ b/krokiet/src/connect_select/mod.rs
@@ -29,6 +29,7 @@ pub(crate) fn connect_select(app: &MainWindow, shared_models: &Arc<Mutex<SharedM
             SelectMode::SelectAll => select_all(&current_model),
             SelectMode::UnselectAll => deselect_all(&current_model),
             SelectMode::InvertSelection => invert_selection(&current_model),
+            SelectMode::InvertSelectionInGroup => invert_selection_in_group(&current_model),
             SelectMode::SelectTheBiggestSize => select_by_property(&current_model, active_tab, Property::Size, true),
             SelectMode::SelectTheSmallestSize => select_by_property(&current_model, active_tab, Property::Size, false),
             SelectMode::SelectTheBiggestResolution => select_by_property(&current_model, active_tab, Property::Resolution, false),
@@ -102,6 +103,7 @@ pub(crate) fn set_select_buttons(app: &MainWindow) {
 
     let additional_buttons = match active_tab {
         ActiveTab::DuplicateFiles | ActiveTab::SimilarVideos | ActiveTab::SimilarMusic => vec![
+            SelectMode::InvertSelectionInGroup,
             SelectMode::SelectOldest,
             SelectMode::SelectNewest,
             SelectMode::SelectTheSmallestSize,
@@ -110,6 +112,7 @@ pub(crate) fn set_select_buttons(app: &MainWindow) {
             SelectMode::SelectLongestPath,
         ],
         ActiveTab::SimilarImages => vec![
+            SelectMode::InvertSelectionInGroup,
             SelectMode::SelectOldest,
             SelectMode::SelectNewest,
             SelectMode::SelectTheSmallestSize,
@@ -257,6 +260,41 @@ fn invert_selection(model: &ModelRc<SingleMainListModel>) -> SelectionResult {
     (checked_items, unchecked_items, ModelRc::new(VecModel::from(old_data)))
 }
 
+fn invert_selection_in_group(model: &ModelRc<SingleMainListModel>) -> SelectionResult {
+    let mut checked_items = 0;
+    let mut unchecked_items = 0;
+    let mut old_data = model.iter().collect::<Vec<_>>();
+
+    let header_idx: Vec<usize> = old_data
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, m)| if m.header_row { Some(idx) } else { None })
+        .chain(std::iter::once(old_data.len()))
+        .collect();
+
+    for group_idx in 0..header_idx.len() - 1 {
+        let group_start = header_idx[group_idx] + 1;
+        let group_end = header_idx[group_idx + 1];
+
+        let has_selection_in_group = old_data[group_start..group_end].iter().any(|x| x.checked);
+
+        if !has_selection_in_group {
+            continue;
+        }
+
+        for i in group_start..group_end {
+            if old_data[i].checked {
+                unchecked_items += 1;
+            } else {
+                checked_items += 1;
+            }
+            old_data[i].checked = !old_data[i].checked;
+        }
+    }
+
+    (checked_items, unchecked_items, ModelRc::new(VecModel::from(old_data)))
+}
+
 fn find_header_idx_and_deselect_all(old_data: &mut [SingleMainListModel]) -> Vec<usize> {
     let mut header_idx = old_data
         .iter()
@@ -360,5 +398,41 @@ mod tests {
         assert!(new_model.row_data(2).unwrap().checked);
         assert!(new_model.row_data(3).unwrap().checked);
         assert!(new_model.row_data(4).unwrap().checked);
+    }
+
+    #[test]
+    fn invert_selection_in_group_only_changes_groups_with_selection() {
+        let mut model = get_model_vec(7);
+        model[1].header_row = true; // Group 1 header
+        // Group 1 (indices 0): items 0 - no selection initially
+        model[2].header_row = true; // Group 2 header
+        // Group 2 (indices 1): items 2, 3 - item 2 selected
+        model[2].checked = true;
+        let model = create_model_from_model_vec(&model);
+
+        let (checked_items, unchecked_items, new_model) = invert_selection_in_group(&model);
+
+        // Group 1 has no selection, should remain unchanged
+        assert!(!new_model.row_data(0).unwrap().checked);
+        // Group 2 has selection, should invert: item 2 checked->unchecked, item 3 unchecked->checked
+        assert!(!new_model.row_data(2).unwrap().checked);
+        assert!(new_model.row_data(3).unwrap().checked);
+        // Verify counts
+        assert_eq!(checked_items, 1); // item 3 was unchecked, now checked
+        assert_eq!(unchecked_items, 1); // item 2 was checked, now unchecked
+    }
+
+    #[test]
+    fn invert_selection_in_group_does_nothing_when_no_groups_have_selection() {
+        let mut model = get_model_vec(5);
+        model[1].header_row = true;
+        let model = create_model_from_model_vec(&model);
+
+        let (checked_items, unchecked_items, new_model) = invert_selection_in_group(&model);
+
+        assert_eq!(checked_items, 0);
+        assert_eq!(unchecked_items, 0);
+        assert!(!new_model.row_data(0).unwrap().checked);
+        assert!(!new_model.row_data(2).unwrap().checked);
     }
 }

--- a/krokiet/src/connect_translation.rs
+++ b/krokiet/src/connect_translation.rs
@@ -546,6 +546,7 @@ pub(crate) fn translate_select_mode(select_mode: SelectMode) -> SharedString {
         SelectMode::SelectAll => flk!("selection_all").into(),
         SelectMode::UnselectAll => flk!("selection_deselect_all").into(),
         SelectMode::InvertSelection => flk!("selection_invert_selection").into(),
+        SelectMode::InvertSelectionInGroup => flk!("selection_invert_selection_in_group").into(),
         SelectMode::SelectTheBiggestSize => flk!("selection_the_biggest_size").into(),
         SelectMode::SelectTheBiggestResolution => flk!("selection_the_biggest_resolution").into(),
         SelectMode::SelectTheSmallestSize => flk!("selection_the_smallest_size").into(),

--- a/krokiet/ui/common.slint
+++ b/krokiet/ui/common.slint
@@ -78,6 +78,7 @@ export enum SelectMode {
     SelectAll,
     UnselectAll,
     InvertSelection,
+    InvertSelectionInGroup,
     SelectTheBiggestSize,
     SelectTheBiggestResolution,
     SelectTheSmallestSize,


### PR DESCRIPTION
This change adds a new option to the `krokiet` UI that allows the user to invert the selections of items within a group of duplicate files only if one or more items within the group are selected.

Disclaimer: most of the changes were created using AI coding agents. I have personally built and tested the changed in my Macbook as I needed this feature to sort over 100k duplicate files.