### PR TITLE
Fix issue 1815

### DIFF
--- a/czkawka_core/src/common/tool_data.rs
+++ b/czkawka_core/src/common/tool_data.rs
@@ -371,7 +371,7 @@ pub trait CommonData {
                             }
                         }
                     } else {
-                        all_values = sort_items(all_values)
+                        all_values = sort_items(all_values);
                     }
                     let len = all_values.len();
                     match delete_method {
@@ -454,7 +454,7 @@ pub trait CommonData {
                     }
 
                     if dry_run {
-                        return Some(vec![(e, None)]);
+                        return Some(vec![(e, None, None)]);
                     }
 
                     let delete_res = if matches!(delete_item_type, DeleteItemType::DeletingFiles(_)) {
@@ -464,8 +464,8 @@ pub trait CommonData {
                     };
 
                     match delete_res {
-                        Ok(()) => Some(vec![(e, None)]),
-                        Err(err) => Some(vec![(e, Some(err))]),
+                        Ok(()) => Some(vec![(e, None, None)]),
+                        Err(err) => Some(vec![(e, None, Some(err))]),
                     }
                 })
                 .while_some()
@@ -487,21 +487,21 @@ pub trait CommonData {
                     }
 
                     if dry_run {
-                        return Some(files.iter().map(|e| (e, None)).collect::<Vec<_>>());
+                        return Some(files.iter().map(|e| (e, Some(original.get_path()), None)).collect::<Vec<_>>());
                     }
 
                     let res = files
                         .iter()
                         .map(|file| {
-                            let err = match make_hard_link(original.get_path(), file.get_path()) {
+                            let err = match make_hard_link(file.get_path(), original.get_path()) {
                                 Ok(()) => None,
                                 Err(err) => Some(format!(
                                     "Failed to hardlink \"{}\" to \"{}\": {err}",
+                                    file.get_path().to_string_lossy(),
                                     original.get_path().to_string_lossy(),
-                                    file.get_path().to_string_lossy()
                                 )),
                             };
-                            (file, err)
+                            (file, Some(original.get_path()), err)
                         })
                         .collect::<Vec<_>>();
 
@@ -514,17 +514,18 @@ pub trait CommonData {
 
         let mut delete_result = DeleteResult::default();
 
-        for (file_entry, delete_err) in res {
+        for (file_entry, maybe_original, delete_err) in res {
             if let Some(err) = delete_err {
                 delete_result.errors.push(err);
                 delete_result.failed_to_delete_files += 1;
             } else {
                 if dry_run {
                     if is_hardlinking {
+                        let original = maybe_original.expect("Should be defined");
                         delete_result.infos.push(format!(
                             "Would hardlink: \"{}\" to \"{}\"",
                             file_entry.get_path().to_string_lossy(),
-                            file_entry.get_path().to_string_lossy()
+                            original.to_string_lossy()
                         ));
                     } else {
                         delete_result.infos.push(format!("Would delete: \"{}\"", file_entry.get_path().to_string_lossy()));

--- a/czkawka_core/src/common/tool_data.rs
+++ b/czkawka_core/src/common/tool_data.rs
@@ -337,8 +337,16 @@ pub trait CommonData {
             let res = files_to_process
                 .into_iter()
                 .map(|values| {
-                    let mut all_values = sort_items(values);
-                    let original = all_values.remove(0);
+                    let mut all_values = values;
+                    let original;
+                    if self.get_use_reference_folders() {
+                        // The reference should be the first item.
+                        original = all_values.remove(0);
+                        all_values = sort_items(all_values);
+                    } else {
+                        all_values = sort_items(all_values);
+                        original = all_values.remove(0);
+                    }
                     (original, all_values)
                 })
                 .collect::<Vec<_>>();
@@ -347,8 +355,25 @@ pub trait CommonData {
             let res = files_to_process
                 .into_iter()
                 .flat_map(|values| {
-                    let len = values.len();
-                    let mut all_values = sort_items(values);
+                    let mut all_values = values;
+                    if self.get_use_reference_folders() {
+                        match all_values.len() {
+                            0 | 1 => unreachable!("Using reference folders you should not get less than 2 items"),
+                            2 => {
+                                // The reference should be the first item, and should not be deleted.
+                                all_values.remove(0);
+                                return all_values;
+                            }
+                            _ => {
+                                // The reference should be the first item, and should not be deleted.
+                                all_values.remove(0);
+                                all_values = sort_items(all_values);
+                            }
+                        }
+                    } else {
+                        all_values = sort_items(all_values)
+                    }
+                    let len = all_values.len();
                     match delete_method {
                         DeleteMethod::Delete => all_values,
                         DeleteMethod::AllExceptNewest | DeleteMethod::AllExceptBiggest => {

--- a/czkawka_core/src/tools/duplicate/traits.rs
+++ b/czkawka_core/src/tools/duplicate/traits.rs
@@ -26,7 +26,23 @@ impl DeletingItems for DuplicateFinder {
         let files_to_delete = match self.get_params().check_method {
             CheckingMethod::Name => self.files_with_identical_names.values().cloned().collect::<Vec<_>>(),
             CheckingMethod::SizeName => self.files_with_identical_size_names.values().cloned().collect::<Vec<_>>(),
-            CheckingMethod::Hash => self.files_with_identical_hashes.values().flatten().cloned().collect::<Vec<_>>(),
+            CheckingMethod::Hash => {
+                if self.get_use_reference() {
+                    self.files_with_identical_hashes_referenced
+                        .values()
+                        .flat_map(|e| {
+                            e.iter().map(|(reference, rest)| {
+                                let mut combined = Vec::with_capacity(1 + rest.len());
+                                combined.push(reference.to_owned());
+                                combined.extend(rest.to_owned());
+                                combined
+                            })
+                        })
+                        .collect::<Vec<_>>()
+                } else {
+                    self.files_with_identical_hashes.values().flatten().cloned().collect::<Vec<_>>()
+                }
+            }
             CheckingMethod::Size => self.files_with_identical_size.values().cloned().collect::<Vec<_>>(),
             _ => panic!(),
         };


### PR DESCRIPTION
Fixes issue #1815

Specifically, there are three issues addressed in this PR, all related to functions not checking if a reference folder was used and not changing behavior accordingly. 
1) When using the `dup` command of `czkawka_cli` with a reference folder, no files would be deleted when given the `-D` option
2) When using the `dup` command of `czkawka_cli` with a reference folder, the `--dry-run` option does not list the operations that would be performed.
3) When using the `dup` command of `czkawka_cli`, if `--dry-run` is called with `-D HARD` it prints the same file and not `Would hardlink: ORIGINAL to COPY`. Can be checked in lines 501-502: https://github.com/qarmin/czkawka/blob/b5b454af543f8f8ecb8e43c1db901766c200cbeb/czkawka_core/src/common/tool_data.rs#L492-L511

`cargo test --bin czkawka_cli` passed all tests.

## Note:
- I think this is the expected behavior but I will still note it to avoid misunderstandings. When given a reference folder, the delete options of `-D` are run on the non-reference files. 
    For instance, if `file1` is the reference, and `[file2, file3]` are the others, if given option to delete all except newest, only the oldest between `[file2, file3]` will be deleted, and `file1` will not be included in the list even if it is the newest.
    The only exception is when hardlinking, in that case every file will be hardlinked against the reference file.
- There is currently no option to delete all duplicate files aside from the reference one, the `-D` options are limited to `(AEN, AEO, ON, OO, AEB, AES, OB, OS, HARD)`. From what I've seen, the code should already be there, what is missing is just the parsing of the cli arguments. I did not implement it here, however, as it is a separate issue and I did not want to clutter the PR with too much stuff.

