### PR TITLE
Preserve file attributes during move/copy operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1702,7 +1702,6 @@ dependencies = [
  "crossbeam-channel",
  "czkawka_core",
  "directories-next",
- "fs_extra",
  "fun_time",
  "gdk4",
  "glib",
@@ -2540,12 +2539,6 @@ name = "four-cc"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "795cbfc56d419a7ce47ccbb7504dd9a5b7c484c083c356e797de08bd988d9629"
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fun_time"
@@ -4545,7 +4538,6 @@ dependencies = [
  "crossbeam-channel",
  "czkawka_core",
  "fontique",
- "fs_extra",
  "home",
  "humansize",
  "i18n-embed",

--- a/czkawka_gui/Cargo.toml
+++ b/czkawka_gui/Cargo.toml
@@ -21,7 +21,6 @@ directories-next = "2.0"
 open = "5.3"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 regex = "1.11"
-fs_extra = "1.3"
 
 i18n-embed = { version = "0.16", features = ["fluent-system", "desktop-requester"] }
 i18n-embed-fl = "0.10"

--- a/czkawka_gui/src/connect_things/connect_button_move.rs
+++ b/czkawka_gui/src/connect_things/connect_button_move.rs
@@ -166,11 +166,7 @@ fn move_item_preserving_attrs(src: &Path, dst: &Path) -> std::io::Result<()> {
         return Ok(());
     }
     copy_item_preserving_attrs(src, dst)?;
-    if src.is_dir() {
-        std::fs::remove_dir_all(src)
-    } else {
-        std::fs::remove_file(src)
-    }
+    if src.is_dir() { std::fs::remove_dir_all(src) } else { std::fs::remove_file(src) }
 }
 
 fn copy_item_preserving_attrs(src: &Path, dst: &Path) -> std::io::Result<()> {
@@ -183,9 +179,7 @@ fn copy_item_preserving_attrs(src: &Path, dst: &Path) -> std::io::Result<()> {
         }
     } else {
         std::fs::copy(src, dst)?;
-        let times = std::fs::FileTimes::new()
-            .set_accessed(metadata.accessed()?)
-            .set_modified(metadata.modified()?);
+        let times = std::fs::FileTimes::new().set_accessed(metadata.accessed()?).set_modified(metadata.modified()?);
         std::fs::OpenOptions::new().write(true).open(dst)?.set_times(times)?;
     }
     std::fs::set_permissions(dst, metadata.permissions())?;

--- a/czkawka_gui/src/connect_things/connect_button_move.rs
+++ b/czkawka_gui/src/connect_things/connect_button_move.rs
@@ -1,6 +1,5 @@
 use std::path::Path;
 
-use fs_extra::dir::CopyOptions;
 use gtk4::prelude::*;
 use gtk4::{ResponseType, TreePath};
 use log::debug;
@@ -140,16 +139,15 @@ fn move_files_common(
 
         let thing = get_full_name_from_path_name(&path, &file_name);
         let destination_file = destination_folder.join(&file_name);
-        if Path::new(&thing).is_dir() {
-            if let Err(e) = fs_extra::dir::move_dir(&thing, &destination_file, &CopyOptions::new()) {
-                messages += flg!("move_folder_failed", name = thing, reason = e.to_string()).as_str();
-                messages += "\n";
-                continue 'next_result;
-            }
-        } else if let Err(e) = fs_extra::file::move_file(&thing, &destination_file, &fs_extra::file::CopyOptions::new()) {
-            messages += flg!("move_file_failed", name = thing, reason = e.to_string()).as_str();
+        let thing_path = Path::new(&thing);
+        if let Err(e) = move_item_preserving_attrs(thing_path, &destination_file) {
+            let msg = if thing_path.is_dir() {
+                flg!("move_folder_failed", name = thing, reason = e.to_string())
+            } else {
+                flg!("move_file_failed", name = thing, reason = e.to_string())
+            };
+            messages += msg.as_str();
             messages += "\n";
-
             continue 'next_result;
         }
         model.remove(&iter);
@@ -161,4 +159,35 @@ fn move_files_common(
     entry_info.set_text(flg!("move_stats", num_files = moved_files, all_files = selected_rows.len()).as_str());
 
     text_view_errors.buffer().set_text(messages.as_str());
+}
+
+fn move_item_preserving_attrs(src: &Path, dst: &Path) -> std::io::Result<()> {
+    if std::fs::rename(src, dst).is_ok() {
+        return Ok(());
+    }
+    copy_item_preserving_attrs(src, dst)?;
+    if src.is_dir() {
+        std::fs::remove_dir_all(src)
+    } else {
+        std::fs::remove_file(src)
+    }
+}
+
+fn copy_item_preserving_attrs(src: &Path, dst: &Path) -> std::io::Result<()> {
+    let metadata = src.metadata()?;
+    if metadata.is_dir() {
+        std::fs::create_dir_all(dst)?;
+        for entry in std::fs::read_dir(src)? {
+            let entry = entry?;
+            copy_item_preserving_attrs(&entry.path(), &dst.join(entry.file_name()))?;
+        }
+    } else {
+        std::fs::copy(src, dst)?;
+        let times = std::fs::FileTimes::new()
+            .set_accessed(metadata.accessed()?)
+            .set_modified(metadata.modified()?);
+        std::fs::OpenOptions::new().write(true).open(dst)?.set_times(times)?;
+    }
+    std::fs::set_permissions(dst, metadata.permissions())?;
+    Ok(())
 }

--- a/krokiet/Cargo.toml
+++ b/krokiet/Cargo.toml
@@ -23,7 +23,6 @@ serde_json = "1.0"
 humansize = "2.1"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 rayon = "1.10"
-fs_extra = "1.3" # TODO replace with less buggy library
 num_enum = "0.7.5"
 regex = "1.11"
 copypasta = "0.10"

--- a/krokiet/src/file_actions/connect_move.rs
+++ b/krokiet/src/file_actions/connect_move.rs
@@ -103,21 +103,32 @@ fn move_single_item(data: &SimplerSingleMainListModel, path_idx: usize, name_idx
 
 // Tries to copy file/folder, and returns error if it fails
 fn try_to_copy_item(input_file: &Path, output_file: &Path) -> Result<(), String> {
-    let res = if input_file.is_dir() {
-        let options = fs_extra::dir::CopyOptions::new();
-        fs_extra::dir::copy(input_file, output_file, &options) // TODO consider to use less buggy library
-    } else {
-        let options = fs_extra::file::CopyOptions::new();
-        fs_extra::file::copy(input_file, output_file, &options)
-    };
-    if let Err(e) = res {
-        return Err(flk!(
+    copy_with_attrs(input_file, output_file).map_err(|e| {
+        flk!(
             "rust_error_copying_file",
             input = input_file.to_string_lossy().to_string(),
             output = output_file.to_string_lossy().to_string(),
             reason = e.to_string()
-        ));
+        )
+    })
+}
+
+fn copy_with_attrs(src: &Path, dst: &Path) -> std::io::Result<()> {
+    let metadata = src.metadata()?;
+    if metadata.is_dir() {
+        fs::create_dir_all(dst)?;
+        for entry in fs::read_dir(src)? {
+            let entry = entry?;
+            copy_with_attrs(&entry.path(), &dst.join(entry.file_name()))?;
+        }
+    } else {
+        fs::copy(src, dst)?;
+        let times = fs::FileTimes::new()
+            .set_accessed(metadata.accessed()?)
+            .set_modified(metadata.modified()?);
+        fs::OpenOptions::new().write(true).open(dst)?.set_times(times)?;
     }
+    fs::set_permissions(dst, metadata.permissions())?;
     Ok(())
 }
 

--- a/krokiet/src/file_actions/connect_move.rs
+++ b/krokiet/src/file_actions/connect_move.rs
@@ -123,9 +123,7 @@ fn copy_with_attrs(src: &Path, dst: &Path) -> std::io::Result<()> {
         }
     } else {
         fs::copy(src, dst)?;
-        let times = fs::FileTimes::new()
-            .set_accessed(metadata.accessed()?)
-            .set_modified(metadata.modified()?);
+        let times = fs::FileTimes::new().set_accessed(metadata.accessed()?).set_modified(metadata.modified()?);
         fs::OpenOptions::new().write(true).open(dst)?.set_times(times)?;
     }
     fs::set_permissions(dst, metadata.permissions())?;


### PR DESCRIPTION
## Problem

When files are moved from Czkawka/Krokiet using the move action, moved files receive the current modification time instead of keeping their original metadata. This is especially problematic for photo and video collections, where `mtime` is commonly used for sorting and organization.

Reported in: #1321

## What was changed

The original approach of setting `copy_attributes = true` on `fs_extra` options was not possible — `fs_extra` 1.3.0 does not have this field. `fs_extra` has been removed from both crates and replaced with a stdlib-based implementation that correctly preserves attributes.

### `czkawka_gui/src/connect_things/connect_button_move.rs`

- Replaced `fs_extra::dir::move_dir` and `fs_extra::file::move_file` with a custom `move_item_preserving_attrs` function.
- On the same filesystem, uses `std::fs::rename` — atomic, preserves all attributes with zero overhead.
- On cross-device moves, falls back to `copy_item_preserving_attrs` + delete, which restores permissions and timestamps (`mtime`, `atime`) after copying.

### `krokiet/src/file_actions/connect_move.rs`

- Replaced `fs_extra::dir::copy` and `fs_extra::file::copy` with a custom `copy_with_attrs` function.
- For files: uses `std::fs::copy` (preserves permissions on Unix) followed by `std::fs::FileTimes` to restore `mtime` and `atime`.
- For directories: recursively applies the same logic to every entry.

### `czkawka_gui/Cargo.toml` / `krokiet/Cargo.toml`

- Removed `fs_extra` dependency from both crates.

## Expected behavior

When selected duplicate files or folders are moved or copied, their file attributes are preserved:

- modification time (`mtime`) stays unchanged;
- access time (`atime`) stays unchanged;
- file permissions are preserved.

## Why this matters

Changing modification time during move operations breaks workflows where users rely on filesystem timestamps, for example:

- organizing photos and videos by date;
- sorting media collections;
- preserving imported file metadata;
- moving duplicates to a quarantine/review directory before deletion.
