### PR TITLE
Persist preset names in Krokiet on Save Current Preset click

### DIFF
--- a/krokiet/src/settings/mod.rs
+++ b/krokiet/src/settings/mod.rs
@@ -58,6 +58,10 @@ pub(crate) fn connect_changing_settings_preset(app: &MainWindow) {
                 error!("Failed to save preset - {e}");
             }
         }
+        // Also persist base settings (preset names, default preset, window prefs).
+        // Without this, renaming a preset only takes effect after a clean app exit,
+        // and is lost if the on-exit save path doesn't run.
+        save_base_settings_to_file(&app, current_item);
     });
     let a = app.as_weak();
     app.global::<Callabler>().on_reset_current_preset(move || {
@@ -973,5 +977,35 @@ pub(crate) fn collect_base_settings(app: &MainWindow) -> BasicSettings {
         select_show_except_biggest_resolution: settings.get_select_show_except_biggest_resolution(),
         select_show_except_shortest_path: settings.get_select_show_except_shortest_path(),
         select_show_except_longest_path: settings.get_select_show_except_longest_path(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::{load_data_from_file, save_data_to_file};
+    use crate::settings::model::BasicSettings;
+
+    // The bug fixed in `on_save_current_preset` (writing base settings on Save click) relies
+    // on this round-trip: edit preset_names in memory → save_data_to_file → load_data_from_file
+    // must return the edited names. Without it, renaming a preset cannot survive a restart.
+    #[test]
+    fn basic_settings_round_trips_renamed_preset_names() {
+        let mut path: PathBuf = std::env::temp_dir();
+        path.push(format!("krokiet_test_basic_settings_round_trip_{}.json", std::process::id()));
+
+        let mut settings = BasicSettings::default();
+        settings.preset_names[0] = "Photos 2024".to_string();
+        settings.preset_names[1] = "Backup".to_string();
+
+        save_data_to_file(Some(path.clone()), &settings).expect("save_data_to_file should succeed for a temp path");
+        let loaded: BasicSettings = load_data_from_file(Some(path.clone())).expect("load_data_from_file should succeed for the file we just wrote");
+
+        let _ = std::fs::remove_file(&path);
+
+        assert_eq!(loaded.preset_names[0], "Photos 2024");
+        assert_eq!(loaded.preset_names[1], "Backup");
+        assert_eq!(loaded.preset_names.len(), settings.preset_names.len());
     }
 }


### PR DESCRIPTION
## Problem

Krokiet's **Save Current Preset** button writes the per-preset config file (`config_preset_N.json`) but does not write the base settings file (`config_general.json`). Preset names live in `BasicSettings` and are only flushed on clean app exit via `save_all_settings_to_file()`. On a non-clean exit (window close that returns non-`Ok`, logger that did not flush, force quit), preset renames silently vanish on next launch.

## Repro (Krokiet 11.0.1, macOS 15.7)

1. Open Krokiet
2. Settings tab → click **Edit name** next to a preset, type a new name, click **Save**
3. Click **Save Current Preset**
4. Quit the app
5. Relaunch
6. Preset name has reverted to the default ("Preset 1", etc.)

## Fix

`on_save_current_preset` now calls `save_base_settings_to_file` in addition to the existing per-preset write, so the Save button matches user expectations — Save means save everything visible, including any preset rename just made through the Edit name dialog.

Adds a round-trip unit test for `BasicSettings` in `krokiet/src/settings/mod.rs` to lock in the data path the new call exercises.

## Verification

- `cargo test -p krokiet` — passes (new test `basic_settings_round_trips_renamed_preset_names`)
- `cargo +nightly fmt` + `cargo clippy --all-targets -- -D warnings` — clean
- Manual end-to-end on macOS 15.7 in a clean Tart VM:
  - Rename `Preset 1` → `TEST-FIX-VERIFY 1` in the Edit name dialog
  - Click Save Current Preset → `config_general.json` mtime updates, `preset_names[0] = "TEST-FIX-VERIFY 1"`
  - `pkill -9` (worst-case force-quit) → file content survives
  - Relaunch → Settings combo box shows `TEST-FIX-VERIFY 1`
  - Without the fix, the same sequence leaves `config_general.json` unchanged (still defaults).

## Related

- #1225 (closed 2024-02-24) — "'Presets' does not work correctly" was a previous preset-persistence bug, fixed for the per-preset config path. The base settings file (where preset names live) was not covered by that fix.

## Scope

Intentionally minimal: one new call inside the existing callback, plus one unit test. The narrower follow-up — saving base settings directly from the Edit name dialog's own Save button, so rename-then-force-quit-without-clicking-Save-Current-Preset doesn't lose the rename — is out of scope here. That would require a new `Callabler` callback and wiring it from `krokiet/ui/settings_list.slint`.