### PR TITLE
krokiet: draggable splitter for Included/Excluded Paths panel

### DIFF
--- a/krokiet/src/settings/mod.rs
+++ b/krokiet/src/settings/mod.rs
@@ -265,10 +265,12 @@ pub(crate) fn set_base_settings_to_gui(app: &MainWindow, basic_settings: &BasicS
 
     let width = basic_settings.window_width.clamp(100, 1920 * 4);
     let height = basic_settings.window_height.clamp(100, 1080 * 4);
+    let bottom_panel_height = basic_settings.bottom_panel_height.clamp(60, 1080 * 4);
 
     if basic_settings.settings_load_windows_size_at_startup {
         app.window().set_size(WindowSize::Physical(PhysicalSize { width, height }));
     }
+    settings.set_bottom_panel_height(bottom_panel_height as f32);
     settings.set_dark_theme(basic_settings.dark_theme);
     settings.set_show_only_icons(basic_settings.show_only_icons);
     app.global::<Callabler>().invoke_theme_changed();
@@ -928,6 +930,7 @@ pub(crate) fn collect_base_settings(app: &MainWindow) -> BasicSettings {
     let preset_names = settings.get_settings_presets().iter().map(|x| x.to_string()).collect::<Vec<_>>();
     let window_width = (app.window().size().width as f32 / app.window().scale_factor()) as u32;
     let window_height = (app.window().size().height as f32 / app.window().scale_factor()) as u32;
+    let bottom_panel_height = settings.get_bottom_panel_height() as u32;
 
     assert_eq!(preset_names.len(), PRESET_NUMBER);
     let language = combo_box_items.language.config_name;
@@ -948,6 +951,7 @@ pub(crate) fn collect_base_settings(app: &MainWindow) -> BasicSettings {
         preset_names,
         window_width,
         window_height,
+        bottom_panel_height,
         dark_theme,
         show_only_icons,
         settings_load_tabs_sizes_at_startup,

--- a/krokiet/src/settings/model.rs
+++ b/krokiet/src/settings/model.rs
@@ -32,6 +32,7 @@ pub const DEFAULT_MINIMAL_FRAGMENT_DURATION_VALUE: f32 = 5.0;
 pub const MAX_HASH_SIZE: f32 = 40.0;
 pub const DEFAULT_WINDOW_WIDTH: u32 = 800;
 pub const DEFAULT_WINDOW_HEIGHT: u32 = 600;
+pub const DEFAULT_BOTTOM_PANEL_HEIGHT: u32 = 150;
 pub const DEFAULT_MIN_VIDEO_THUMBNAIL_POSITION_PERCENT: u8 = 1;
 pub const DEFAULT_MAX_VIDEO_THUMBNAIL_POSITION_PERCENT: u8 = 99;
 
@@ -303,6 +304,8 @@ pub struct BasicSettings {
     pub window_width: u32,
     #[serde(default = "default_window_height")]
     pub window_height: u32,
+    #[serde(default = "default_bottom_panel_height")]
+    pub bottom_panel_height: u32,
     #[serde(default = "detect_language")]
     pub language: String,
     #[serde(default = "ttrue")]
@@ -492,6 +495,9 @@ pub(crate) fn default_window_width() -> u32 {
 pub(crate) fn default_window_height() -> u32 {
     DEFAULT_WINDOW_HEIGHT
 }
+pub(crate) fn default_bottom_panel_height() -> u32 {
+    DEFAULT_BOTTOM_PANEL_HEIGHT
+}
 pub(crate) fn default_video_optimizer_mode() -> String {
     "transcode".to_string()
 }
@@ -575,5 +581,42 @@ impl Default for SavedCustomSelectTabState {
             leave_one_in_group: true,
             columns: Vec::new(),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{BasicSettings, DEFAULT_BOTTOM_PANEL_HEIGHT, default_bottom_panel_height};
+
+    #[test]
+    fn test_default_bottom_panel_height_is_150() {
+        assert_eq!(default_bottom_panel_height(), 150);
+        assert_eq!(DEFAULT_BOTTOM_PANEL_HEIGHT, 150);
+    }
+
+    #[test]
+    fn test_basic_settings_default_has_bottom_panel_height_150() {
+        let settings = BasicSettings::default();
+        assert_eq!(settings.bottom_panel_height, 150);
+    }
+
+    #[test]
+    fn test_bottom_panel_height_missing_in_json_uses_default() {
+        // Older config files predate this field — they must deserialize
+        // cleanly and pick up the 150 default rather than failing.
+        let json = "{}";
+        let settings: BasicSettings = serde_json::from_str(json).expect("empty json should deserialize");
+        assert_eq!(settings.bottom_panel_height, 150);
+    }
+
+    #[test]
+    fn test_bottom_panel_height_round_trip() {
+        let settings = BasicSettings {
+            bottom_panel_height: 275,
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&settings).expect("serialize");
+        let restored: BasicSettings = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(restored.bottom_panel_height, 275);
     }
 }

--- a/krokiet/ui/bottom_panel.slint
+++ b/krokiet/ui/bottom_panel.slint
@@ -148,7 +148,7 @@ export component BottomPanel {
     callback folder_choose_requested(bool);
     callback file_choose_requested(bool);
     callback show_manual_add_dialog(bool);
-    min-height: bottom_panel_visibility == BottomPanelVisibility.NotVisible ? 0px : 150px;
+    min-height: bottom_panel_visibility == BottomPanelVisibility.NotVisible ? 0px : 60px;
     min-width: bottom_panel_visibility == BottomPanelVisibility.NotVisible ? 0px : 400px;
     if bottom_panel_visibility == BottomPanelVisibility.Directories: DirectoriesPanel {
         width: parent.width;

--- a/krokiet/ui/main_window.slint
+++ b/krokiet/ui/main_window.slint
@@ -2,7 +2,7 @@ import { HorizontalBox, LineEdit, Palette, VerticalBox } from "std-widgets.slint
 import { FontSizes } from "fonts.slint";
 import { LeftSidePanel } from "left_side_panel.slint";
 import { MainList } from "main_lists.slint";
-import { ActiveTab, PopupRequest, ProgressToSend, SingleMainListModel } from "common.slint";
+import { ActiveTab, BottomPanelVisibility, PopupRequest, ProgressToSend, SingleMainListModel } from "common.slint";
 import { ActionButtons } from "action_buttons.slint";
 import { Progress } from "progress.slint";
 import { Settings } from "settings.slint";
@@ -209,9 +209,46 @@ export component MainWindow inherits Window {
             }
         }
 
+        // Draggable splitter handle for resizing the bottom panel.
+        //
+        // Uses the incremental Slint pattern from docs.slint.dev: each `moved`
+        // event adjusts the target by (mouse-y - pressed-y), using the LIVE
+        // panel height as the base. Capturing a press-time snapshot does NOT
+        // work here — the TouchArea itself moves vertically with the splitter
+        // as the panel grows, so mouse-y in the new TouchArea-local frame
+        // returns to pressed-y each frame, zeroing the delta and reverting
+        // the change. The "increment from current value" idiom is stable
+        // through that feedback because Δmouse-y equals the layout-induced
+        // Δ-TA-origin, so the same delta keeps applying each event.
+        Rectangle {
+            vertical-stretch: 0.0;
+            height: 6px;
+            background: splitter_ta.has-hover || splitter_ta.pressed
+                ? Palette.accent-background
+                : Palette.alternate-background;
+            splitter_ta := TouchArea {
+                mouse-cursor: MouseCursor.row-resize;
+                moved => {
+                    if (self.pressed) {
+                        Settings.bottom_panel_height = max(60px,
+                            min(root.height - 200px,
+                                Settings.bottom_panel_height - (self.mouse-y - self.pressed-y)));
+                    }
+                }
+            }
+        }
+
         bottom_panel := BottomPanel {
             bottom_panel_visibility <=> action_buttons.bottom_panel_visibility;
             vertical-stretch: 0.0;
+            // Per Slint docs (positioning-and-layouts), elements with an
+            // explicit height inside a VerticalBox are not resized by the
+            // layout. min-height/max-height pinning works for the size but
+            // contributes to the parent layout's min-height sum and can
+            // cause overflow that breaks sibling hit-testing — verified by
+            // the previous iteration breaking sidebar clicks.
+            height: self.bottom_panel_visibility == BottomPanelVisibility.NotVisible
+                ? 0px : Settings.bottom_panel_height;
             folder_choose_requested(included_paths) => {
                 root.folder_choose_requested(included_paths)
             }

--- a/krokiet/ui/settings.slint
+++ b/krokiet/ui/settings.slint
@@ -17,6 +17,7 @@ export global Settings {
     in-out property <bool> dark_theme: true;
     in-out property <bool> show_only_icons: false;
     in-out property <bool> load_windows_size_at_startup: true;
+    in-out property <length> bottom_panel_height: 150px;
     in-out property <bool> load_tabs_sizes_at_startup: true;
     in-out property <bool> limit_messages_lines: true;
     in-out property <float> manual_application_scale: 1.0;


### PR DESCRIPTION
## Summary

Adds a draggable splitter handle above the Included/Excluded Paths panel in krokiet, so the user can resize the bottom panel by dragging. Height persists across launches.

Closes #1792.

## Changes

- **`krokiet/src/settings/model.rs`** — new `bottom_panel_height: u32` field on `BasicSettings` (`#[serde(default)]`, default 150, clamp 60..1080*4). Round-trip + missing-field tests added. Older config files (no `bottom_panel_height` key) deserialize cleanly via serde default.
- **`krokiet/src/settings/mod.rs`** — load/clamp in `set_base_settings_to_gui`, save in `collect_base_settings`. Mirrors the existing `window_height` plumbing.
- **`krokiet/ui/settings.slint`** — new `Settings.bottom_panel_height: length` global (default 150px).
- **`krokiet/ui/bottom_panel.slint`** — `BottomPanel` `min-height` floor relaxed from 150px to 60px so the user can drag small.
- **`krokiet/ui/main_window.slint`** — 6px draggable `Rectangle` splitter handle with a `TouchArea` (mouse-cursor: row-resize) above the bottom panel; `BottomPanel.height` bound to `Settings.bottom_panel_height` with clamp `60px..root.height - 200px`.

## Drag math note

Each `moved` event applies `(mouse-y - pressed-y)` to the **live** `Settings.bottom_panel_height`, not to a press-time snapshot. The snapshot pattern is unstable here because the `TouchArea` itself translates with the splitter as the panel grows; `mouse-y` in the new TouchArea-local frame returns to `pressed-y` each event, zeroing the delta. The "increment from current" idiom is stable because `Δmouse-y` matches the layout-induced `Δ-TA-origin` one-to-one. This matches the canonical splitter pattern from <https://docs.slint.dev/latest/docs/slint/guide/development/custom-controls>.

## Layout note

`BottomPanel` size is controlled via an explicit `height:` binding (per Slint positioning-and-layouts: elements with a fixed width/height are not resized by the layout). Pinning via `min-height` + `max-height` was tried but the constraint propagates to the parent `VerticalBox`'s min-height sum and caused overflow that broke hit-testing on the sibling `LeftSidePanel` tabs.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p krokiet --all-targets -- -D warnings` — clean
- [x] `bash misc/run_checks.sh` — clean (no unused slint imports / translations / callbacks / settings properties; `bottom_panel_height` is referenced in main_window.slint)
- [x] `cargo test -p krokiet --bin krokiet settings::model` — 4/4 pass (defaults, missing-field deserialization, round-trip)
- [x] Manual verification in a macOS Tart VM via Screen Sharing: hover shows row-resize cursor; drag visibly resizes the panel; clamps at floor and ceiling; sidebar tabs remain clickable; height persists across launches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)