### PR TITLE
krokiet: persist settings when user quits via Cmd+Q on macOS

### DIFF
--- a/krokiet/src/main.rs
+++ b/krokiet/src/main.rs
@@ -173,6 +173,12 @@ fn main() {
     // This is simpler solution, than setting sizes of popups manually for each language
     app.invoke_initialize_popup_sizes();
 
+    // Periodic autosave bounds worst-case loss when the process exits without
+    // `app.run()` returning — notably macOS Cmd+Q, which goes through
+    // `NSApplication.terminate:` and hard-exits before the post-run save below
+    // can fire. See https://github.com/qarmin/czkawka/issues/1942.
+    let _autosave_timer = start_settings_autosave(&app, original_preset_idx);
+
     match app.run() {
         Ok(()) => {
             save_all_settings_to_file(&app, original_preset_idx);
@@ -182,6 +188,16 @@ fn main() {
             show_critical_error(e.to_string());
         }
     }
+}
+
+fn start_settings_autosave(app: &MainWindow, original_preset_idx: i32) -> slint::Timer {
+    let timer = slint::Timer::default();
+    let app_weak = app.as_weak();
+    timer.start(slint::TimerMode::Repeated, std::time::Duration::from_secs(5), move || {
+        let app = app_weak.upgrade().expect("MainWindow dropped while autosave timer is still live");
+        save_all_settings_to_file(&app, original_preset_idx);
+    });
+    timer
 }
 
 pub fn show_critical_error(error: String) {

--- a/krokiet/src/settings/mod.rs
+++ b/krokiet/src/settings/mod.rs
@@ -151,7 +151,7 @@ pub(crate) fn save_all_settings_to_file(app: &MainWindow, original_preset_idx: i
     save_base_settings_to_file(app, original_preset_idx);
     save_custom_settings_to_file(app);
 
-    info!("Saved settings to file");
+    debug!("Saved settings to file");
 }
 
 pub(crate) fn save_base_settings_to_file(app: &MainWindow, original_preset_idx: i32) {


### PR DESCRIPTION
## What

Adds a 5-second periodic autosave to krokiet's main event loop so that settings are persisted while the app is running, not only when `app.run()` returns.

## Why

On macOS, krokiet currently loses every persisted setting (window size, preset names, splitter height, dark theme, etc.) when the user quits via **Cmd+Q**.

The existing persistence path lives at `krokiet/src/main.rs:176`:

```rust
match app.run() {
    Ok(()) => {
        save_all_settings_to_file(&app, original_preset_idx);
    }
    ...
}
```

This works for the red traffic-light close button because winit emits `WindowEvent::CloseRequested` from `windowShouldClose:`, Slint's event loop drains, and `app.run()` returns `Ok(())`.

Cmd+Q is a different path: NSApplication's `terminate:` posts `applicationWillTerminate:`, winit's `will_terminate` handler calls `notify_windows_of_exit` + `internal_exit`, then NSApplication calls `exit(0)`. The Rust stack never unwinds — `app.run()` never returns — so `save_all_settings_to_file` never runs. There is also no per-window `CloseRequested` fired for Cmd+Q (winit doesn't intercept `applicationShouldTerminate:`), so `slint::Window::on_close_requested` can't be used either.

A periodic autosave is the simplest pure-Rust fix that doesn't require adding `objc2`/`i-slint-backend-winit` direct deps or enabling unstable Slint feature flags. It bounds worst-case loss to one timer interval and leaves the existing post-run save unchanged for the red-button path.

The `info!("Saved settings to file")` log is demoted to `debug!` since it now fires every 5 seconds.

## Verification

Verified in a fresh macOS 15.7.3 (aarch64) VM, built with `cargo build --release -p krokiet`:

1. **Autosave fires:** Planted a 6-key config (`window_height: 567`, `dark_theme: false`), launched krokiet, waited 8 seconds. File grew to the full 30+ key default state with `window_height: 567` and `dark_theme: false` preserved — proving autosave wrote during the session.
2. **State survives hard exit:** With autosave active, sent `kill -9` to krokiet (worst case, equivalent to Cmd+Q's `exit(0)` from a persistence standpoint). File on disk still shows the autosaved state. The original bug would have lost everything.
3. **Red-button path:** Untouched in the diff — the `Ok(())` arm still calls `save_all_settings_to_file` exactly as before.

Diff is 17 lines added, 1 line changed across two files. No new dependencies.

Closes #1942