### PR TITLE
feat(similar-images): add geometric invariance

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ The project will remain available in the repository. For some time I will ensure
 #### Users
 - Due to changes in the broken files mode, which now supports multiple checkers and includes additional checks, the file type is no longer stored in the cache. Existing cache files are incompatible with this version and will be automatically regenerated
 - The prehash method has been updated, so cached hash is no longer valid, so it will be automatically regenerated
+- Similar images cache files are incompatible with this version due to geometric invariance support and will be automatically regenerated
 
 ### Core
 - Switched AV1 encoding from the very slow `libaom-av1` to `libsvtav1` - [#1888](https://github.com/qarmin/czkawka/pull/1888)
@@ -25,11 +26,13 @@ The project will remain available in the repository. For some time I will ensure
 - Temporary files mode now allows customization of searched file extensions - [#1919](https://github.com/qarmin/czkawka/pull/1919)
 - Prehash now also hashes the end of files to detect differences earlier - [#1919](https://github.com/qarmin/czkawka/pull/1919)
 - Added support for detecting corruption in Fonts (TTF, OTF, TTC), Markup (JSON, XML, TOML, YAML, SVG), and Archives (7z, gz/tgz, tar, zst, bz2, xz) - [#1919](https://github.com/qarmin/czkawka/pull/1919)
+- Added geometric invariance support for similar images mode, allowing mirrored, flipped, and rotated images to be matched - [#1944](https://github.com/qarmin/czkawka/pull/1944)
 - Fixed a bug where relative symlinks were resolved without considering the parent directory - [#1900](https://github.com/qarmin/czkawka/pull/1900)
 - Fixed a prehash cache bypass that caused full hash computation on some files during a second scan - [#1907](https://github.com/qarmin/czkawka/pull/1907)
 - Extended integration tests, to prevent regressions in the future - [#1919](https://github.com/qarmin/czkawka/pull/1919)
 
 ### CLI
+- Added `--geometric-invariance` option to similar images mode - [#1944](https://github.com/qarmin/czkawka/pull/1944)
 
 ### GTK GUI
 - Fixed a crash when using the sort button - [#1837](https://github.com/qarmin/czkawka/pull/1837)
@@ -48,9 +51,11 @@ The project will remain available in the repository. For some time I will ensure
 - Added invert selection within groups - [#1915](https://github.com/qarmin/czkawka/pull/1915)
 - Fixed shortest/longest path selection modes, which previously compared only paths without file names - [#1919](https://github.com/qarmin/czkawka/pull/1919)
 - Ability to restore save/restore data in custom popup - [#1919](https://github.com/qarmin/czkawka/pull/1919)
+- Added a geometric invariance setting to similar images mode - [#1944](https://github.com/qarmin/czkawka/pull/1944)
 
 ### Cedinia
 - Initial experimental release of Cedinia, a new Android app with touch support - [#1821](https://github.com/qarmin/czkawka/pull/1821)
+- Added a geometric invariance setting to similar images mode - [#1944](https://github.com/qarmin/czkawka/pull/1944)
 
 ### Prebuilt binaries
 - Linux prebuilt binaries now include AVIF support (requires `libavif` and `libdav1d`)

--- a/cedinia/i18n/en/cedinia.ftl
+++ b/cedinia/i18n/en/cedinia.ftl
@@ -125,6 +125,7 @@ settings_hash_size = Hash size
 settings_hash_size_desc = Larger sizes, have less false positives, but also finds less similar images
 settings_hash_alg = Hash algorithm
 settings_image_filter = Resize filter
+settings_geometric_invariance = Geometric invariance
 settings_ignore_same_size = Ignore images with the same dimensions
 settings_gallery_image_fit_cover = Gallery: crop to square
 settings_gallery_image_fit_cover_desc = Fill the tile; disable to keep original aspect ratio

--- a/cedinia/src/callbacks/scan.rs
+++ b/cedinia/src/callbacks/scan.rs
@@ -7,7 +7,7 @@ use crossbeam_channel::Sender;
 use czkawka_core::common::model::{CheckingMethod, HashType};
 use czkawka_core::re_exported::{FilterType, HashAlg};
 use czkawka_core::tools::big_file::SearchMode;
-use czkawka_core::tools::similar_images::SimilarityPreset;
+use czkawka_core::tools::similar_images::{GeometricInvariance, SimilarityPreset};
 use slint::{ComponentHandle, ModelRc, SharedString, VecModel};
 
 use crate::model::count_checked;
@@ -163,6 +163,7 @@ fn build_scan_request(win: &MainWindow, tool: ActiveTool, dirs: Vec<PathBuf>, ex
                 hash_size: StringComboBoxItems::value_from_idx(&items.hash_size, s.get_hash_size_idx(), 16),
                 hash_alg: StringComboBoxItems::value_from_idx(&items.hash_alg, s.get_hash_alg_idx(), HashAlg::Mean),
                 image_filter: StringComboBoxItems::value_from_idx(&items.image_filter, s.get_image_filter_idx(), FilterType::Triangle),
+                geometric_invariance: StringComboBoxItems::value_from_idx(&items.image_geometric_invariance, s.get_geometric_invariance_idx(), GeometricInvariance::Off),
                 ignore_same_size: s.get_ignore_same_size(),
                 ignore_same_resolution: s.get_ignore_same_resolution(),
                 filters,

--- a/cedinia/src/scan_runner.rs
+++ b/cedinia/src/scan_runner.rs
@@ -9,7 +9,7 @@ use czkawka_core::common::progress_data::{CurrentStage, ProgressData as CoreProg
 use czkawka_core::common::tool_data::CommonData;
 use czkawka_core::re_exported::{FilterType, HashAlg};
 use czkawka_core::tools::big_file::SearchMode;
-use czkawka_core::tools::similar_images::SimilarityPreset;
+use czkawka_core::tools::similar_images::{GeometricInvariance, SimilarityPreset};
 
 use crate::flc;
 use crate::scanners::{
@@ -80,6 +80,7 @@ pub enum ScanRequest {
         hash_size: u8,
         hash_alg: HashAlg,
         image_filter: FilterType,
+        geometric_invariance: GeometricInvariance,
         ignore_same_size: bool,
         ignore_same_resolution: bool,
         filters: CommonFilters,
@@ -246,6 +247,7 @@ fn worker_loop<H: ScanResultHandler + Sync>(req_rx: &Receiver<ScanRequest>, hand
                 hash_size,
                 hash_alg,
                 image_filter,
+                geometric_invariance,
                 ignore_same_size,
                 ignore_same_resolution,
                 filters,
@@ -256,6 +258,7 @@ fn worker_loop<H: ScanResultHandler + Sync>(req_rx: &Receiver<ScanRequest>, hand
                     hash_size,
                     hash_alg,
                     image_filter,
+                    geometric_invariance,
                     ignore_same_size,
                     ignore_same_resolution,
                     &filters,

--- a/cedinia/src/scanners.rs
+++ b/cedinia/src/scanners.rs
@@ -186,6 +186,7 @@ pub(crate) fn scan_similar_images<H: ScanResultHandler>(
     hash_size: u8,
     hash_alg: czkawka_core::re_exported::HashAlg,
     image_filter: czkawka_core::re_exported::FilterType,
+    geometric_invariance: czkawka_core::tools::similar_images::GeometricInvariance,
     ignore_same_size: bool,
     ignore_same_resolution: bool,
     filters: &CommonFilters,
@@ -193,18 +194,10 @@ pub(crate) fn scan_similar_images<H: ScanResultHandler>(
     handler: &Arc<H>,
     scan_id: u32,
 ) -> Vec<FileItem> {
-    use czkawka_core::tools::similar_images::{GeometricInvariance, ImagesEntry, SimilarImages, SimilarImagesParameters, return_similarity_from_similarity_preset};
+    use czkawka_core::tools::similar_images::{ImagesEntry, SimilarImages, SimilarImagesParameters, return_similarity_from_similarity_preset};
     let max_diff = return_similarity_from_similarity_preset(similarity_preset, hash_size);
     let (ptx, fwd) = spawn_progress_forwarder(Arc::clone(handler), scan_id);
-    let params = SimilarImagesParameters::new(
-        max_diff,
-        hash_size,
-        hash_alg,
-        image_filter,
-        ignore_same_size,
-        ignore_same_resolution,
-        GeometricInvariance::Off,
-    );
+    let params = SimilarImagesParameters::new(max_diff, hash_size, hash_alg, image_filter, ignore_same_size, ignore_same_resolution, geometric_invariance);
     let mut tool = SimilarImages::new(params);
     tool.set_included_paths(dirs);
     apply_filters(&mut tool, filters);

--- a/cedinia/src/scanners.rs
+++ b/cedinia/src/scanners.rs
@@ -193,10 +193,18 @@ pub(crate) fn scan_similar_images<H: ScanResultHandler>(
     handler: &Arc<H>,
     scan_id: u32,
 ) -> Vec<FileItem> {
-    use czkawka_core::tools::similar_images::{ImagesEntry, SimilarImages, SimilarImagesParameters, return_similarity_from_similarity_preset};
+    use czkawka_core::tools::similar_images::{GeometricInvariance, ImagesEntry, SimilarImages, SimilarImagesParameters, return_similarity_from_similarity_preset};
     let max_diff = return_similarity_from_similarity_preset(similarity_preset, hash_size);
     let (ptx, fwd) = spawn_progress_forwarder(Arc::clone(handler), scan_id);
-    let params = SimilarImagesParameters::new(max_diff, hash_size, hash_alg, image_filter, ignore_same_size, ignore_same_resolution);
+    let params = SimilarImagesParameters::new(
+        max_diff,
+        hash_size,
+        hash_alg,
+        image_filter,
+        ignore_same_size,
+        ignore_same_resolution,
+        GeometricInvariance::Off,
+    );
     let mut tool = SimilarImages::new(params);
     tool.set_included_paths(dirs);
     apply_filters(&mut tool, filters);

--- a/cedinia/src/set_initial_gui_infos.rs
+++ b/cedinia/src/set_initial_gui_infos.rs
@@ -55,6 +55,11 @@ pub(crate) fn set_initial_gui_infos(app: &MainWindow) {
         display_names(&items.image_filter),
         "SimilarImagesSettings.image_filter_options out of sync with Rust"
     );
+    assert_eq!(
+        slint_vec(si.get_geometric_invariance_options()),
+        display_names(&items.image_geometric_invariance),
+        "SimilarImagesSettings.geometric_invariance_options out of sync with Rust"
+    );
 
     assert_eq!(
         slint_vec(bf.get_search_mode_options()),

--- a/cedinia/src/settings/gui_settings_values.rs
+++ b/cedinia/src/settings/gui_settings_values.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use czkawka_core::common::model::{CheckingMethod, HashType};
 use czkawka_core::re_exported::{FilterType, HashAlg};
 use czkawka_core::tools::big_file::SearchMode;
-use czkawka_core::tools::similar_images::SimilarityPreset;
+use czkawka_core::tools::similar_images::{GeometricInvariance, SimilarityPreset};
 use log::warn;
 
 pub enum DisplaySpec {
@@ -95,6 +95,7 @@ pub struct StringComboBoxItems {
     pub similarity_preset: Vec<StringComboBoxItem<SimilarityPreset>>,
     pub hash_alg: Vec<StringComboBoxItem<HashAlg>>,
     pub image_filter: Vec<StringComboBoxItem<FilterType>>,
+    pub image_geometric_invariance: Vec<StringComboBoxItem<GeometricInvariance>>,
     pub same_music_check_method: Vec<StringComboBoxItem<CheckingMethod>>,
     pub similar_videos_audio_preset: Vec<StringComboBoxItem<AudioPresetParams>>,
 }
@@ -171,6 +172,12 @@ impl StringComboBoxItems {
             ("lanczos3", "Lanczos3", FilterType::Lanczos3),
         ]);
 
+        let image_geometric_invariance = Self::convert(&[
+            ("off", "Off", GeometricInvariance::Off),
+            ("mirror_flip", "Mirror + Flip", GeometricInvariance::MirrorFlip),
+            ("mirror_flip_rotate90", "Mirror + Flip + Rotate 90", GeometricInvariance::MirrorFlipRotate90),
+        ]);
+
         let same_music_check_method = Self::convert_i18n(&[
             ("tags", CheckingMethod::AudioTags, DisplaySpec::Translatable("option_music_method_tags")),
             ("audio", CheckingMethod::AudioContent, DisplaySpec::Translatable("option_music_method_audio")),
@@ -221,6 +228,7 @@ impl StringComboBoxItems {
             similarity_preset,
             hash_alg,
             image_filter,
+            image_geometric_invariance,
             same_music_check_method,
             similar_videos_audio_preset,
         }
@@ -394,8 +402,16 @@ mod tests {
         assert!(!items.similarity_preset.is_empty());
         assert!(!items.hash_alg.is_empty());
         assert!(!items.image_filter.is_empty());
+        assert!(!items.image_geometric_invariance.is_empty());
         assert!(!items.same_music_check_method.is_empty());
         assert!(!items.similar_videos_audio_preset.is_empty());
+    }
+
+    #[test]
+    fn image_geometric_invariance_config_names_are_stable() {
+        let items = StringComboBoxItems::new();
+        let names: Vec<&str> = items.image_geometric_invariance.iter().map(|e| e.config_name.as_str()).collect();
+        assert_eq!(names, &["off", "mirror_flip", "mirror_flip_rotate90"]);
     }
 
     #[test]

--- a/cedinia/src/settings/mod.rs
+++ b/cedinia/src/settings/mod.rs
@@ -44,6 +44,9 @@ fn default_hash_alg() -> String {
 fn default_image_filter() -> String {
     "triangle".to_string()
 }
+fn default_geometric_invariance() -> String {
+    "off".to_string()
+}
 fn default_same_music_check_method() -> String {
     "tags".to_string()
 }
@@ -99,6 +102,8 @@ pub struct CediniaSettings {
     pub similar_images_hash_alg: String,
     #[serde(default = "default_image_filter")]
     pub similar_images_image_filter: String,
+    #[serde(default = "default_geometric_invariance")]
+    pub similar_images_geometric_invariance: String,
     #[serde(default)]
     pub similar_images_ignore_same_size: bool,
     #[serde(default)]
@@ -341,6 +346,11 @@ pub fn apply_settings_to_gui(win: &MainWindow, s: &CediniaSettings) {
     win.global::<SimilarImagesSettings>().set_image_filter_idx(if_idx as i32);
     win.global::<SimilarImagesSettings>().set_image_filter_value(s.similar_images_image_filter.clone().into());
 
+    let gi_idx = StringComboBoxItems::idx_from_config_name(&s.similar_images_geometric_invariance, &items.image_geometric_invariance);
+    win.global::<SimilarImagesSettings>().set_geometric_invariance_idx(gi_idx as i32);
+    win.global::<SimilarImagesSettings>()
+        .set_geometric_invariance_value(s.similar_images_geometric_invariance.clone().into());
+
     win.global::<SimilarImagesSettings>().set_ignore_same_size(s.similar_images_ignore_same_size);
     win.global::<SimilarImagesSettings>().set_ignore_same_resolution(s.similar_images_ignore_same_resolution);
     win.global::<SimilarImagesSettings>().set_gallery_image_fit_cover(s.gallery_image_fit_cover);
@@ -434,6 +444,10 @@ pub fn collect_settings_from_gui(win: &MainWindow) -> CediniaSettings {
             .image_filter
             .get(si.get_image_filter_idx() as usize)
             .map_or_else(|| panic!("Invalid image_filter_idx {} in GUI", si.get_image_filter_idx()), |e| e.config_name.clone()),
+        similar_images_geometric_invariance: items.image_geometric_invariance.get(si.get_geometric_invariance_idx() as usize).map_or_else(
+            || panic!("Invalid geometric_invariance_idx {} in GUI", si.get_geometric_invariance_idx()),
+            |e| e.config_name.clone(),
+        ),
         similar_images_ignore_same_size: si.get_ignore_same_size(),
         similar_images_ignore_same_resolution: si.get_ignore_same_resolution(),
         gallery_image_fit_cover: si.get_gallery_image_fit_cover(),

--- a/cedinia/src/translations.rs
+++ b/cedinia/src/translations.rs
@@ -118,6 +118,7 @@ pub(crate) fn translate_items(app: &MainWindow) {
     t.set_settings_hash_size_text(flc!("settings_hash_size").into());
     t.set_settings_hash_alg_text(flc!("settings_hash_alg").into());
     t.set_settings_image_filter_text(flc!("settings_image_filter").into());
+    t.set_settings_geometric_invariance_text(flc!("settings_geometric_invariance").into());
     t.set_settings_ignore_same_size_text(flc!("settings_ignore_same_size").into());
     t.set_settings_gallery_image_fit_cover_text(flc!("settings_gallery_image_fit_cover").into());
     t.set_settings_gallery_image_fit_cover_desc_text(flc!("settings_gallery_image_fit_cover_desc").into());

--- a/cedinia/ui/app_state.slint
+++ b/cedinia/ui/app_state.slint
@@ -52,6 +52,10 @@ export global SimilarImagesSettings {
     in-out property <string> image_filter_value:      "triangle";
     in-out property <[string]> image_filter_options:  ["Nearest", "Triangle", "CatmullRom", "Gaussian", "Lanczos3"];
 
+    in-out property <int>    geometric_invariance_idx:       0;
+    in-out property <string> geometric_invariance_value:     "off";
+    in-out property <[string]> geometric_invariance_options: ["Off", "Mirror + Flip", "Mirror + Flip + Rotate 90"];
+
     in-out property <bool>   ignore_same_size:        false;
     in-out property <bool>   ignore_same_resolution:  false;
     in-out property <bool>   gallery_image_fit_cover: true;

--- a/cedinia/ui/settings_screen.slint
+++ b/cedinia/ui/settings_screen.slint
@@ -374,6 +374,13 @@ export component SettingsScreen {
                     }
                     Divider {}
 
+                    SegmentRow {
+                        label: Translations.settings_geometric_invariance_text;
+                        options: SimilarImagesSettings.geometric_invariance_options;
+                        selected <=> SimilarImagesSettings.geometric_invariance_idx;
+                    }
+                    Divider {}
+
                     ToggleRow { label: Translations.settings_ignore_same_size_text; value <=> SimilarImagesSettings.ignore_same_size; }
                     Divider {}
 

--- a/cedinia/ui/translations.slint
+++ b/cedinia/ui/translations.slint
@@ -115,6 +115,7 @@ export global Translations {
     in-out property <string> settings_hash_size_text:         "Hash size";
     in-out property <string> settings_hash_alg_text:          "Hash algorithm";
     in-out property <string> settings_image_filter_text:      "Resize filter";
+    in-out property <string> settings_geometric_invariance_text: "Geometric invariance";
     in-out property <string> settings_ignore_same_size_text:  "Ignore images with the same dimensions";
     in-out property <string> settings_ignore_same_resolution_text: "Ignore images with the same resolution";
     in-out property <string> settings_gallery_image_fit_cover_text: "Gallery: crop to square";

--- a/czkawka_cli/src/commands.rs
+++ b/czkawka_cli/src/commands.rs
@@ -1408,18 +1408,6 @@ fn parse_geometric_invariance(src: &str) -> Result<GeometricInvariance, String> 
     Ok(geometric_invariance)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_parse_geometric_invariance() {
-        assert_eq!(parse_geometric_invariance("off"), Ok(GeometricInvariance::Off));
-        assert_eq!(parse_geometric_invariance("mirror-flip"), Ok(GeometricInvariance::MirrorFlip));
-        assert_eq!(parse_geometric_invariance("mirror-flip-rotate90"), Ok(GeometricInvariance::MirrorFlipRotate90));
-    }
-}
-
 fn parse_music_duplicate_type(src: &str) -> Result<MusicSimilarity, String> {
     if src.trim().is_empty() {
         return Ok(MusicSimilarity::NONE);
@@ -1495,3 +1483,15 @@ EXAMPLES:
     {bin} video-optimizer -d /home/rafal transcode -c h264 -f results.txt
     {bin} video-optimizer -d /home/rafal crop -m blackbars -f results.txt
     {bin} exif-remover -d /home/rafal -x IMAGE -f results.txt"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_geometric_invariance() {
+        assert_eq!(parse_geometric_invariance("off"), Ok(GeometricInvariance::Off));
+        assert_eq!(parse_geometric_invariance("mirror-flip"), Ok(GeometricInvariance::MirrorFlip));
+        assert_eq!(parse_geometric_invariance("mirror-flip-rotate90"), Ok(GeometricInvariance::MirrorFlipRotate90));
+    }
+}

--- a/czkawka_cli/src/commands.rs
+++ b/czkawka_cli/src/commands.rs
@@ -10,6 +10,7 @@ use czkawka_core::common::tool_data::DeleteMethod;
 use czkawka_core::re_exported::{Cropdetect, FilterType, HashAlg};
 use czkawka_core::tools::broken_files::CheckedTypes;
 use czkawka_core::tools::same_music::MusicSimilarity;
+use czkawka_core::tools::similar_images::GeometricInvariance;
 use czkawka_core::tools::similar_videos::{
     ALLOWED_AUDIO_LENGTH_RATIO, ALLOWED_AUDIO_SIMILARITY_PERCENT, ALLOWED_SKIP_FORWARD_AMOUNT, ALLOWED_VID_HASH_DURATION, DEFAULT_AUDIO_LENGTH_RATIO,
     DEFAULT_AUDIO_MAXIMUM_DIFFERENCE, DEFAULT_AUDIO_MIN_DURATION_SECONDS, DEFAULT_AUDIO_SIMILARITY_PERCENT, DEFAULT_SKIP_FORWARD_AMOUNT, DEFAULT_THUMBNAIL_GRID_TILES_PER_SIDE,
@@ -332,6 +333,14 @@ pub struct SimilarImagesArgs {
         long_help = "Size of the perceptual hash. Larger values provide more detailed comparison but require higher max_difference values. 8 is fastest and least detailed, 64 is slowest but most detailed. Recommended: 8 or 16 for typical use."
     )]
     pub hash_size: u8,
+    #[clap(
+        long,
+        default_value = "off",
+        value_parser = parse_geometric_invariance,
+        help = "Geometric invariance mode (off, mirror-flip, mirror-flip-rotate90)",
+        long_help = "Geometric invariance mode for similar image matching. off compares images as-is, mirror-flip also compares mirrored/flipped variants, mirror-flip-rotate90 also compares 90-degree rotations."
+    )]
+    pub geometric_invariance: GeometricInvariance,
 }
 
 #[derive(Debug, clap::Args)]
@@ -1387,6 +1396,28 @@ fn parse_image_hash_size(src: &str) -> Result<u8, String> {
         _ => return Err("Couldn't parse the image hash size (allowed: 8, 16, 32, 64)".to_string()),
     };
     Ok(hash_size)
+}
+
+fn parse_geometric_invariance(src: &str) -> Result<GeometricInvariance, String> {
+    let geometric_invariance = match src.to_lowercase().replace('_', "-").as_str() {
+        "off" => GeometricInvariance::Off,
+        "mirror-flip" => GeometricInvariance::MirrorFlip,
+        "mirror-flip-rotate90" => GeometricInvariance::MirrorFlipRotate90,
+        _ => return Err("Couldn't parse geometric invariance (allowed: off, mirror-flip, mirror-flip-rotate90)".to_string()),
+    };
+    Ok(geometric_invariance)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_geometric_invariance() {
+        assert_eq!(parse_geometric_invariance("off"), Ok(GeometricInvariance::Off));
+        assert_eq!(parse_geometric_invariance("mirror-flip"), Ok(GeometricInvariance::MirrorFlip));
+        assert_eq!(parse_geometric_invariance("mirror-flip-rotate90"), Ok(GeometricInvariance::MirrorFlipRotate90));
+    }
 }
 
 fn parse_music_duplicate_type(src: &str) -> Result<MusicSimilarity, String> {

--- a/czkawka_cli/src/main.rs
+++ b/czkawka_cli/src/main.rs
@@ -24,7 +24,7 @@ use czkawka_core::tools::empty_folder::EmptyFolder;
 use czkawka_core::tools::exif_remover::{ExifRemover, ExifRemoverParameters, ExifTagsFixerParams};
 use czkawka_core::tools::invalid_symlinks::InvalidSymlinks;
 use czkawka_core::tools::same_music::{SameMusic, SameMusicParameters};
-use czkawka_core::tools::similar_images::{GeometricInvariance, SimilarImages, SimilarImagesParameters};
+use czkawka_core::tools::similar_images::{SimilarImages, SimilarImagesParameters};
 use czkawka_core::tools::similar_videos::{SimilarVideos, SimilarVideosParameters};
 use czkawka_core::tools::temporary::{Temporary, TemporaryParameters};
 use czkawka_core::tools::video_optimizer::{
@@ -241,6 +241,7 @@ fn similar_images(similar_images: SimilarImagesArgs, stop_flag: &Arc<AtomicBool>
         hash_alg,
         image_filter,
         hash_size,
+        geometric_invariance,
         delete_method,
         allow_hard_links,
         ignore_same_size,
@@ -256,7 +257,7 @@ fn similar_images(similar_images: SimilarImagesArgs, stop_flag: &Arc<AtomicBool>
         image_filter,
         ignore_same_size.ignore_same_size,
         ignore_same_resolution.ignore_same_resolution,
-        GeometricInvariance::Off,
+        geometric_invariance,
     );
     let mut tool = SimilarImages::new(params);
 

--- a/czkawka_cli/src/main.rs
+++ b/czkawka_cli/src/main.rs
@@ -24,7 +24,7 @@ use czkawka_core::tools::empty_folder::EmptyFolder;
 use czkawka_core::tools::exif_remover::{ExifRemover, ExifRemoverParameters, ExifTagsFixerParams};
 use czkawka_core::tools::invalid_symlinks::InvalidSymlinks;
 use czkawka_core::tools::same_music::{SameMusic, SameMusicParameters};
-use czkawka_core::tools::similar_images::{SimilarImages, SimilarImagesParameters};
+use czkawka_core::tools::similar_images::{GeometricInvariance, SimilarImages, SimilarImagesParameters};
 use czkawka_core::tools::similar_videos::{SimilarVideos, SimilarVideosParameters};
 use czkawka_core::tools::temporary::{Temporary, TemporaryParameters};
 use czkawka_core::tools::video_optimizer::{
@@ -256,6 +256,7 @@ fn similar_images(similar_images: SimilarImagesArgs, stop_flag: &Arc<AtomicBool>
         image_filter,
         ignore_same_size.ignore_same_size,
         ignore_same_resolution.ignore_same_resolution,
+        GeometricInvariance::Off,
     );
     let mut tool = SimilarImages::new(params);
 

--- a/czkawka_core/src/common/cache.rs
+++ b/czkawka_core/src/common/cache.rs
@@ -26,7 +26,7 @@ use crate::helpers::messages::Messages;
 
 pub(crate) const CACHE_VERSION: u8 = 100;
 pub(crate) const CACHE_DUPLICATE_VERSION: u8 = 120;
-pub(crate) const CACHE_IMAGE_VERSION: u8 = 100;
+pub(crate) const CACHE_IMAGE_VERSION: u8 = 101;
 pub(crate) const CACHE_VIDEO_VERSION: u8 = 110;
 pub(crate) const CACHE_BROKEN_FILES_VERSION: u8 = 120;
 pub(crate) const CACHE_VIDEO_OPTIMIZE_VERSION: u8 = 110;

--- a/czkawka_core/src/common/dir_traversal.rs
+++ b/czkawka_core/src/common/dir_traversal.rs
@@ -987,12 +987,12 @@ mod tests {
     #[test]
     fn test_traversal_group_by_inode() -> io::Result<()> {
         let dir = tempfile::Builder::new().tempdir()?;
-        let dir_path = normalize_path(&dir.path());
+        let dir_path = normalize_path(dir.path());
         let (src, hard, other) = create_files(&dir_path)?;
         let secs = NOW.duration_since(SystemTime::UNIX_EPOCH).expect("Cannot fail duration from epoch").as_secs();
 
         let mut common_data = CommonToolData::new(ToolType::SimilarImages);
-        common_data.directories.set_included_paths([dir_path.to_owned()].to_vec());
+        common_data.directories.set_included_paths(vec![dir_path]);
         common_data.set_minimal_file_size(0);
 
         match DirTraversalBuilder::new()
@@ -1028,10 +1028,10 @@ mod tests {
                     actual
                 );
             }
-            _ => {
+            DirTraversalResult::Stopped => {
                 panic!("Expect SuccessFiles.");
             }
-        };
+        }
         Ok(())
     }
 }

--- a/czkawka_core/src/common/dir_traversal.rs
+++ b/czkawka_core/src/common/dir_traversal.rs
@@ -464,6 +464,7 @@ fn process_file_in_file_mode_path_check(
     }
 }
 
+#[cfg_attr(target_family = "windows", expect(clippy::needless_pass_by_ref_mut))]
 fn process_dir_in_file_symlink_mode(
     recursive_search: bool,
     entry_data: &DirEntry,

--- a/czkawka_core/src/common/process_utils.rs
+++ b/czkawka_core/src/common/process_utils.rs
@@ -8,7 +8,7 @@ use log::{error, warn};
 
 use crate::flc;
 
-#[expect(clippy::needless_pass_by_ref_mut)]
+#[cfg_attr(not(target_os = "windows"), expect(clippy::needless_pass_by_ref_mut))]
 pub fn disable_windows_console_window(command: &mut Command) {
     #[cfg(target_os = "windows")]
     {

--- a/czkawka_core/src/tools/duplicate/mod.rs
+++ b/czkawka_core/src/tools/duplicate/mod.rs
@@ -139,12 +139,10 @@ fn filter_hard_links(vec_file_entry: Vec<FileEntry>) -> Vec<FileEntry> {
     let mut inodes: IndexSet<u128> = IndexSet::with_capacity(vec_file_entry.len());
     let mut identical: Vec<FileEntry> = Vec::with_capacity(vec_file_entry.len());
     for f in vec_file_entry {
-        if let Ok(meta) = file_id::get_high_res_file_id(&f.path) {
-            if let file_id::FileId::HighRes { file_id, .. } = meta {
-                if !inodes.insert(file_id) {
-                    continue;
-                }
-            }
+        if let Ok(file_id::FileId::HighRes { file_id, .. }) = file_id::get_high_res_file_id(&f.path)
+            && !inodes.insert(file_id)
+        {
+            continue;
         }
         identical.push(f);
     }

--- a/czkawka_core/src/tools/similar_images/core.rs
+++ b/czkawka_core/src/tools/similar_images/core.rs
@@ -515,13 +515,10 @@ impl SimilarImages {
             return WorkContinueStatus::Stop;
         }
 
-        if self.get_params().geometric_invariance == GeometricInvariance::Off {
-            Self::verify_duplicated_items(&collected_similar_images);
-        }
-
         // Info about hashes is not needed anymore, so we drop this info
         self.similar_vectors = collected_similar_images.into_values().collect();
         self.merge_overlapping_groups();
+        Self::verify_duplicated_items(&self.similar_vectors);
 
         self.exclude_items_with_same_size();
         self.exclude_items_with_same_resolution();
@@ -629,8 +626,9 @@ impl SimilarImages {
 
         let mut merged: HashMap<usize, Vec<ImagesEntry>> = HashMap::new();
         for (id, entry) in entries_by_id.into_iter().enumerate() {
-            let root = dsu.find(id);
-            merged.entry(root).or_default().push(entry);
+            if let Some(root) = dsu.find(id) {
+                merged.entry(root).or_default().push(entry);
+            }
         }
 
         self.similar_vectors = merged.into_values().filter(|group| group.len() > 1).collect();
@@ -643,8 +641,7 @@ impl SimilarImages {
         }
     }
 
-    // TODO this probably not works good when reference folders are used
-    pub(crate) fn verify_duplicated_items(collected_similar_images: &IndexMap<ImHash, Vec<ImagesEntry>>) {
+    pub(crate) fn verify_duplicated_items(similar_vectors: &[Vec<ImagesEntry>]) {
         if !cfg!(debug_assertions) {
             return;
         }
@@ -652,7 +649,7 @@ impl SimilarImages {
         let mut result_hashset: IndexSet<String> = Default::default();
         let mut found = false;
 
-        for vec_file_entry in collected_similar_images.values() {
+        for vec_file_entry in similar_vectors {
             if vec_file_entry.is_empty() {
                 error!("Found empty group");
                 found = true;
@@ -690,30 +687,53 @@ impl DisjointSet {
         }
     }
 
-    fn find(&mut self, x: usize) -> usize {
-        let parent = *self.parent.get(x).expect("disjoint set parent index should be valid");
-        if parent != x {
-            let root = self.find(parent);
-            *self.parent.get_mut(x).expect("disjoint set parent index should be valid") = root;
-            return root;
+    fn find(&mut self, x: usize) -> Option<usize> {
+        let mut root = x;
+        loop {
+            let parent = self.parent.get(root).copied()?;
+            if parent == root {
+                break;
+            }
+            root = parent;
         }
-        x
+
+        let mut current = x;
+        while current != root {
+            let parent = self.parent.get(current).copied()?;
+            *self.parent.get_mut(current)? = root;
+            current = parent;
+        }
+
+        Some(root)
     }
 
     fn union(&mut self, a: usize, b: usize) {
-        let mut root_a = self.find(a);
-        let mut root_b = self.find(b);
+        let Some(mut root_a) = self.find(a) else {
+            return;
+        };
+        let Some(mut root_b) = self.find(b) else {
+            return;
+        };
         if root_a == root_b {
             return;
         }
-        let rank_a = *self.rank.get(root_a).expect("disjoint set rank index should be valid");
-        let rank_b = *self.rank.get(root_b).expect("disjoint set rank index should be valid");
+        let Some(rank_a) = self.rank.get(root_a).copied() else {
+            return;
+        };
+        let Some(rank_b) = self.rank.get(root_b).copied() else {
+            return;
+        };
         if rank_a < rank_b {
             std::mem::swap(&mut root_a, &mut root_b);
         }
-        *self.parent.get_mut(root_b).expect("disjoint set parent index should be valid") = root_a;
+        let Some(parent_b) = self.parent.get_mut(root_b) else {
+            return;
+        };
+        *parent_b = root_a;
         if rank_a == rank_b {
-            *self.rank.get_mut(root_a).expect("disjoint set rank index should be valid") = rank_a.saturating_add(1);
+            if let Some(rank_a_mut) = self.rank.get_mut(root_a) {
+                *rank_a_mut = rank_a.saturating_add(1);
+            }
         }
     }
 }
@@ -960,6 +980,64 @@ mod tests {
                 assert_eq!(second_group, vec![&fe1.path, &fe2.path]);
             }
         }
+    }
+
+    #[test]
+    fn test_merge_overlapping_groups_merges_transitive_matches_and_keeps_min_difference() {
+        let mut similar_images = SimilarImages::new(get_default_parameters());
+
+        let mut fe1 = create_random_file_entry(vec![1, 1, 1, 1, 1, 1, 1, 1], "abc.txt");
+        let mut fe2 = create_random_file_entry(vec![1, 1, 1, 1, 1, 1, 1, 2], "bcd.txt");
+        let mut fe2_again = fe2.clone();
+        let mut fe3 = create_random_file_entry(vec![1, 1, 1, 1, 1, 1, 1, 3], "cde.txt");
+        fe1.difference = 0;
+        fe2.difference = 7;
+        fe2_again.difference = 3;
+        fe3.difference = 4;
+
+        similar_images.similar_vectors = vec![vec![fe1, fe2], vec![fe2_again, fe3]];
+
+        similar_images.merge_overlapping_groups();
+
+        assert_eq!(similar_images.similar_vectors.len(), 1);
+        assert_eq!(similar_images.similar_vectors[0].len(), 3);
+
+        let mut paths = similar_images.similar_vectors[0]
+            .iter()
+            .map(|entry| entry.path.to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+        paths.sort();
+        assert_eq!(paths, vec!["abc.txt", "bcd.txt", "cde.txt"]);
+
+        let bcd = similar_images.similar_vectors[0]
+            .iter()
+            .find(|entry| entry.path == PathBuf::from("bcd.txt"))
+            .expect("bcd.txt should be present in merged group");
+        assert_eq!(bcd.difference, 3);
+    }
+
+    #[test]
+    fn test_verify_duplicated_items_accepts_valid_merged_overlaps() {
+        let fe1 = create_random_file_entry(vec![1, 1, 1, 1, 1, 1, 1, 1], "abc.txt");
+        let fe2 = create_random_file_entry(vec![1, 1, 1, 1, 1, 1, 1, 2], "bcd.txt");
+
+        SimilarImages::verify_duplicated_items(&[vec![fe1, fe2]]);
+    }
+
+    #[test]
+    #[should_panic(expected = "Found Invalid entries")]
+    fn test_verify_duplicated_items_rejects_duplicate_result_paths() {
+        let fe1 = create_random_file_entry(vec![1, 1, 1, 1, 1, 1, 1, 1], "abc.txt");
+        let fe1_again = create_random_file_entry(vec![1, 1, 1, 1, 1, 1, 1, 2], "abc.txt");
+
+        SimilarImages::verify_duplicated_items(&[vec![fe1], vec![fe1_again]]);
+    }
+
+    #[test]
+    fn test_similar_images_cache_file_uses_new_cache_version() {
+        let cache_file = get_similar_images_cache_file(8, HashAlg::Gradient, FilterType::Lanczos3, GeometricInvariance::Off);
+
+        assert!(cache_file.ends_with("_101.bin"));
     }
 
     #[test]

--- a/czkawka_core/src/tools/similar_images/core.rs
+++ b/czkawka_core/src/tools/similar_images/core.rs
@@ -1011,7 +1011,7 @@ mod tests {
 
         let bcd = similar_images.similar_vectors[0]
             .iter()
-            .find(|entry| entry.path == PathBuf::from("bcd.txt"))
+            .find(|entry| entry.path.as_path() == Path::new("bcd.txt"))
             .expect("bcd.txt should be present in merged group");
         assert_eq!(bcd.difference, 3);
     }

--- a/czkawka_core/src/tools/similar_images/core.rs
+++ b/czkawka_core/src/tools/similar_images/core.rs
@@ -730,10 +730,10 @@ impl DisjointSet {
             return;
         };
         *parent_b = root_a;
-        if rank_a == rank_b {
-            if let Some(rank_a_mut) = self.rank.get_mut(root_a) {
-                *rank_a_mut = rank_a.saturating_add(1);
-            }
+        if rank_a == rank_b
+            && let Some(rank_a_mut) = self.rank.get_mut(root_a)
+        {
+            *rank_a_mut = rank_a.saturating_add(1);
         }
     }
 }

--- a/czkawka_core/src/tools/similar_images/core.rs
+++ b/czkawka_core/src/tools/similar_images/core.rs
@@ -402,7 +402,9 @@ impl SimilarImages {
 
         progress_handler.join_thread();
 
-        debug_check_for_duplicated_things(self.common_data.use_reference_folders, &hashes_parents, &hashes_similarity, all_hashed_images, "LATTER");
+        if self.get_params().geometric_invariance == GeometricInvariance::Off {
+            debug_check_for_duplicated_things(self.common_data.use_reference_folders, &hashes_parents, &hashes_similarity, all_hashed_images, "LATTER");
+        }
         self.collect_hash_compare_result(hashes_parents, &hashes_with_multiple_images, all_hashed_images, collected_similar_images, hashes_similarity);
 
         WorkContinueStatus::Continue

--- a/czkawka_core/src/tools/similar_images/core.rs
+++ b/czkawka_core/src/tools/similar_images/core.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -21,7 +21,7 @@ use crate::common::progress_data::{CurrentStage, ProgressData};
 use crate::common::progress_stop_handler::{check_if_stop_received, prepare_thread_handler_common};
 use crate::common::tool_data::{CommonData, CommonToolData};
 use crate::flc;
-use crate::tools::similar_images::{Hamming, ImHash, ImagesEntry, SIMILAR_VALUES, SimilarImages, SimilarImagesParameters, SimilarityPreset};
+use crate::tools::similar_images::{GeometricInvariance, Hamming, ImHash, ImagesEntry, SIMILAR_VALUES, SimilarImages, SimilarImagesParameters, SimilarityPreset};
 
 impl SimilarImages {
     pub fn new(params: SimilarImagesParameters) -> Self {
@@ -97,7 +97,12 @@ impl SimilarImages {
     #[fun_time(message = "hash_images_load_cache", level = "debug")]
     fn hash_images_load_cache(&mut self) -> (BTreeMap<String, ImagesEntry>, BTreeMap<String, ImagesEntry>, BTreeMap<String, ImagesEntry>) {
         load_and_split_cache_generalized_by_path(
-            &get_similar_images_cache_file(self.get_params().hash_size, self.get_params().hash_alg, self.get_params().image_filter),
+            &get_similar_images_cache_file(
+                self.get_params().hash_size,
+                self.get_params().hash_alg,
+                self.get_params().image_filter,
+                self.get_params().geometric_invariance,
+            ),
             mem::take(&mut self.images_to_check),
             self,
         )
@@ -106,7 +111,12 @@ impl SimilarImages {
     #[fun_time(message = "save_to_cache", level = "debug")]
     fn save_to_cache(&mut self, vec_file_entry: &[ImagesEntry], loaded_hash_map: BTreeMap<String, ImagesEntry>) {
         save_and_connect_cache_generalized_by_path(
-            &get_similar_images_cache_file(self.get_params().hash_size, self.get_params().hash_alg, self.get_params().image_filter),
+            &get_similar_images_cache_file(
+                self.get_params().hash_size,
+                self.get_params().hash_alg,
+                self.get_params().image_filter,
+                self.get_params().geometric_invariance,
+            ),
             vec_file_entry,
             loaded_hash_map,
             self,
@@ -160,10 +170,7 @@ impl SimilarImages {
 
         // All valid entries are used to create bktree used to check for hash similarity
         for file_entry in vec_file_entry {
-            // Only use to comparing, non broken hashes(all 0 or 255 hashes means that algorithm fails to decode them because e.g. contains a lot of alpha channel)
-            if !(file_entry.hash.is_empty() || file_entry.hash.iter().all(|e| *e == 0) || file_entry.hash.iter().all(|e| *e == 255)) {
-                self.image_hashes.entry(file_entry.hash.clone()).or_default().push(file_entry);
-            }
+            self.add_hashes_to_map(file_entry);
         }
 
         // Break if stop was clicked after saving to cache
@@ -187,10 +194,65 @@ impl SimilarImages {
             .hash_alg(self.get_params().hash_alg)
             .resize_filter(self.get_params().image_filter);
         let hasher = hasher_config.to_hasher();
-        let hash = hasher.hash_image(&img);
-        file_entry.hash = hash.as_bytes().to_vec();
+        file_entry.hashes = self.compute_hashes_for_image(&img, &hasher);
 
         Ok(file_entry)
+    }
+
+    fn add_hashes_to_map(&mut self, mut file_entry: ImagesEntry) {
+        let hashes = mem::take(&mut file_entry.hashes);
+        if hashes.is_empty() {
+            return;
+        }
+        let entry_for_map = ImagesEntry { hashes: Vec::new(), ..file_entry };
+
+        for hash in hashes {
+            if !Self::is_hash_valid(&hash) {
+                continue;
+            }
+            let vec_entry = self.image_hashes.entry(hash).or_default();
+            if vec_entry.iter().any(|entry| entry.path == entry_for_map.path) {
+                continue;
+            }
+            vec_entry.push(entry_for_map.clone());
+        }
+    }
+
+    fn compute_hashes_for_image(&self, image: &image::DynamicImage, hasher: &image_hasher::Hasher) -> Vec<ImHash> {
+        let mut hashes: BTreeSet<ImHash> = BTreeSet::new();
+        let mut push_hash = |img: &image::DynamicImage| {
+            let hash = hasher.hash_image(img);
+            hashes.insert(hash.as_bytes().to_vec());
+        };
+
+        push_hash(image);
+
+        match self.get_params().geometric_invariance {
+            GeometricInvariance::Off => {}
+            GeometricInvariance::MirrorFlip => {
+                push_hash(&image.fliph());
+                push_hash(&image.flipv());
+            }
+            GeometricInvariance::MirrorFlipRotate90 => {
+                let flipped = image.fliph();
+                let flipped_rotate90 = flipped.rotate90();
+                let flipped_rotate270 = flipped.rotate270();
+
+                push_hash(&flipped);
+                push_hash(&image.flipv());
+                push_hash(&image.rotate90());
+                push_hash(&image.rotate180());
+                push_hash(&image.rotate270());
+                push_hash(&flipped_rotate90);
+                push_hash(&flipped_rotate270);
+            }
+        }
+
+        hashes.into_iter().collect()
+    }
+
+    fn is_hash_valid(hash: &ImHash) -> bool {
+        !(hash.is_empty() || hash.iter().all(|e| *e == 0) || hash.iter().all(|e| *e == 255))
     }
 
     // Split hashes at 2 parts, base hashes and hashes to compare, 3 argument is set of hashes with multiple images
@@ -453,10 +515,13 @@ impl SimilarImages {
             return WorkContinueStatus::Stop;
         }
 
-        Self::verify_duplicated_items(&collected_similar_images);
+        if self.get_params().geometric_invariance == GeometricInvariance::Off {
+            Self::verify_duplicated_items(&collected_similar_images);
+        }
 
         // Info about hashes is not needed anymore, so we drop this info
         self.similar_vectors = collected_similar_images.into_values().collect();
+        self.merge_overlapping_groups();
 
         self.exclude_items_with_same_size();
         self.exclude_items_with_same_resolution();
@@ -519,6 +584,58 @@ impl SimilarImages {
         }
     }
 
+    fn merge_overlapping_groups(&mut self) {
+        let groups = mem::take(&mut self.similar_vectors);
+        if groups.is_empty() {
+            return;
+        }
+
+        let mut path_to_id: HashMap<String, usize> = HashMap::new();
+        let mut entries_by_id: Vec<ImagesEntry> = Vec::new();
+
+        for group in &groups {
+            for entry in group {
+                let key = entry.path.to_string_lossy().to_string();
+                if let Some(id) = path_to_id.get(&key).copied() {
+                    if let Some(existing_entry) = entries_by_id.get_mut(id) {
+                        existing_entry.difference = existing_entry.difference.min(entry.difference);
+                    }
+                } else {
+                    let id = entries_by_id.len();
+                    path_to_id.insert(key, id);
+                    entries_by_id.push(entry.clone());
+                }
+            }
+        }
+
+        let mut dsu = DisjointSet::new(entries_by_id.len());
+        for group in groups {
+            let mut ids = group
+                .iter()
+                .filter_map(|entry| path_to_id.get(entry.path.to_string_lossy().as_ref()).copied())
+                .collect::<Vec<_>>();
+            ids.sort_unstable();
+            ids.dedup();
+            if ids.len() < 2 {
+                continue;
+            }
+            let Some((&base, remaining_ids)) = ids.split_first() else {
+                continue;
+            };
+            for id in remaining_ids {
+                dsu.union(base, *id);
+            }
+        }
+
+        let mut merged: HashMap<usize, Vec<ImagesEntry>> = HashMap::new();
+        for (id, entry) in entries_by_id.into_iter().enumerate() {
+            let root = dsu.find(id);
+            merged.entry(root).or_default().push(entry);
+        }
+
+        self.similar_vectors = merged.into_values().filter(|group| group.len() > 1).collect();
+    }
+
     #[fun_time(message = "remove_multiple_records_from_reference_folders", level = "debug")]
     fn remove_multiple_records_from_reference_folders(&mut self) {
         if self.common_data.use_reference_folders {
@@ -557,6 +674,47 @@ impl SimilarImages {
             }
         }
         assert!(!found, "Found Invalid entries, verify errors before");
+    }
+}
+
+struct DisjointSet {
+    parent: Vec<usize>,
+    rank: Vec<u8>,
+}
+
+impl DisjointSet {
+    fn new(size: usize) -> Self {
+        Self {
+            parent: (0..size).collect(),
+            rank: vec![0; size],
+        }
+    }
+
+    fn find(&mut self, x: usize) -> usize {
+        let parent = *self.parent.get(x).expect("disjoint set parent index should be valid");
+        if parent != x {
+            let root = self.find(parent);
+            *self.parent.get_mut(x).expect("disjoint set parent index should be valid") = root;
+            return root;
+        }
+        x
+    }
+
+    fn union(&mut self, a: usize, b: usize) {
+        let mut root_a = self.find(a);
+        let mut root_b = self.find(b);
+        if root_a == root_b {
+            return;
+        }
+        let rank_a = *self.rank.get(root_a).expect("disjoint set rank index should be valid");
+        let rank_b = *self.rank.get(root_b).expect("disjoint set rank index should be valid");
+        if rank_a < rank_b {
+            std::mem::swap(&mut root_a, &mut root_b);
+        }
+        *self.parent.get_mut(root_b).expect("disjoint set parent index should be valid") = root_a;
+        if rank_a == rank_b {
+            *self.rank.get_mut(root_a).expect("disjoint set rank index should be valid") = rank_a.saturating_add(1);
+        }
     }
 }
 
@@ -701,11 +859,13 @@ fn debug_check_for_duplicated_things(
     assert!(!found_broken_thing);
 }
 
-pub fn get_similar_images_cache_file(hash_size: u8, hash_alg: HashAlg, image_filter: FilterType) -> String {
+pub fn get_similar_images_cache_file(hash_size: u8, hash_alg: HashAlg, image_filter: FilterType, geometric_invariance: GeometricInvariance) -> String {
     format!(
-        "cache_similar_images_{hash_size}_{}_{}_{CACHE_IMAGE_VERSION}.bin",
+        "cache_similar_images_{hash_size}_{}_{}_{}_{}.bin",
         convert_algorithm_to_string(hash_alg),
         convert_filters_to_string(image_filter),
+        geometric_invariance.as_cache_tag(),
+        CACHE_IMAGE_VERSION,
     )
 }
 
@@ -720,7 +880,7 @@ mod tests {
 
     use super::*;
     use crate::common::tool_data::CommonData;
-    use crate::tools::similar_images::{Hamming, ImHash, ImagesEntry, SimilarImages, SimilarImagesParameters};
+    use crate::tools::similar_images::{GeometricInvariance, Hamming, ImHash, ImagesEntry, SimilarImages, SimilarImagesParameters};
 
     fn get_default_parameters() -> SimilarImagesParameters {
         SimilarImagesParameters {
@@ -730,6 +890,7 @@ mod tests {
             image_filter: FilterType::Lanczos3,
             exclude_images_with_same_size: false,
             exclude_images_with_same_resolution: false,
+            geometric_invariance: GeometricInvariance::Off,
         }
     }
 
@@ -791,7 +952,7 @@ mod tests {
             let first_group = similar_images.get_similar_images()[0].iter().map(|e| &e.path).collect::<Vec<_>>();
             let second_group = similar_images.get_similar_images()[1].iter().map(|e| &e.path).collect::<Vec<_>>();
             // Initial order is not guaranteed, so we need to check both options
-            if similar_images.get_similar_images()[0][0].hash == fe1.hash {
+            if first_group.contains(&&fe1.path) {
                 assert_eq!(first_group, vec![&fe1.path, &fe2.path]);
                 assert_eq!(second_group, vec![&fe3.path, &fe4.path, &fe5.path]);
             } else {
@@ -1149,7 +1310,9 @@ mod tests {
 
     fn add_hashes(hashmap: &mut IndexMap<ImHash, Vec<ImagesEntry>>, file_entries: Vec<ImagesEntry>) {
         for fe in file_entries {
-            hashmap.entry(fe.hash.clone()).or_default().push(fe);
+            for hash in &fe.hashes {
+                hashmap.entry(hash.clone()).or_default().push(fe.clone());
+            }
         }
     }
 
@@ -1160,7 +1323,7 @@ mod tests {
             width: 100,
             height: 100,
             modified_date: 0,
-            hash,
+            hashes: vec![hash],
             difference: 0,
         }
     }
@@ -1175,7 +1338,7 @@ mod connect_results_tests {
 
     #[test]
     fn test_connect_results_real_case() {
-        let params = SimilarImagesParameters::new(10, 8, HashAlg::Gradient, FilterType::Lanczos3, false, false);
+        let params = SimilarImagesParameters::new(10, 8, HashAlg::Gradient, FilterType::Lanczos3, false, false, GeometricInvariance::Off);
         let _finder = SimilarImages::new(params);
 
         let hash1: ImHash = vec![59, 41, 53, 27, 19, 143, 228, 228];

--- a/czkawka_core/src/tools/similar_images/mod.rs
+++ b/czkawka_core/src/tools/similar_images/mod.rs
@@ -37,7 +37,7 @@ pub struct ImagesEntry {
     pub width: u32,
     pub height: u32,
     pub modified_date: u64,
-    pub hash: ImHash,
+    pub hashes: Vec<ImHash>,
     pub difference: u32,
 }
 
@@ -61,8 +61,25 @@ impl FileEntry {
 
             width: 0,
             height: 0,
-            hash: Vec::new(),
+            hashes: Vec::new(),
             difference: 0,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum GeometricInvariance {
+    Off,
+    MirrorFlip,
+    MirrorFlipRotate90,
+}
+
+impl GeometricInvariance {
+    pub const fn as_cache_tag(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::MirrorFlip => "mirror_flip",
+            Self::MirrorFlipRotate90 => "mirror_flip_rotate90",
         }
     }
 }
@@ -99,6 +116,7 @@ pub struct SimilarImagesParameters {
     pub image_filter: FilterType,
     pub exclude_images_with_same_size: bool,
     pub exclude_images_with_same_resolution: bool,
+    pub geometric_invariance: GeometricInvariance,
 }
 
 impl SimilarImagesParameters {
@@ -109,6 +127,7 @@ impl SimilarImagesParameters {
         image_filter: FilterType,
         exclude_images_with_same_size: bool,
         exclude_images_with_same_resolution: bool,
+        geometric_invariance: GeometricInvariance,
     ) -> Self {
         assert!([8, 16, 32, 64].contains(&hash_size));
         Self {
@@ -118,6 +137,7 @@ impl SimilarImagesParameters {
             image_filter,
             exclude_images_with_same_size,
             exclude_images_with_same_resolution,
+            geometric_invariance,
         }
     }
 }

--- a/czkawka_core/src/tools/similar_images/tests.rs
+++ b/czkawka_core/src/tools/similar_images/tests.rs
@@ -1,12 +1,14 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 
+use image::{DynamicImage, ImageBuffer, Rgba};
 use image_hasher::{FilterType, HashAlg};
+use tempfile::TempDir;
 
 use crate::common::tool_data::CommonData;
 use crate::common::traits::Search;
-use crate::tools::similar_images::{SimilarImages, SimilarImagesParameters};
+use crate::tools::similar_images::{GeometricInvariance, SimilarImages, SimilarImagesParameters};
 
 fn get_test_resources_path() -> PathBuf {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test_resources").join("images");
@@ -14,6 +16,19 @@ fn get_test_resources_path() -> PathBuf {
     assert!(path.exists(), "Test resources not found at \"{}\"", path.to_string_lossy());
 
     path
+}
+
+fn create_asymmetric_test_image(path: &Path) -> DynamicImage {
+    let mut img = ImageBuffer::from_pixel(32, 24, Rgba([0_u8, 0_u8, 0_u8, 255_u8]));
+    for x in 0..32 {
+        img.put_pixel(x, 0, Rgba([255_u8, 0_u8, 0_u8, 255_u8]));
+    }
+    img.put_pixel(5, 10, Rgba([0_u8, 255_u8, 0_u8, 255_u8]));
+    img.put_pixel(20, 18, Rgba([0_u8, 0_u8, 255_u8, 255_u8]));
+
+    let dynamic = DynamicImage::ImageRgba8(img);
+    dynamic.save(path).expect("Failed to save base test image");
+    dynamic
 }
 
 #[test]
@@ -42,7 +57,7 @@ fn test_similar_images() {
     ];
 
     for (idx, (hash_alg, filter_type, hash_size, similarity, duplicates, groups, all_in_similar)) in algo_filter_hash_sim_found.into_iter().enumerate() {
-        let params = SimilarImagesParameters::new(similarity, hash_size, hash_alg, filter_type, false, false);
+        let params = SimilarImagesParameters::new(similarity, hash_size, hash_alg, filter_type, false, false, GeometricInvariance::Off);
 
         let mut finder = SimilarImages::new(params);
         finder.set_included_paths(vec![test_path.clone()]);
@@ -69,7 +84,7 @@ fn test_similar_images() {
 fn test_similar_images_exclude_same_size() {
     let test_path = get_test_resources_path();
 
-    let params = SimilarImagesParameters::new(10, 8, HashAlg::Gradient, FilterType::Lanczos3, true, false);
+    let params = SimilarImagesParameters::new(10, 8, HashAlg::Gradient, FilterType::Lanczos3, true, false, GeometricInvariance::Off);
 
     let mut finder = SimilarImages::new(params);
     finder.set_included_paths(vec![test_path]);
@@ -94,12 +109,10 @@ fn test_similar_images_exclude_same_size() {
 
 #[test]
 fn test_similar_images_empty_directory() {
-    use tempfile::TempDir;
-
     let temp_dir = TempDir::new().unwrap();
     let path = temp_dir.path();
 
-    let params = SimilarImagesParameters::new(10, 8, HashAlg::Gradient, FilterType::Lanczos3, false, false);
+    let params = SimilarImagesParameters::new(10, 8, HashAlg::Gradient, FilterType::Lanczos3, false, false, GeometricInvariance::Off);
 
     let mut finder = SimilarImages::new(params);
     finder.set_included_paths(vec![path.to_path_buf()]);
@@ -115,4 +128,58 @@ fn test_similar_images_empty_directory() {
     assert_eq!(info.number_of_duplicates, 0);
     assert_eq!(info.number_of_groups, 0);
     assert_eq!(similar_images.len(), 0);
+}
+
+#[test]
+fn test_similar_images_mirror_flip_invariance() {
+    let temp_dir = TempDir::new().unwrap();
+    let base_path = temp_dir.path().join("base.png");
+    let flipped_path = temp_dir.path().join("flipped.png");
+
+    let base = create_asymmetric_test_image(&base_path);
+    base.fliph().save(&flipped_path).expect("Failed to save flipped image");
+
+    let params = SimilarImagesParameters::new(0, 8, HashAlg::Gradient, FilterType::Lanczos3, false, false, GeometricInvariance::MirrorFlip);
+    let mut finder = SimilarImages::new(params);
+    finder.set_included_paths(vec![temp_dir.path().to_path_buf()]);
+    finder.set_recursive_search(true);
+    finder.set_use_cache(false);
+
+    let stop_flag = Arc::new(AtomicBool::new(false));
+    finder.search(&stop_flag, None);
+
+    let info = finder.get_information();
+    let similar_images = finder.get_similar_images();
+
+    assert_eq!(info.number_of_groups, 1);
+    assert_eq!(info.number_of_duplicates, 1);
+    assert_eq!(similar_images.len(), 1);
+    assert_eq!(similar_images[0].len(), 2);
+}
+
+#[test]
+fn test_similar_images_rotate_invariance() {
+    let temp_dir = TempDir::new().unwrap();
+    let base_path = temp_dir.path().join("base.png");
+    let rotated_path = temp_dir.path().join("rotated.png");
+
+    let base = create_asymmetric_test_image(&base_path);
+    base.rotate90().save(&rotated_path).expect("Failed to save rotated image");
+
+    let params = SimilarImagesParameters::new(0, 8, HashAlg::Gradient, FilterType::Lanczos3, false, false, GeometricInvariance::MirrorFlipRotate90);
+    let mut finder = SimilarImages::new(params);
+    finder.set_included_paths(vec![temp_dir.path().to_path_buf()]);
+    finder.set_recursive_search(true);
+    finder.set_use_cache(false);
+
+    let stop_flag = Arc::new(AtomicBool::new(false));
+    finder.search(&stop_flag, None);
+
+    let info = finder.get_information();
+    let similar_images = finder.get_similar_images();
+
+    assert_eq!(info.number_of_groups, 1);
+    assert_eq!(info.number_of_duplicates, 1);
+    assert_eq!(similar_images.len(), 1);
+    assert_eq!(similar_images[0].len(), 2);
 }

--- a/czkawka_core/src/tools/temporary/core.rs
+++ b/czkawka_core/src/tools/temporary/core.rs
@@ -129,6 +129,7 @@ impl Temporary {
     }
 }
 
+#[cfg_attr(target_family = "windows", expect(clippy::needless_pass_by_ref_mut))]
 pub(crate) fn check_folder_children(
     dir_result: &mut Vec<PathBuf>,
     warnings: &mut Vec<String>,

--- a/czkawka_gui/i18n/en/czkawka_gui.ftl
+++ b/czkawka_gui/i18n/en/czkawka_gui.ftl
@@ -110,6 +110,9 @@ image_hash_alg_tooltip =
 
         So, to determine the best one for you, manual testing is required.
 
+image_geometric_invariance_tooltip =
+        Also compare mirrored/flipped and optionally rotated variants of each image. This improves matching but increases hashing time.
+
 big_files_mode_combobox_tooltip = Allows to search for smallest/biggest files
 big_files_mode_label = Checked files
 big_files_mode_smallest_combo_box = The Smallest
@@ -152,6 +155,7 @@ main_tree_view_column_codec = Codec
 main_label_check_method = Check method
 main_label_hash_type = Hash type
 main_label_hash_size = Hash size
+main_label_geometric_invariance = Geometric invariance
 main_label_size_bytes = Size (bytes)
 main_label_min_size = Min
 main_label_max_size = Max

--- a/czkawka_gui/src/connect_things/connect_button_search.rs
+++ b/czkawka_gui/src/connect_things/connect_button_search.rs
@@ -28,8 +28,8 @@ use crate::gui_structs::common_tree_view::TreeViewListStoreTrait;
 use crate::gui_structs::common_upper_tree_view::UpperTreeViewEnum;
 use crate::gui_structs::gui_data::GuiData;
 use crate::help_combo_box::{
-    AUDIO_TYPE_CHECK_METHOD_COMBO_BOX, BIG_FILES_CHECK_METHOD_COMBO_BOX, DUPLICATES_CHECK_METHOD_COMBO_BOX, DUPLICATES_HASH_TYPE_COMBO_BOX, IMAGES_HASH_SIZE_COMBO_BOX,
-    IMAGES_HASH_TYPE_COMBO_BOX, IMAGES_RESIZE_ALGORITHM_COMBO_BOX,
+    AUDIO_TYPE_CHECK_METHOD_COMBO_BOX, BIG_FILES_CHECK_METHOD_COMBO_BOX, DUPLICATES_CHECK_METHOD_COMBO_BOX, DUPLICATES_HASH_TYPE_COMBO_BOX, IMAGES_GEOMETRIC_INVARIANCE_COMBO_BOX,
+    IMAGES_HASH_SIZE_COMBO_BOX, IMAGES_HASH_TYPE_COMBO_BOX, IMAGES_RESIZE_ALGORITHM_COMBO_BOX,
 };
 use crate::help_functions::{get_path_buf_from_vector_of_strings, hide_all_buttons, reset_text_view, set_buttons};
 use crate::helpers::enums::{ColumnsExcludedDirectory, ColumnsIncludedDirectory, Message};
@@ -570,6 +570,7 @@ fn similar_image_search(
     let combo_box_image_hash_size = gui_data.main_notebook.combo_box_image_hash_size.clone();
     let combo_box_image_hash_algorithm = gui_data.main_notebook.combo_box_image_hash_algorithm.clone();
     let combo_box_image_resize_algorithm = gui_data.main_notebook.combo_box_image_resize_algorithm.clone();
+    let combo_box_image_geometric_invariance = gui_data.main_notebook.combo_box_image_geometric_invariance.clone();
     let check_button_image_ignore_same_size = gui_data.main_notebook.check_button_image_ignore_same_size.clone();
     let check_button_settings_similar_images_delete_outdated_cache = gui_data.settings.check_button_settings_similar_images_delete_outdated_cache.clone();
     let image_preview_similar_images = gui_data.main_notebook.image_preview_similar_images.clone();
@@ -587,6 +588,9 @@ fn similar_image_search(
     let hash_alg_index = combo_box_image_hash_algorithm.active().expect("Failed to get active search") as usize;
     let hash_alg = IMAGES_HASH_TYPE_COMBO_BOX[hash_alg_index].hash_alg;
 
+    let geometric_invariance_index = combo_box_image_geometric_invariance.active().expect("Failed to get active search") as usize;
+    let geometric_invariance = IMAGES_GEOMETRIC_INVARIANCE_COMBO_BOX[geometric_invariance_index].invariance;
+
     let ignore_same_size = check_button_image_ignore_same_size.is_active();
 
     let similarity = scale_similarity_similar_images.value() as u32;
@@ -603,6 +607,7 @@ fn similar_image_search(
                 image_filter,
                 ignore_same_size,
                 false, // Not implemented in gtk gui
+                geometric_invariance,
             );
             let mut tool = SimilarImages::new(params);
 

--- a/czkawka_gui/src/connect_things/connect_settings.rs
+++ b/czkawka_gui/src/connect_things/connect_settings.rs
@@ -8,6 +8,7 @@ use czkawka_core::helpers::messages::{MessageLimit, Messages};
 use czkawka_core::re_exported::HashAlg;
 use czkawka_core::tools::duplicate::DuplicateEntry;
 use czkawka_core::tools::duplicate::core::get_duplicate_cache_file;
+use czkawka_core::tools::similar_images::GeometricInvariance;
 use czkawka_core::tools::similar_images::core::get_similar_images_cache_file;
 use czkawka_core::tools::similar_videos::core::get_similar_videos_cache_file;
 use czkawka_core::tools::similar_videos::{DEFAULT_CROP_DETECT, DEFAULT_SKIP_FORWARD_AMOUNT, DEFAULT_VID_HASH_DURATION};
@@ -183,13 +184,16 @@ pub(crate) fn connect_settings(gui_data: &GuiData) {
                                     HashAlg::Mean,
                                     HashAlg::Median,
                                 ] {
-                                    let file_name = get_similar_images_cache_file(hash_size, hash_alg, image_filter);
-                                    let (mut messages, loaded_items) =
-                                        load_cache_from_file_generalized_by_path::<czkawka_core::tools::similar_images::ImagesEntry>(&file_name, true, &Default::default());
+                                    for geometric_invariance in [GeometricInvariance::Off, GeometricInvariance::MirrorFlip, GeometricInvariance::MirrorFlipRotate90] {
+                                        let file_name = get_similar_images_cache_file(hash_size, hash_alg, image_filter, geometric_invariance);
+                                        let (mut cache_messages, loaded_items) =
+                                            load_cache_from_file_generalized_by_path::<czkawka_core::tools::similar_images::ImagesEntry>(&file_name, true, &Default::default());
 
-                                    if let Some(cache_entries) = loaded_items {
-                                        let save_messages = save_cache_to_file_generalized(&file_name, &cache_entries, false, 0);
-                                        messages.extend_with_another_messages(save_messages);
+                                        if let Some(cache_entries) = loaded_items {
+                                            let save_messages = save_cache_to_file_generalized(&file_name, &cache_entries, false, 0);
+                                            cache_messages.extend_with_another_messages(save_messages);
+                                        }
+                                        messages.extend_with_another_messages(cache_messages);
                                     }
                                 }
                             }

--- a/czkawka_gui/src/gui_structs/gui_main_notebook.rs
+++ b/czkawka_gui/src/gui_structs/gui_main_notebook.rs
@@ -46,10 +46,12 @@ pub struct GuiMainNotebook {
     pub label_image_resize_algorithm: Label,
     pub label_image_hash_type: Label,
     pub label_image_hash_size: Label,
+    pub label_image_geometric_invariance: Label,
 
     pub combo_box_image_resize_algorithm: ComboBoxText,
     pub combo_box_image_hash_algorithm: ComboBoxText,
     pub combo_box_image_hash_size: ComboBoxText,
+    pub combo_box_image_geometric_invariance: ComboBoxText,
 
     pub check_button_image_ignore_same_size: CheckButton,
     pub check_button_video_ignore_same_size: CheckButton,
@@ -126,6 +128,7 @@ impl GuiMainNotebook {
         let combo_box_image_resize_algorithm: ComboBoxText = builder.object("combo_box_image_resize_algorithm").expect("Cambalache");
         let combo_box_image_hash_algorithm: ComboBoxText = builder.object("combo_box_image_hash_algorithm").expect("Cambalache");
         let combo_box_image_hash_size: ComboBoxText = builder.object("combo_box_image_hash_size").expect("Cambalache");
+        let combo_box_image_geometric_invariance: ComboBoxText = builder.object("combo_box_image_geometric_invariance").expect("Cambalache");
         let combo_box_big_files_mode: ComboBoxText = builder.object("combo_box_big_files_mode").expect("Cambalache");
 
         let check_button_image_ignore_same_size: CheckButton = builder.object("check_button_image_ignore_same_size").expect("Cambalache");
@@ -139,6 +142,7 @@ impl GuiMainNotebook {
         let label_image_resize_algorithm: Label = builder.object("label_image_resize_algorithm").expect("Cambalache");
         let label_image_hash_type: Label = builder.object("label_image_hash_type").expect("Cambalache");
         let label_image_hash_size: Label = builder.object("label_image_hash_size").expect("Cambalache");
+        let label_image_geometric_invariance: Label = builder.object("label_image_geometric_invariance").expect("Cambalache");
         let label_image_similarity: Label = builder.object("label_image_similarity").expect("Cambalache");
         let label_image_similarity_max: Label = builder.object("label_image_similarity_max").expect("Cambalache");
         let label_video_similarity: Label = builder.object("label_video_similarity").expect("Cambalache");
@@ -195,9 +199,11 @@ impl GuiMainNotebook {
             label_image_resize_algorithm,
             label_image_hash_type,
             label_image_hash_size,
+            label_image_geometric_invariance,
             combo_box_image_resize_algorithm,
             combo_box_image_hash_algorithm,
             combo_box_image_hash_size,
+            combo_box_image_geometric_invariance,
             check_button_image_ignore_same_size,
             check_button_video_ignore_same_size,
             label_image_similarity,
@@ -256,6 +262,7 @@ impl GuiMainNotebook {
         self.label_image_resize_algorithm.set_label(&flg!("main_label_resize_algorithm"));
         self.label_image_hash_type.set_label(&flg!("main_label_hash_type"));
         self.label_image_hash_size.set_label(&flg!("main_label_hash_size"));
+        self.label_image_geometric_invariance.set_label(&flg!("main_label_geometric_invariance"));
         self.label_image_similarity.set_label(&flg!("main_label_similarity"));
         self.label_image_similarity_max.set_label(&fnc_get_similarity_very_high());
         self.label_video_similarity.set_label(&flg!("main_label_similarity"));
@@ -279,6 +286,10 @@ impl GuiMainNotebook {
 
         self.combo_box_image_hash_algorithm.set_tooltip_text(Some(&flg!("image_hash_alg_tooltip")));
         self.label_image_hash_type.set_tooltip_text(Some(&flg!("image_hash_alg_tooltip")));
+
+        self.combo_box_image_geometric_invariance
+            .set_tooltip_text(Some(&flg!("image_geometric_invariance_tooltip")));
+        self.label_image_geometric_invariance.set_tooltip_text(Some(&flg!("image_geometric_invariance_tooltip")));
 
         self.combo_box_big_files_mode.set_tooltip_text(Some(&flg!("big_files_mode_combobox_tooltip")));
         self.label_big_files_mode.set_tooltip_text(Some(&flg!("big_files_mode_combobox_tooltip")));

--- a/czkawka_gui/src/help_combo_box.rs
+++ b/czkawka_gui/src/help_combo_box.rs
@@ -1,6 +1,7 @@
 use czkawka_core::common::model::{CheckingMethod, HashType};
 use czkawka_core::re_exported::{FilterType, HashAlg};
 use czkawka_core::tools::big_file::SearchMode;
+use czkawka_core::tools::similar_images::GeometricInvariance;
 
 pub struct HashTypeStruct {
     pub eng_name: &'static str,
@@ -143,3 +144,23 @@ pub const IMAGES_HASH_TYPE_COMBO_BOX: &[ImageHashTypeStruct] = &[
 ];
 
 pub const IMAGES_HASH_SIZE_COMBO_BOX: [i32; 4] = [8, 16, 32, 64];
+
+pub struct ImageGeometricInvarianceStruct {
+    pub eng_name: &'static str,
+    pub invariance: GeometricInvariance,
+}
+
+pub const IMAGES_GEOMETRIC_INVARIANCE_COMBO_BOX: [ImageGeometricInvarianceStruct; 3] = [
+    ImageGeometricInvarianceStruct {
+        eng_name: "Off",
+        invariance: GeometricInvariance::Off,
+    },
+    ImageGeometricInvarianceStruct {
+        eng_name: "Mirror + Flip",
+        invariance: GeometricInvariance::MirrorFlip,
+    },
+    ImageGeometricInvarianceStruct {
+        eng_name: "Mirror + Flip + Rotate 90",
+        invariance: GeometricInvariance::MirrorFlipRotate90,
+    },
+];

--- a/czkawka_gui/src/initialize_gui.rs
+++ b/czkawka_gui/src/initialize_gui.rs
@@ -5,7 +5,8 @@ use gtk4::prelude::*;
 use crate::gtk_traits::ComboBoxTraits;
 use crate::gui_structs::gui_data::GuiData;
 use crate::help_combo_box::{
-    DUPLICATES_CHECK_METHOD_COMBO_BOX, DUPLICATES_HASH_TYPE_COMBO_BOX, IMAGES_HASH_SIZE_COMBO_BOX, IMAGES_HASH_TYPE_COMBO_BOX, IMAGES_RESIZE_ALGORITHM_COMBO_BOX,
+    DUPLICATES_CHECK_METHOD_COMBO_BOX, DUPLICATES_HASH_TYPE_COMBO_BOX, IMAGES_GEOMETRIC_INVARIANCE_COMBO_BOX, IMAGES_HASH_SIZE_COMBO_BOX, IMAGES_HASH_TYPE_COMBO_BOX,
+    IMAGES_RESIZE_ALGORITHM_COMBO_BOX,
 };
 use crate::help_functions::scale_set_min_max_values;
 use crate::language_functions::LANGUAGES_ALL;
@@ -46,6 +47,10 @@ pub(crate) fn initialize_gui(gui_data: &GuiData) {
         .main_notebook
         .combo_box_image_resize_algorithm
         .set_model_and_first(IMAGES_RESIZE_ALGORITHM_COMBO_BOX.iter().map(|e| &e.eng_name));
+    gui_data
+        .main_notebook
+        .combo_box_image_geometric_invariance
+        .set_model_and_first(IMAGES_GEOMETRIC_INVARIANCE_COMBO_BOX.iter().map(|e| &e.eng_name));
 
     //// Initialize main scrolled view with notebook
     {

--- a/czkawka_gui/src/saving_loading.rs
+++ b/czkawka_gui/src/saving_loading.rs
@@ -61,6 +61,7 @@ const DEFAULT_THREAD_NUMBER: u32 = 0;
 const DEFAULT_NUMBER_OF_BIGGEST_FILES: &str = "50";
 const DEFAULT_SIMILAR_IMAGES_SIMILARITY: f32 = 0.0;
 const DEFAULT_SIMILAR_IMAGES_IGNORE_SAME_SIZE: bool = false;
+const DEFAULT_SIMILAR_IMAGES_GEOMETRIC_INVARIANCE: u32 = 0;
 const DEFAULT_SIMILAR_VIDEOS_SIMILARITY: f32 = 15.0;
 const DEFAULT_SIMILAR_VIDEOS_IGNORE_SAME_SIZE: bool = false;
 
@@ -289,6 +290,9 @@ pub struct SettingsJson {
     #[serde(default = "default_similar_images_ignore_same_size")]
     pub similar_images_ignore_same_size: bool,
 
+    #[serde(default = "default_similar_images_geometric_invariance")]
+    pub similar_images_geometric_invariance: u32,
+
     #[serde(default = "default_similar_videos_similarity")]
     pub similar_videos_similarity: f64,
 
@@ -421,6 +425,9 @@ fn default_similar_images_similarity() -> f64 {
 fn default_similar_images_ignore_same_size() -> bool {
     DEFAULT_SIMILAR_IMAGES_IGNORE_SAME_SIZE
 }
+fn default_similar_images_geometric_invariance() -> u32 {
+    DEFAULT_SIMILAR_IMAGES_GEOMETRIC_INVARIANCE
+}
 fn default_similar_videos_similarity() -> f64 {
     DEFAULT_SIMILAR_VIDEOS_SIMILARITY as f64
 }
@@ -551,6 +558,9 @@ fn set_configuration_to_gui_internal(upper_notebook: &GuiUpperNotebook, main_not
             .combo_box_image_resize_algorithm
             .set_active(Some(default_config.combo_box_image_resize_algorithm));
         main_notebook.combo_box_image_hash_size.set_active(Some(default_config.combo_box_image_hash_size));
+        main_notebook
+            .combo_box_image_geometric_invariance
+            .set_active(Some(default_config.similar_images_geometric_invariance));
         main_notebook.combo_box_big_files_mode.set_active(Some(default_config.combo_box_big_files_mode));
 
         main_notebook.check_button_broken_files_audio.set_active(default_config.broken_files_audio);
@@ -665,6 +675,7 @@ fn gui_to_settings(upper_notebook: &GuiUpperNotebook, main_notebook: &GuiMainNot
         combo_box_image_resize_algorithm: main_notebook.combo_box_image_resize_algorithm.active().unwrap_or(0),
         combo_box_image_hash_type: main_notebook.combo_box_image_hash_algorithm.active().unwrap_or(0),
         combo_box_image_hash_size: main_notebook.combo_box_image_hash_size.active().unwrap_or(1),
+        similar_images_geometric_invariance: main_notebook.combo_box_image_geometric_invariance.active().unwrap_or(0),
         number_of_biggest_files: main_notebook.entry_big_files_number.text().to_string(),
         similar_images_similarity: main_notebook.scale_similarity_similar_images.value(),
         similar_images_ignore_same_size: main_notebook.check_button_image_ignore_same_size.is_active(),

--- a/czkawka_gui/ui/main_window.ui
+++ b/czkawka_gui/ui/main_window.ui
@@ -547,6 +547,16 @@
                                 <child>
                                   <object class="GtkComboBoxText" id="combo_box_image_hash_algorithm"/>
                                 </child>
+                                <child>
+                                  <object class="GtkLabel" id="label_image_geometric_invariance">
+                                    <property name="label" translatable="yes">Geometric invariance</property>
+                                    <property name="margin-end">2</property>
+                                    <property name="margin-start">5</property>
+                                  </object>
+                                </child>
+                                <child>
+                                  <object class="GtkComboBoxText" id="combo_box_image_geometric_invariance"/>
+                                </child>
                               </object>
                             </child>
                             <child>

--- a/instructions/Instruction.md
+++ b/instructions/Instruction.md
@@ -444,7 +444,7 @@ Results show groups of files with matching tags or similar audio content.
 
 A tool for detecting similar images that may differ in aspects such as watermarks, size, or compression artifacts.
 
-Currently, it works well for images that have not been rotated.
+By default it works best for images that have not been rotated or mirrored. Enable **Geometric invariance** to match flipped/mirrored images, and optionally 90-degree rotations, at the cost of slower hashing.
 
 #### **Process Overview**
 

--- a/krokiet/i18n/en/krokiet.ftl
+++ b/krokiet/i18n/en/krokiet.ftl
@@ -238,6 +238,7 @@ subsettings_images_resize_algorithm = Resize Algorithm
 subsettings_images_ignore_same_size = Ignore images with same size
 subsettings_images_ignore_same_resolution = Ignore images with same resolution
 subsettings_images_max_difference = Max difference
+subsettings_images_geometric_invariance = Geometric invariance
 subsettings_images_duplicates_hash_type = Hash Type
 subsettings_duplicates_check_method = Check method
 subsettings_duplicates_name_case_sensitive = Case Sensitive(only name modes)

--- a/krokiet/src/connect_scan/similar_images.rs
+++ b/krokiet/src/connect_scan/similar_images.rs
@@ -22,6 +22,7 @@ pub(crate) fn scan_similar_images(a: Weak<MainWindow>, sd: ScanData) {
         .spawn(move || {
             let hash_alg = sd.combo_box_items.image_hash_alg.value;
             let resize_algorithm = sd.combo_box_items.resize_algorithm.value;
+            let geometric_invariance = sd.combo_box_items.image_geometric_invariance.value;
             let hash_size = sd
                 .custom_settings
                 .similar_images_sub_hash_size
@@ -35,6 +36,7 @@ pub(crate) fn scan_similar_images(a: Weak<MainWindow>, sd: ScanData) {
                 resize_algorithm,
                 sd.custom_settings.similar_images_sub_ignore_same_size,
                 sd.custom_settings.similar_images_sub_ignore_same_resolution,
+                geometric_invariance,
             );
             let mut tool = SimilarImages::new(params);
 

--- a/krokiet/src/connect_translation.rs
+++ b/krokiet/src/connect_translation.rs
@@ -236,6 +236,7 @@ fn translate_items(app: &MainWindow) {
     translation.set_subsettings_images_ignore_same_size_text(flk!("subsettings_images_ignore_same_size").into());
     translation.set_subsettings_images_ignore_same_resolution_text(flk!("subsettings_images_ignore_same_resolution").into());
     translation.set_subsettings_images_max_difference_text(flk!("subsettings_images_max_difference").into());
+    translation.set_subsettings_images_geometric_invariance_text(flk!("subsettings_images_geometric_invariance").into());
     translation.set_subsettings_images_duplicates_hash_type_text(flk!("subsettings_images_duplicates_hash_type").into());
     translation.set_subsettings_duplicates_check_method_text(flk!("subsettings_duplicates_check_method").into());
     translation.set_subsettings_duplicates_name_case_sensitive_text(flk!("subsettings_duplicates_name_case_sensitive").into());

--- a/krokiet/src/notification_manager.rs
+++ b/krokiet/src/notification_manager.rs
@@ -12,7 +12,7 @@ pub fn send_scan_completed_notification(tool: &str, body: &str) {
     #[cfg(all(unix, not(target_os = "macos")))]
     notif.urgency(notify_rust::Urgency::Normal);
     match notif.show() {
-        Ok(_) => log::info!("Desktop notification sent"),
+        Ok(_handle) => log::info!("Desktop notification sent"),
         Err(e) => error!("Failed to send desktop notification: {e}"),
     }
 }

--- a/krokiet/src/set_initial_gui_info.rs
+++ b/krokiet/src/set_initial_gui_info.rs
@@ -14,6 +14,7 @@ pub(crate) fn set_initial_gui_infos(app: &MainWindow) {
         languages,
         hash_size,
         resize_algorithm,
+        image_geometric_invariance,
         image_hash_alg,
         duplicates_hash_type,
         biggest_files_method,
@@ -29,6 +30,7 @@ pub(crate) fn set_initial_gui_infos(app: &MainWindow) {
     let languages_display_names = StringComboBoxItems::get_display_names(languages);
     let hash_size_display_names = StringComboBoxItems::get_display_names(hash_size);
     let resize_algorithm_display_names = StringComboBoxItems::get_display_names(resize_algorithm);
+    let geometric_invariance_display_names = StringComboBoxItems::get_display_names(image_geometric_invariance);
     let image_hash_alg_display_names = StringComboBoxItems::get_display_names(image_hash_alg);
     let duplicates_hash_type_display_names = StringComboBoxItems::get_display_names(duplicates_hash_type);
     let biggest_files_method_display_names = StringComboBoxItems::get_display_names(biggest_files_method);
@@ -68,6 +70,10 @@ pub(crate) fn set_initial_gui_infos(app: &MainWindow) {
     assert_eq!(
         settings.get_similar_images_sub_available_hash_type().iter().collect::<Vec<SharedString>>(),
         image_hash_alg_display_names
+    );
+    assert_eq!(
+        settings.get_similar_images_sub_available_geometric_invariance().iter().collect::<Vec<SharedString>>(),
+        geometric_invariance_display_names
     );
     assert_eq!(
         settings.get_biggest_files_sub_method().iter().collect::<Vec<SharedString>>(),

--- a/krokiet/src/settings/combo_box.rs
+++ b/krokiet/src/settings/combo_box.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use czkawka_core::common::model::{CheckingMethod, HashType};
 use czkawka_core::re_exported::{Cropdetect, HashAlg};
 use czkawka_core::tools::big_file::SearchMode;
+use czkawka_core::tools::similar_images::GeometricInvariance;
 use czkawka_core::tools::video_optimizer::{NoiseReductionMethod, VideoCodec, VideoCroppingMechanism, VideoOptimizerMode};
 use image::imageops::FilterType;
 use log::warn;
@@ -33,6 +34,7 @@ pub struct StringComboBoxItems {
     pub hash_size: Vec<StringComboBoxItem<u8>>,
     pub resize_algorithm: Vec<StringComboBoxItem<FilterType>>,
     pub image_hash_alg: Vec<StringComboBoxItem<HashAlg>>,
+    pub image_geometric_invariance: Vec<StringComboBoxItem<GeometricInvariance>>,
     pub duplicates_hash_type: Vec<StringComboBoxItem<HashType>>,
     pub biggest_files_method: Vec<StringComboBoxItem<SearchMode>>,
     pub audio_check_type: Vec<StringComboBoxItem<CheckingMethod>>,
@@ -88,6 +90,12 @@ impl StringComboBoxItems {
             ("vertgradient", "VertGradient", HashAlg::VertGradient),
             ("doublegradient", "DoubleGradient", HashAlg::DoubleGradient),
             ("median", "Median", HashAlg::Median),
+        ]);
+
+        let image_geometric_invariance = Self::convert_to_combobox_items(&[
+            ("off", "Off", GeometricInvariance::Off),
+            ("mirror_flip", "Mirror + Flip", GeometricInvariance::MirrorFlip),
+            ("mirror_flip_rotate90", "Mirror + Flip + Rotate 90", GeometricInvariance::MirrorFlipRotate90),
         ]);
 
         let duplicates_hash_type = Self::convert_to_combobox_items(&[
@@ -158,6 +166,7 @@ impl StringComboBoxItems {
             hash_size,
             resize_algorithm,
             image_hash_alg,
+            image_geometric_invariance,
             duplicates_hash_type,
             biggest_files_method,
             audio_check_type,

--- a/krokiet/src/settings/mod.rs
+++ b/krokiet/src/settings/mod.rs
@@ -331,6 +331,11 @@ pub(crate) fn set_combobox_custom_settings_items(settings: &Settings, custom_set
     settings.set_similar_images_sub_resize_algorithm_index(idx as i32);
     settings.set_similar_images_sub_resize_algorithm_value(display_names[idx].clone());
 
+    let (idx, display_names) =
+        StringComboBoxItems::get_item_and_idx_from_config_name(&custom_settings.similar_images_sub_geometric_invariance, &collected_items.image_geometric_invariance);
+    settings.set_similar_images_sub_geometric_invariance_index(idx as i32);
+    settings.set_similar_images_sub_geometric_invariance_value(display_names[idx].clone());
+
     // Duplicates check method
     let (idx, display_names) = StringComboBoxItems::get_item_and_idx_from_config_name(&custom_settings.duplicates_sub_check_method, &collected_items.duplicates_check_method);
     // settings.set_duplicates_sub_check_method_model(display_names);
@@ -649,6 +654,7 @@ pub(crate) fn collect_settings(app: &MainWindow) -> SettingsCustom {
     let similar_images_sub_hash_size = combo_box_items.hash_size.config_name.clone();
     let similar_images_sub_hash_alg = combo_box_items.image_hash_alg.config_name.clone();
     let similar_images_sub_resize_algorithm = combo_box_items.resize_algorithm.config_name.clone();
+    let similar_images_sub_geometric_invariance = combo_box_items.image_geometric_invariance.config_name.clone();
     let similar_images_sub_ignore_same_size = settings.get_similar_images_sub_ignore_same_size();
     let similar_images_sub_ignore_same_resolution = settings.get_similar_images_sub_ignore_same_resolution();
     let similar_images_sub_similarity = settings.get_similar_images_sub_current_similarity().round() as i32;
@@ -794,6 +800,7 @@ pub(crate) fn collect_settings(app: &MainWindow) -> SettingsCustom {
         similar_images_sub_hash_size,
         similar_images_sub_hash_alg,
         similar_images_sub_resize_algorithm,
+        similar_images_sub_geometric_invariance,
         similar_images_sub_ignore_same_size,
         similar_images_sub_ignore_same_resolution,
         similar_images_sub_similarity,
@@ -893,6 +900,7 @@ pub(crate) fn collect_combo_box_settings(app: &MainWindow) -> ComboBoxItems {
     let hash_size_idx = settings.get_similar_images_sub_hash_size_index() as usize;
     let resize_algorithm_idx = settings.get_similar_images_sub_resize_algorithm_index() as usize;
     let image_hash_alg_idx = settings.get_similar_images_sub_hash_alg_index() as usize;
+    let image_geometric_invariance_idx = settings.get_similar_images_sub_geometric_invariance_index() as usize;
     let duplicates_hash_type_idx = settings.get_duplicates_sub_available_hash_type_index() as usize;
     let biggest_files_method_idx = settings.get_biggest_files_sub_method_index() as usize;
     let audio_check_type_idx = settings.get_similar_music_sub_audio_check_type_index() as usize;
@@ -908,6 +916,7 @@ pub(crate) fn collect_combo_box_settings(app: &MainWindow) -> ComboBoxItems {
         hash_size: collected_combo_boxes.hash_size[hash_size_idx].clone(),
         resize_algorithm: collected_combo_boxes.resize_algorithm[resize_algorithm_idx].clone(),
         image_hash_alg: collected_combo_boxes.image_hash_alg[image_hash_alg_idx].clone(),
+        image_geometric_invariance: collected_combo_boxes.image_geometric_invariance[image_geometric_invariance_idx].clone(),
         duplicates_hash_type: collected_combo_boxes.duplicates_hash_type[duplicates_hash_type_idx].clone(),
         biggest_files_method: collected_combo_boxes.biggest_files_method[biggest_files_method_idx].clone(),
         audio_check_type: collected_combo_boxes.audio_check_type[audio_check_type_idx].clone(),

--- a/krokiet/src/settings/model.rs
+++ b/krokiet/src/settings/model.rs
@@ -6,6 +6,7 @@ use czkawka_core::common::items::{DEFAULT_EXCLUDED_DIRECTORIES, DEFAULT_EXCLUDED
 use czkawka_core::common::model::{CheckingMethod, HashType};
 use czkawka_core::re_exported::{Cropdetect, HashAlg};
 use czkawka_core::tools::big_file::SearchMode;
+use czkawka_core::tools::similar_images::GeometricInvariance;
 use czkawka_core::tools::similar_videos::{
     DEFAULT_AUDIO_LENGTH_RATIO, DEFAULT_AUDIO_MAXIMUM_DIFFERENCE, DEFAULT_AUDIO_MIN_DURATION_SECONDS, DEFAULT_AUDIO_SIMILARITY_PERCENT, DEFAULT_SKIP_FORWARD_AMOUNT,
     DEFAULT_VID_HASH_DURATION, DEFAULT_VIDEO_PERCENTAGE_FOR_THUMBNAIL,
@@ -91,6 +92,8 @@ pub struct SettingsCustom {
     pub similar_images_sub_hash_alg: String,
     #[serde(default = "default_resize_algorithm")]
     pub similar_images_sub_resize_algorithm: String,
+    #[serde(default = "default_geometric_invariance")]
+    pub similar_images_sub_geometric_invariance: String,
     #[serde(default)]
     pub similar_images_sub_ignore_same_size: bool,
     #[serde(default)]
@@ -282,6 +285,7 @@ pub struct ComboBoxItems {
     pub hash_size: StringComboBoxItem<u8>,
     pub resize_algorithm: StringComboBoxItem<FilterType>,
     pub image_hash_alg: StringComboBoxItem<HashAlg>,
+    pub image_geometric_invariance: StringComboBoxItem<GeometricInvariance>,
     pub duplicates_hash_type: StringComboBoxItem<HashType>,
     pub biggest_files_method: StringComboBoxItem<SearchMode>,
     pub audio_check_type: StringComboBoxItem<CheckingMethod>,
@@ -482,6 +486,9 @@ pub(crate) fn default_resize_algorithm() -> String {
 }
 pub(crate) fn default_hash_type() -> String {
     "mean".to_string()
+}
+pub(crate) fn default_geometric_invariance() -> String {
+    "off".to_string()
 }
 pub(crate) fn default_sub_hash_size() -> String {
     DEFAULT_HASH_SIZE.to_string()

--- a/krokiet/ui/settings.slint
+++ b/krokiet/ui/settings.slint
@@ -65,6 +65,9 @@ export global Settings {
     in-out property <[string]> similar_images_sub_available_hash_type: ["Mean", "Gradient", "BlockHash", "VertGradient", "DoubleGradient", "Median"];
     in-out property <int> similar_images_sub_hash_alg_index: 0;
     in-out property <string> similar_images_sub_hash_alg_value: "Mean";
+    in-out property <[string]> similar_images_sub_available_geometric_invariance: ["Off", "Mirror + Flip", "Mirror + Flip + Rotate 90"];
+    in-out property <int> similar_images_sub_geometric_invariance_index: 0;
+    in-out property <string> similar_images_sub_geometric_invariance_value: "Off";
     in-out property <float> similar_images_sub_max_similarity: 40;
     in-out property <float> similar_images_sub_current_similarity: 20;
     in-out property <bool> similar_images_sub_ignore_same_size: false;

--- a/krokiet/ui/tool_settings.slint
+++ b/krokiet/ui/tool_settings.slint
@@ -110,6 +110,13 @@ export component ToolSettings {
                 current_value <=> Settings.similar_images_sub_hash_alg_value;
             }
 
+            ComboBoxWrapper {
+                text: Translations.subsettings_images_geometric_invariance_text;
+                model: Settings.similar_images_sub_available_geometric_invariance;
+                current_index <=> Settings.similar_images_sub_geometric_invariance_index;
+                current_value <=> Settings.similar_images_sub_geometric_invariance_value;
+            }
+
             Rectangle {
                 height: 0px;
             }

--- a/krokiet/ui/translations.slint
+++ b/krokiet/ui/translations.slint
@@ -83,6 +83,7 @@ export global Translations {
     in-out property <string> subsettings_images_ignore_same_size_text: "Ignore images with same size";
     in-out property <string> subsettings_images_ignore_same_resolution_text: "Ignore images with same resolution";
     in-out property <string> subsettings_images_max_difference_text: "Max difference";
+    in-out property <string> subsettings_images_geometric_invariance_text: "Geometric invariance";
 
     in-out property <string> subsettings_images_duplicates_hash_type_text: "Hash Type";
 


### PR DESCRIPTION
Adds optional geometric invariance support to similar image search.

This allows similar image detection to account for:
- mirrored/flipped images
- mirrored/flipped images plus 90-degree rotations

The option is exposed in the GTK UI and Krokiet UI, persisted in settings, included in cache names, and left disabled by default to preserve existing behavior.

- Adds `GeometricInvariance` to `SimilarImagesParameters`.
- Stores multiple hashes per image when invariance is enabled.
- Merges overlapping groups produced by alternate image transforms.
- Adds UI settings and English translations for GTK and Krokiet.
- Keeps CLI and Cedinia behavior unchanged by passing `GeometricInvariance::Off`.

This should address https://github.com/qarmin/czkawka/issues/1492

