### PR TITLE
fix: correct reversed hide_hard_links logic in similar_images and similar_videos

### DIFF
--- a/czkawka_core/src/tools/similar_images/core.rs
+++ b/czkawka_core/src/tools/similar_images/core.rs
@@ -69,7 +69,7 @@ impl SimilarImages {
                         Some((inode, fes))
                     })
                     .while_some()
-                    .flat_map(if hide_hard_links { |(_, fes)| fes } else { take_1_per_inode })
+                    .flat_map(if hide_hard_links { take_1_per_inode } else { |(_, fes)| fes })
                     .map(|fe| {
                         let fe_str = fe.path.to_string_lossy().to_string();
                         let image_entry = fe.into_images_entry();

--- a/czkawka_core/src/tools/similar_images/tests.rs
+++ b/czkawka_core/src/tools/similar_images/tests.rs
@@ -116,3 +116,59 @@ fn test_similar_images_empty_directory() {
     assert_eq!(info.number_of_groups, 0);
     assert_eq!(similar_images.len(), 0);
 }
+
+#[test]
+fn test_similar_images_hide_hard_links() {
+    use std::fs;
+    use tempfile::TempDir;
+
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path();
+
+    let test_image_src = get_test_resources_path().join("normal.jpg");
+    let img1_path = path.join("image1.jpg");
+    let img2_path = path.join("image2.jpg");
+    fs::copy(&test_image_src, &img1_path).unwrap();
+
+    #[cfg(target_family = "unix")]
+    fs::hard_link(&img1_path, &img2_path).unwrap();
+    #[cfg(target_family = "windows")]
+    {
+        if fs::hard_link(&img1_path, &img2_path).is_err() {
+            return;
+        }
+    }
+
+    {
+        let params = SimilarImagesParameters::new(10, 8, HashAlg::Gradient, FilterType::Lanczos3, false, false);
+        let mut finder = SimilarImages::new(params);
+        finder.set_hide_hard_links(true);
+        finder.set_included_paths(vec![path.to_path_buf()]);
+        finder.set_recursive_search(true);
+        finder.set_use_cache(false);
+
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        finder.search(&stop_flag, None);
+
+        let info = finder.get_information();
+        assert_eq!(info.number_of_duplicates, 0);
+        assert_eq!(info.number_of_groups, 0);
+    }
+
+    {
+        let params = SimilarImagesParameters::new(10, 8, HashAlg::Gradient, FilterType::Lanczos3, false, false);
+        let mut finder = SimilarImages::new(params);
+        finder.set_hide_hard_links(false);
+        finder.set_included_paths(vec![path.to_path_buf()]);
+        finder.set_recursive_search(true);
+        finder.set_use_cache(false);
+
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        finder.search(&stop_flag, None);
+
+        let info = finder.get_information();
+        assert_eq!(info.number_of_duplicates, 1);
+        assert_eq!(info.number_of_groups, 1);
+    }
+}
+

--- a/czkawka_core/src/tools/similar_images/tests.rs
+++ b/czkawka_core/src/tools/similar_images/tests.rs
@@ -117,6 +117,7 @@ fn test_similar_images_empty_directory() {
     assert_eq!(similar_images.len(), 0);
 }
 
+#[cfg(target_family = "unix")]
 #[test]
 fn test_similar_images_hide_hard_links() {
     use std::fs;

--- a/czkawka_core/src/tools/similar_images/tests.rs
+++ b/czkawka_core/src/tools/similar_images/tests.rs
@@ -120,6 +120,7 @@ fn test_similar_images_empty_directory() {
 #[test]
 fn test_similar_images_hide_hard_links() {
     use std::fs;
+
     use tempfile::TempDir;
 
     let temp_dir = TempDir::new().unwrap();
@@ -171,4 +172,3 @@ fn test_similar_images_hide_hard_links() {
         assert_eq!(info.number_of_groups, 1);
     }
 }
-

--- a/czkawka_core/src/tools/similar_videos/core.rs
+++ b/czkawka_core/src/tools/similar_videos/core.rs
@@ -71,7 +71,7 @@ impl SimilarVideos {
                         Some((inode, fes))
                     })
                     .while_some()
-                    .flat_map(if hide_hard_links { |(_, fes)| fes } else { take_1_per_inode })
+                    .flat_map(if hide_hard_links { take_1_per_inode } else { |(_, fes)| fes })
                     .collect();
 
                 if check_audio {

--- a/czkawka_core/src/tools/similar_videos/tests.rs
+++ b/czkawka_core/src/tools/similar_videos/tests.rs
@@ -132,3 +132,52 @@ fn test_similar_videos_audio_mode_ignores_non_video_files() {
     assert_eq!(info.number_of_duplicates, 0, "Should find no video duplicates when only audio (MP3) files are present");
     assert_eq!(info.number_of_groups, 0, "Should find no groups when only audio (MP3) files are present");
 }
+
+#[test]
+fn test_similar_videos_hide_hard_links() {
+    use std::fs;
+    use tempfile::TempDir;
+
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path();
+
+    let vid1_path = path.join("video1.mp4");
+    let vid2_path = path.join("video2.mp4");
+    fs::write(&vid1_path, b"dummy content").unwrap();
+
+    #[cfg(target_family = "unix")]
+    fs::hard_link(&vid1_path, &vid2_path).unwrap();
+    #[cfg(target_family = "windows")]
+    {
+        if fs::hard_link(&vid1_path, &vid2_path).is_err() {
+            return;
+        }
+    }
+
+    {
+        let mut finder = SimilarVideos::new(make_params_visual());
+        finder.set_hide_hard_links(true);
+        finder.set_included_paths(vec![path.to_path_buf()]);
+        finder.set_recursive_search(true);
+        finder.set_use_cache(false);
+
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        finder.check_for_similar_videos(&stop_flag, None);
+
+        assert_eq!(finder.videos_to_check.len(), 1);
+    }
+
+    {
+        let mut finder = SimilarVideos::new(make_params_visual());
+        finder.set_hide_hard_links(false);
+        finder.set_included_paths(vec![path.to_path_buf()]);
+        finder.set_recursive_search(true);
+        finder.set_use_cache(false);
+
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        finder.check_for_similar_videos(&stop_flag, None);
+
+        assert_eq!(finder.videos_to_check.len(), 2);
+    }
+}
+

--- a/czkawka_core/src/tools/similar_videos/tests.rs
+++ b/czkawka_core/src/tools/similar_videos/tests.rs
@@ -136,6 +136,7 @@ fn test_similar_videos_audio_mode_ignores_non_video_files() {
 #[test]
 fn test_similar_videos_hide_hard_links() {
     use std::fs;
+
     use tempfile::TempDir;
 
     let temp_dir = TempDir::new().unwrap();
@@ -180,4 +181,3 @@ fn test_similar_videos_hide_hard_links() {
         assert_eq!(finder.videos_to_check.len(), 2);
     }
 }
-

--- a/czkawka_core/src/tools/similar_videos/tests.rs
+++ b/czkawka_core/src/tools/similar_videos/tests.rs
@@ -133,6 +133,7 @@ fn test_similar_videos_audio_mode_ignores_non_video_files() {
     assert_eq!(info.number_of_groups, 0, "Should find no groups when only audio (MP3) files are present");
 }
 
+#[cfg(target_family = "unix")]
 #[test]
 fn test_similar_videos_hide_hard_links() {
     use std::fs;


### PR DESCRIPTION
i was testing a similar images scan and noticed that it shows hardlinks even if the 'hide hardlinks' setting was enabled. if i checked correctly this only seems to apply to similar_image and similar_videos.
also added new unit tests for this.
let me know if anything needs to be changed