### PR TITLE
Surface rollback rename failure in make_hard_link/make_file_symlink

### DIFF
--- a/czkawka_core/src/common/fs_ops.rs
+++ b/czkawka_core/src/common/fs_ops.rs
@@ -192,11 +192,26 @@ pub fn make_hard_link<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Res
             fs::remove_file(&temp)?;
             Ok(())
         }
-        Err(e) => {
-            let _ = fs::rename(&temp, dst);
-            Err(describe_hardlink_error(e, dst))
-        }
+        Err(e) => Err(recover_from_failed_link(&temp, dst, describe_hardlink_error(e, dst))),
     }
+}
+
+// After moving the original `dst` aside to `temp`, the hardlink/symlink creation failed. Move the
+// original back. If that rollback rename also fails, the original file is now orphaned at `temp`;
+// returning only the primary error would hide that (silent data loss, issue #1991), so fold the
+// rollback failure and the temp location into the returned error.
+fn recover_from_failed_link(temp: &Path, dst: &Path, primary_error: io::Error) -> io::Error {
+    let Err(rollback_error) = fs::rename(temp, dst) else {
+        return primary_error;
+    };
+    Error::new(
+        primary_error.kind(),
+        format!(
+            "{primary_error}; original file could not be restored and is now left at \"{}\" (rename back to \"{}\" failed: {rollback_error})",
+            temp.to_string_lossy(),
+            dst.to_string_lossy()
+        ),
+    )
 }
 
 // rclone/network/FUSE mounts and cross-device targets can't hold a hard link; the bare
@@ -243,10 +258,7 @@ pub fn make_file_symlink<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::
             fs::remove_file(&temp)?;
             Ok(())
         }
-        Err(e) => {
-            let _ = fs::rename(&temp, dst);
-            Err(e)
-        }
+        Err(e) => Err(recover_from_failed_link(&temp, dst, e)),
     }
 }
 
@@ -286,5 +298,39 @@ mod tests {
 
         assert_eq!(described.kind(), ErrorKind::PermissionDenied);
         assert_eq!(described.to_string(), "Permission denied");
+    }
+
+    #[test]
+    fn recover_from_failed_link_returns_primary_error_when_rollback_succeeds() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let temp = dir.path().join("orig.czkawka_tmp");
+        let dst = dir.path().join("orig");
+        fs::write(&temp, b"original contents").expect("write temp");
+
+        let returned = recover_from_failed_link(&temp, &dst, Error::new(ErrorKind::Unsupported, "hard_link failed"));
+
+        // Rollback succeeded: the original file is back at dst, temp is gone, and the caller sees
+        // the unchanged primary error.
+        assert_eq!(returned.kind(), ErrorKind::Unsupported);
+        assert_eq!(returned.to_string(), "hard_link failed");
+        assert_eq!(fs::read(&dst).expect("dst restored"), b"original contents");
+        assert!(!temp.exists(), "temp should have been renamed back to dst");
+    }
+
+    #[test]
+    fn recover_from_failed_link_reports_orphaned_file_when_rollback_fails() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // temp does not exist, so the rollback rename fails deterministically on every platform.
+        let temp = dir.path().join("orig.czkawka_tmp");
+        let dst = dir.path().join("orig");
+
+        let returned = recover_from_failed_link(&temp, &dst, Error::new(ErrorKind::Unsupported, "hard_link failed"));
+
+        assert_eq!(returned.kind(), ErrorKind::Unsupported);
+        let message = returned.to_string();
+        assert!(message.contains("hard_link failed"), "missing primary error in: {message}");
+        assert!(message.contains("orig.czkawka_tmp"), "missing orphaned temp path in: {message}");
+        assert!(message.contains("could not be restored"), "missing recovery note in: {message}");
+        assert!(!dst.exists(), "dst must not be created when rollback fails");
     }
 }


### PR DESCRIPTION
## What was broken

`make_hard_link` and `make_file_symlink` in `czkawka_core/src/common/fs_ops.rs` create a link by first renaming the existing destination file aside to a temporary `<dst>.<rand>.czkawka_tmp` path, then creating the link in its place. If link creation fails, they rename the original file back.

The result of that rollback rename was discarded with `let _ = fs::rename(&temp, dst)`. If the rollback rename itself failed (for example the destination directory became read-only, or another process recreated `dst` in the meantime), the caller received only the original link error. It was never told that the user's original file had been left under the temporary `.czkawka_tmp` name instead of at `dst`.

The original file is not deleted, so it stays recoverable at the temporary path, but nothing in the reported error lets the user know where it went.

## Root cause

`fs_ops.rs:196` (hard link) and `fs_ops.rs:247` (symlink): the rollback `fs::rename(&temp, dst)` result was dropped via `let _ = ...`.

## Fix

Extract the rollback into a small helper `recover_from_failed_link(temp, dst, primary_error)`:

- When the rollback rename succeeds, it returns the primary link error unchanged, so the common case behaves exactly as before.
- When the rollback rename fails, it returns an error with the same `ErrorKind` whose message folds in the original failure, the temporary path where the file now lives, and the rollback error, so the user can find and restore the file.

Both call sites now go through it. This mirrors the existing `describe_hardlink_error` helper already in this file.

## Tests

Two deterministic, cross-platform unit tests were added:

- `recover_from_failed_link_returns_primary_error_when_rollback_succeeds` - the rollback restores `dst`, the temp file is gone, and the returned error is the unchanged primary error.
- `recover_from_failed_link_reports_orphaned_file_when_rollback_fails` - with the rollback forced to fail, the returned error keeps the original `ErrorKind` and its message names the primary failure and the orphaned temp path.

## Validation (local)

- `cargo test -p czkawka_core --lib`: 231 passed, 0 failed, 6 ignored.
- `cargo +nightly fmt --check`: the changed file is clean.
- `cargo clippy -p czkawka_core --all-targets`: no errors and no new warnings from this change. (There is one pre-existing `while_let_loop` warning at `fs_ops.rs:55` in `check_if_folder_contains_only_empty_folders`; it is unrelated to this change and left untouched.)

Tested locally on Windows only; not run on Linux or macOS. The code uses only `std::fs`, so the behavior should be the same on those platforms, but I have not verified it there.

## Notes

The combined-failure path (link creation fails and the rollback rename also fails) cannot be reproduced deterministically on a normal filesystem, because the temporary file is in the destination's own directory and the rollback normally always succeeds. For that reason the rollback logic was extracted into a directly testable helper, following the pattern already used for `describe_hardlink_error`.

Closes #1991
