### PR TITLE
Added Support for .desktop in Wayland and X11 on Winit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4558,6 +4558,7 @@ dependencies = [
  "fs_extra",
  "home",
  "humansize",
+ "i-slint-backend-winit",
  "i18n-embed",
  "i18n-embed-fl",
  "image",

--- a/krokiet/Cargo.toml
+++ b/krokiet/Cargo.toml
@@ -48,6 +48,7 @@ notify-rust = { version = "4" }
 # Easier cross-compilation of app to e.g. 32 bit os, by using dlopen instead of linking libraries at compile time
 # Must match version used in slint
 fontique = { version = "=0.10.0", default-features = false, features = ["fontconfig-dlopen", "std"] }
+i-slint-backend-winit = "=1.17.0"
 
 [build-dependencies]
 #slint-build = { path = "/home/rafal/test/slint/api/rs/build/"}

--- a/krokiet/create-desktop-entry
+++ b/krokiet/create-desktop-entry
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+#--------------------------------------
+#Creates a Functional .desktop icon for the distros it supports by falling back into X11 because Slint don't like acessing WAYLAND_APP_ID
+#--------------------------------------
+#Variables
+BIN="${HOME}/.cargo/bin/krokiet"
+ICON_SRC="./icons/krokiet_logo_flag.png"
+APPS_DIR="${HOME}/.local/share/applications/"
+ICON_DIR="${HOME}/.local/share/icons/apps/krokiet/"
+DESKTOP_FILE="${APPS_DIR}/krokiet.desktop"
+#Functions
+handle_error() {
+    local type="$1"
+    printf "Error: %s\n" "${type}"
+    printf "Exiting...\n"
+    exit 1
+}
+check_dir() {
+    local dir="$1"
+    if [ -d "${dir}" ]; then
+        printf "%s found\n" "${dir}!"
+    else
+        printf "%s not found, trying to create...\n" "${dir}"
+        mkdir -p "${dir}" || handle_error "Failed to create ${dir}!"
+        printf "%s created\n" "${dir}"
+    fi
+}
+#Main
+if [ ! -f "${BIN}" ]; then
+    handle_error "Krokiet binary not found: ${BIN }"
+fi
+if [ ! -f "${ICON_SRC}" ]; then
+    handle_error "Source icon not found: ${ICON_SRC}"
+fi
+check_dir "$APPS_DIR"
+check_dir "$ICON_DIR"
+cp "$ICON_SRC" "$ICON_DIR/" || handle_error "Failed to copy icon"
+cat > "${DESKTOP_FILE}" << EOF
+[Desktop Entry]
+Version=1.1
+Type=Application
+Name=Krokiet
+Comment=File cleaning and duplicate finder
+Icon=${ICON_DIR}krokiet_logo_flag.png
+    #The key is here! The env variable to force X11 by disableing Wayland...
+Exec=env SLINT_BACKEND=winit-femtovg WAYLAND_DISPLAY= ${BIN}
+Path=${HOME}/.local/share
+Actions=
+Categories=X-GNOME-Utilities;
+Keywords=Krokiet;krokiet;czkawka;Czkawka;
+StartupWMClass=krokiet
+EOF
+if [ $? -ne 0 ]; then 
+    handle_error "Failed to create ${DESKTOP_FILE}!\n"
+fi
+printf "${DESKTOP_FILE} created sucessfully!\n"
+exit 0
+#by betor

--- a/krokiet/create-desktop-entry
+++ b/krokiet/create-desktop-entry
@@ -29,7 +29,7 @@ check_dir() {
 }
 #Main
 if [ ! -f "${BIN}" ]; then
-    handle_error "Krokiet binary not found: ${BIN }"
+    handle_error "Krokiet binary not found: ${BIN}"
 fi
 if [ ! -f "${ICON_SRC}" ]; then
     handle_error "Source icon not found: ${ICON_SRC}"
@@ -44,7 +44,6 @@ Type=Application
 Name=Krokiet
 Comment=File cleaning and duplicate finder
 Icon=${ICON_DIR}krokiet_logo_flag.png
-    #The key is here! The env variable to force X11 by disableing Wayland...
 Exec=${BIN}
 Path=${HOME}/.local/share
 Actions=
@@ -53,8 +52,8 @@ Keywords=Krokiet;krokiet;czkawka;Czkawka;
 StartupWMClass=krokiet
 EOF
 if [ $? -ne 0 ]; then 
-    handle_error "Failed to create ${DESKTOP_FILE}!\n"
+    handle_error "Failed to create ${DESKTOP_FILE}!"
 fi
-printf "${DESKTOP_FILE} created sucessfully!\n"
+printf "${DESKTOP_FILE} created sucessfully!"
 exit 0
 #by betor

--- a/krokiet/create-desktop-entry
+++ b/krokiet/create-desktop-entry
@@ -45,7 +45,7 @@ Name=Krokiet
 Comment=File cleaning and duplicate finder
 Icon=${ICON_DIR}krokiet_logo_flag.png
     #The key is here! The env variable to force X11 by disableing Wayland...
-Exec=env SLINT_BACKEND=winit-femtovg WAYLAND_DISPLAY= ${BIN}
+Exec=${BIN}
 Path=${HOME}/.local/share
 Actions=
 Categories=X-GNOME-Utilities;

--- a/krokiet/create-desktop-entry
+++ b/krokiet/create-desktop-entry
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 #--------------------------------------
-#Creates a Functional .desktop icon for the distros it supports by falling back into X11 because Slint don't like acessing WAYLAND_APP_ID
+#Creates a Functional .desktop icon for the distros it supports
 #--------------------------------------
 #Variables
 BIN="${HOME}/.cargo/bin/krokiet"

--- a/krokiet/src/main.rs
+++ b/krokiet/src/main.rs
@@ -24,6 +24,8 @@ use file_actions::connect_rename::connect_rename;
 use file_actions::connect_symlink::connect_symlink;
 use log::{error, info};
 use slint::VecModel;
+use slint::platform::set_platform;
+use i_slint_backend_winit::Backend;
 
 use crate::clear_outdated_video_thumbnails::clear_outdated_video_thumbnails;
 use crate::connect_build_info::{apply_build_info, connect_build_info, start_build_info_background_probes};
@@ -93,6 +95,9 @@ mod ui {
 pub use ui::*;
 
 fn main() {
+    let backend = Backend::new().unwrap();
+    set_platform(Box::new(backend)).unwrap();
+    slint::set_xdg_app_id("krokiet").unwrap();
     register_image_decoding_hooks();
     let config_cache_path_set_result = set_config_cache_path("Czkawka", "Krokiet");
     let cli_args = process_cli_args("Krokiet", "krokiet_gui", std::env::args().skip(1).collect());


### PR DESCRIPTION
Added support for .desktop files by:
1) Making so that de binary would be able to pass the xdg_app_id variable so the WM can correctly assign the app's icon;
2) Added a simples shellscript that creates the .desktop on ~/.local/share/applications/krokiet.desktop and puts the png on ~/.local/share/icons/...;
3) Had to add i-slint-backend-winit (1.17.0) as a dependency;

Even thought It is a "symple fix" it took me the whole day scouring forums and testing stuff until it worked. I've had a help from AI since I am not that versed in Rust, but I tested and it works (X11 and Wayland) and to not have any vulnerability since it only passes a variable throught a native slint functio

n and acess everything throught native functions. 

Also this script could help in a future deb package if they get rust up to 1.97.

Anyways happy to contibute and to help
<img width="1920" height="1080" alt="Captura de tela de 2026-08-03 22-23-02" src="https://github.com/user-attachments/assets/74cadcac-ac7f-44d0-a2b9-89056f7b0183" />
<img width="1920" height="1080" alt="Captura de tela de 2026-08-03 22-22-56" src="https://github.com/user-attachments/assets/143fdb34-bdb9-4f8e-90d8-50c3956cb3a9" />
