### PR TITLE
Use async-io for XDG portal trash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,7 +395,6 @@ dependencies = [
  "getrandom 0.4.3",
  "serde",
  "serde_repr",
- "tokio",
  "zbus",
 ]
 
@@ -1662,6 +1661,7 @@ name = "czkawka_core"
 version = "12.0.1"
 dependencies = [
  "ashpd",
+ "async-io",
  "bincode 1.3.3",
  "bitflags 2.13.1",
  "bk-tree",
@@ -1719,7 +1719,6 @@ dependencies = [
  "symphonia 0.6.0",
  "tar",
  "tempfile",
- "tokio",
  "toml 1.1.3+spec-1.1.0",
  "trash",
  "ttf-parser",
@@ -5058,17 +5057,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
-dependencies = [
- "libc",
- "wasi",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "moxcms"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7513,16 +7501,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "socket2"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "softbuffer"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8401,22 +8379,6 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "tokio"
-version = "1.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
-dependencies = [
- "bytes",
- "libc",
- "mio",
- "pin-project-lite",
- "signal-hook-registry",
- "socket2",
- "tracing",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "toml"
@@ -10245,7 +10207,6 @@ dependencies = [
  "rustix 1.1.4",
  "serde",
  "serde_repr",
- "tokio",
  "tracing",
  "uds_windows",
  "uuid",

--- a/czkawka_core/Cargo.toml
+++ b/czkawka_core/Cargo.toml
@@ -111,8 +111,8 @@ glibc_musl_version = "0.1.0"
 
 rand = "0.10.0"
 
-ashpd = { version = "0.13.2", optional = true, features = ["trash"] }
-tokio = { version = "1.49.0", optional = true }
+ashpd = { version = "0.13.2", optional = true, default-features = false, features = ["async-io", "trash"] }
+async-io = { version = "2.6.0", optional = true }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 trash = "5.1"
@@ -144,6 +144,6 @@ libavif = ["image/avif-native", "image/avif"]
 blake_pure = ["blake3/pure"]
 # Allows to use trash on Linux when using xdg-portal, needed by e.g. flatpak where normal trash access always fails
 # No-op on other OSes, it is slower and provides less helpful error messages
-xdg_portal_trash = ["ashpd", "tokio"]
+xdg_portal_trash = ["ashpd", "async-io"]
 [lints]
 workspace = true

--- a/czkawka_core/src/common/fs_ops.rs
+++ b/czkawka_core/src/common/fs_ops.rs
@@ -6,35 +6,6 @@ use crate::flc;
 
 const MAX_SYMLINK_HARDLINK_ATTEMPTS: u8 = 5;
 
-#[cfg(all(feature = "xdg_portal_trash", target_os = "linux"))]
-thread_local! {
-    static TOKIO_RT: std::cell::RefCell<Option<Result<tokio::runtime::Runtime, String>>> = const { std::cell::RefCell::new(None) };
-}
-
-#[cfg(all(feature = "xdg_portal_trash", target_os = "linux"))]
-fn with_runtime<F, R>(f: F) -> Result<R, String>
-where
-    F: FnOnce(&tokio::runtime::Runtime) -> Result<R, String>,
-{
-    TOKIO_RT.with(|cell| {
-        let mut opt = cell.borrow_mut();
-
-        if opt.is_none() {
-            let rt = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .map_err(|e| format!("Failed to build Tokio runtime: {e}"));
-
-            *opt = Some(rt);
-        }
-
-        match opt.as_ref().expect("Tokio runtime is initialized before") {
-            Ok(rt) => f(rt),
-            Err(e) => Err(e.clone()),
-        }
-    })
-}
-
 pub fn check_if_folder_contains_only_empty_folders<P: AsRef<Path>>(path: P) -> Result<(), String> {
     let path = path.as_ref();
     if !path.is_dir() {
@@ -103,7 +74,7 @@ fn trash_delete<P: AsRef<Path>>(path: P) -> Result<(), String> {
         use std::os::fd::AsFd;
         let file = std::fs::OpenOptions::new().write(true).read(true).open(path).map_err(|err| err.to_string())?;
 
-        with_runtime(|rt| rt.block_on(async move { ashpd::desktop::trash::trash_file(&file.as_fd()).await.map_err(|e| e.to_string()) }))?;
+        async_io::block_on(async move { ashpd::desktop::trash::trash_file(&file.as_fd()).await.map_err(|e| e.to_string()) })?;
 
         Ok(())
     }


### PR DESCRIPTION
Avoid enabling zbus's Tokio backend alongside Slint's async-io backend, which makes Krokiet require a Tokio runtime during startup.