### PR TITLE
Update README.md for explicit clarity for users new to rust.

### DIFF
--- a/krokiet/README.md
+++ b/krokiet/README.md
@@ -58,7 +58,7 @@ cargo install krokiet --locked
 
 which will install, the latest and optimized version of Krokiet.
 
-Compilation with `cargo build --release` should produce a working binary, that without any additional dependencies should run on user os.
+Compilation with `cargo build --release` (run from project root) should produce a working binary, that without any additional dependencies should run on user os.
 
 To enable support for extra image formats, compile with optional features:
 


### PR DESCRIPTION
This is a proposed change to increase clarity in the krokiet readme. I am new to rust and it took me a while to figure out where to run the build command from. Maybe I am just clueless, but this addition would've been very helpful for me.