### PR TITLE
Add support for "Album" tag for track duplicate detection by tag matching

### DIFF
--- a/cedinia/src/callbacks/scan.rs
+++ b/cedinia/src/callbacks/scan.rs
@@ -234,6 +234,9 @@ fn build_scan_request(win: &MainWindow, tool: ActiveTool, dirs: Vec<PathBuf>, ex
             if m.get_artist() {
                 sim |= MusicSimilarity::TRACK_ARTIST;
             }
+            if m.get_album() {
+                sim |= MusicSimilarity::TRACK_ALBUM;
+            }
             if m.get_year() {
                 sim |= MusicSimilarity::YEAR;
             }

--- a/cedinia/src/settings/mod.rs
+++ b/cedinia/src/settings/mod.rs
@@ -120,6 +120,8 @@ pub struct CediniaSettings {
     pub same_music_title: bool,
     #[serde(default = "ttrue")]
     pub same_music_artist: bool,
+    #[serde(default = "ttrue")]
+    pub same_music_album: bool,
     #[serde(default)]
     pub same_music_year: bool,
     #[serde(default)]
@@ -461,6 +463,7 @@ pub fn collect_settings_from_gui(win: &MainWindow) -> CediniaSettings {
             .map_or_else(|| panic!("Invalid count_idx {} in GUI", bfiles.get_count_idx()), |e| e.config_name.clone()),
         same_music_title: sm.get_title(),
         same_music_artist: sm.get_artist(),
+        same_music_album: sm.get_album(),
         same_music_year: sm.get_year(),
         same_music_length: sm.get_length(),
         same_music_genre: sm.get_genre(),

--- a/cedinia/src/settings/mod.rs
+++ b/cedinia/src/settings/mod.rs
@@ -368,6 +368,7 @@ pub fn apply_settings_to_gui(win: &MainWindow, s: &CediniaSettings) {
     let sm = win.global::<SameMusicSettings>();
     sm.set_title(s.same_music_title);
     sm.set_artist(s.same_music_artist);
+    sm.set_album(s.same_music_album);
     sm.set_year(s.same_music_year);
     sm.set_length(s.same_music_length);
     sm.set_genre(s.same_music_genre);

--- a/cedinia/ui/globals/app_state.slint
+++ b/cedinia/ui/globals/app_state.slint
@@ -65,6 +65,7 @@ export global SimilarImagesSettings {
 export global SameMusicSettings {
     in-out property <bool>   title:              true;
     in-out property <bool>   artist:             true;
+    in-out property <bool>   album:              false;
     in-out property <bool>   year:               false;
     in-out property <bool>   length:             false;
     in-out property <bool>   genre:              false;

--- a/cedinia/ui/globals/translations.slint
+++ b/cedinia/ui/globals/translations.slint
@@ -130,6 +130,7 @@ export global Translations {
     in-out property <string> settings_music_compare_tags_label_text: "COMPARED TAGS";
     in-out property <string> settings_music_title_text:       "Title";
     in-out property <string> settings_music_artist_text:      "Artist";
+    in-out property <string> settings_music_album_text:       "Album";
     in-out property <string> settings_music_year_text:        "Year";
     in-out property <string> settings_music_length_text:      "Length";
     in-out property <string> settings_music_genre_text:       "Genre";

--- a/cedinia/ui/screens/settings_screen.slint
+++ b/cedinia/ui/screens/settings_screen.slint
@@ -454,6 +454,8 @@ export component SettingsScreen {
                     Divider {}
                     ToggleRow { label: Translations.settings_music_artist_text; value <=> SameMusicSettings.artist; }
                     Divider {}
+                    ToggleRow { label: Translations.settings_music_album_text; value <=> SameMusicSettings.album; }
+                    Divider {}
                     ToggleRow { label: Translations.settings_music_year_text;     value <=> SameMusicSettings.year; }
                     Divider {}
                     ToggleRow { label: Translations.settings_music_length_text;    value <=> SameMusicSettings.length; }

--- a/czkawka_cli/src/commands.rs
+++ b/czkawka_cli/src/commands.rs
@@ -387,7 +387,7 @@ pub struct SameMusicArgs {
         long,
         default_value = "track_title,track_artist",
         value_parser = parse_music_duplicate_type,
-        help = "Search method (track_title,track_artist,year,bitrate,genre,length)",
+        help = "Search method (track_title,track_artist,track_album,year,bitrate,genre,length)",
         long_help = "Sets which rows must be equal to set these files as duplicates (may be mixed, but must be divided by commas)."
     )]
     pub music_similarity: MusicSimilarity,

--- a/czkawka_core/src/tools/same_music/core.rs
+++ b/czkawka_core/src/tools/same_music/core.rs
@@ -245,9 +245,10 @@ impl SameMusic {
         let mut new_duplicates: Vec<Vec<MusicEntry>> = Vec::new();
 
         let approximate = self.params.approximate_comparison;
-        let tag_checks: [(MusicSimilarity, fn(&MusicEntry) -> String, bool); 5] = [
+        let tag_checks: [(MusicSimilarity, fn(&MusicEntry) -> String, bool); 6] = [
             (MusicSimilarity::TRACK_TITLE, |fe| fe.track_title.clone(), approximate),
             (MusicSimilarity::TRACK_ARTIST, |fe| fe.track_artist.clone(), approximate),
+            (MusicSimilarity::TRACK_ALBUM, |fe| fe.track_album.clone(), approximate),
             (MusicSimilarity::YEAR, |fe| fe.year.clone(), false),
             (MusicSimilarity::LENGTH, |fe| format_audio_duration(fe.length), false),
             (MusicSimilarity::GENRE, |fe| fe.genre.clone(), false),
@@ -526,6 +527,7 @@ fn read_single_file_tags(path: &str, mut music_entry: MusicEntry) -> Option<Musi
 
     let mut track_title = String::new();
     let mut track_artist = String::new();
+    let mut track_album = String::new();
     let mut year = String::new();
     let mut genre = String::new();
 
@@ -534,6 +536,7 @@ fn read_single_file_tags(path: &str, mut music_entry: MusicEntry) -> Option<Musi
     if let Some(tag) = tagged_file.primary_tag() {
         track_title = tag.get_string(ItemKey::TrackTitle).unwrap_or_default().to_string();
         track_artist = tag.get_string(ItemKey::TrackArtist).unwrap_or_default().to_string();
+        track_album = tag.get_string(ItemKey::AlbumTitle).unwrap_or_default().to_string();
         year = tag.get_string(ItemKey::Year).unwrap_or_default().to_string();
         genre = tag.get_string(ItemKey::Genre).unwrap_or_default().to_string();
     }
@@ -548,6 +551,11 @@ fn read_single_file_tags(path: &str, mut music_entry: MusicEntry) -> Option<Musi
             && let Some(tag_value) = tag.get_string(ItemKey::TrackArtist)
         {
             track_artist = tag_value.to_string();
+        }
+        if track_album.is_empty()
+            && let Some(tag_value) = tag.get_string(ItemKey::AlbumTitle)
+        {
+            track_album = tag_value.to_string();
         }
         if year.is_empty()
             && let Some(tag_value) = tag.get_string(ItemKey::Year)
@@ -571,6 +579,7 @@ fn read_single_file_tags(path: &str, mut music_entry: MusicEntry) -> Option<Musi
 
     music_entry.track_title = track_title;
     music_entry.track_artist = track_artist;
+    music_entry.track_album = track_album;
     music_entry.year = year;
     music_entry.length = length_in_seconds;
     music_entry.genre = genre;

--- a/czkawka_core/src/tools/same_music/mod.rs
+++ b/czkawka_core/src/tools/same_music/mod.rs
@@ -23,10 +23,11 @@ bitflags! {
 
         const TRACK_TITLE = 0b1;
         const TRACK_ARTIST = 0b10;
-        const YEAR = 0b100;
-        const LENGTH = 0b1000;
-        const GENRE = 0b10000;
-        const BITRATE = 0b10_0000;
+        const TRACK_ALBUM = 0b100;
+        const YEAR = 0b1000;
+        const LENGTH = 0b1_0000;
+        const GENRE = 0b10_0000;
+        const BITRATE = 0b100_0000;
     }
 }
 
@@ -40,6 +41,7 @@ pub struct MusicEntry {
 
     pub track_title: String,
     pub track_artist: String,
+    pub track_album: String,
     pub year: String,
     pub length: u32,
     pub genre: String,
@@ -68,6 +70,7 @@ impl FileEntry {
             fingerprint: Vec::new(),
             track_title: String::new(),
             track_artist: String::new(),
+            track_album: String::new(),
             year: String::new(),
             length: 0,
             genre: String::new(),

--- a/czkawka_core/src/tools/same_music/tests.rs
+++ b/czkawka_core/src/tools/same_music/tests.rs
@@ -187,7 +187,7 @@ fn test_same_music_by_tags_all_criteria() {
     let test_path = get_test_resources_path();
 
     let params = SameMusicParameters::new(
-        MusicSimilarity::TRACK_TITLE | MusicSimilarity::TRACK_ARTIST | MusicSimilarity::YEAR | MusicSimilarity::GENRE,
+        MusicSimilarity::TRACK_TITLE | MusicSimilarity::TRACK_ARTIST | MusicSimilarity::TRACK_ALBUM | MusicSimilarity::YEAR | MusicSimilarity::GENRE,
         false,
         CheckingMethod::AudioTags,
         10.0,
@@ -290,6 +290,7 @@ fn test_same_music_reference_mode_deletes_only_non_reference() {
         fingerprint: Vec::new(),
         track_title: String::new(),
         track_artist: String::new(),
+        track_album: String::new(),
         year: String::new(),
         length: 0,
         genre: String::new(),

--- a/czkawka_core/src/tools/same_music/traits.rs
+++ b/czkawka_core/src/tools/same_music/traits.rs
@@ -138,9 +138,10 @@ impl PrintResults for SameMusic {
 fn write_music_entry<T: Write>(writer: &mut T, file_entry: &MusicEntry) -> std::io::Result<()> {
     writeln!(
         writer,
-        "TT: {}  -  TA: {}  -  Y: {}  -  L: {}  -  G: {}  -  B: {}  -  P: \"{}\"",
+        "TT: {}  -  TAr: {}  - TAl: {} -  Y: {}  -  L: {}  -  G: {}  -  B: {}  -  P: \"{}\"",
         file_entry.track_title,
         file_entry.track_artist,
+        file_entry.track_album,
         file_entry.year,
         format_audio_duration(file_entry.length),
         file_entry.genre,

--- a/czkawka_gui/i18n/en/czkawka_gui.ftl
+++ b/czkawka_gui/i18n/en/czkawka_gui.ftl
@@ -22,6 +22,7 @@ krokiet_info_message =
 # Main window
 music_title_checkbox = Title
 music_artist_checkbox = Artist
+music_album_checkbox = Album
 music_year_checkbox = Year
 music_bitrate_checkbox = Bitrate
 music_genre_checkbox = Genre

--- a/czkawka_gui/src/compute_results.rs
+++ b/czkawka_gui/src/compute_results.rs
@@ -302,6 +302,7 @@ fn compute_same_music(mf: SameMusic, entry_info: &Entry, text_view_errors: &Text
 
         let is_track_title = (MusicSimilarity::TRACK_TITLE & music_similarity) != MusicSimilarity::NONE;
         let is_track_artist = (MusicSimilarity::TRACK_ARTIST & music_similarity) != MusicSimilarity::NONE;
+        let is_track_album = (MusicSimilarity::TRACK_ALBUM & music_similarity) != MusicSimilarity::NONE;
         let is_year = (MusicSimilarity::YEAR & music_similarity) != MusicSimilarity::NONE;
         let is_bitrate = (MusicSimilarity::BITRATE & music_similarity) != MusicSimilarity::NONE;
         let is_length = (MusicSimilarity::LENGTH & music_similarity) != MusicSimilarity::NONE;
@@ -322,6 +323,7 @@ fn compute_same_music(mf: SameMusic, entry_info: &Entry, text_view_errors: &Text
                     base_file_entry.modified_date,
                     &base_file_entry.track_title,
                     &base_file_entry.track_artist,
+                    &base_file_entry.track_album,
                     &base_file_entry.year,
                     base_file_entry.bitrate,
                     &format!("{} kbps", base_file_entry.bitrate),
@@ -340,6 +342,7 @@ fn compute_same_music(mf: SameMusic, entry_info: &Entry, text_view_errors: &Text
                         file_entry.modified_date,
                         &file_entry.track_title,
                         &file_entry.track_artist,
+                        &file_entry.track_album,
                         &file_entry.year,
                         file_entry.bitrate,
                         &format!("{} kbps", file_entry.bitrate),
@@ -366,6 +369,7 @@ fn compute_same_music(mf: SameMusic, entry_info: &Entry, text_view_errors: &Text
                     0,
                     if is_track_title { text } else { "" },
                     if is_track_artist { text } else { "" },
+                    if is_track_album { text } else { "" },
                     if is_year { text } else { "" },
                     0,
                     if is_bitrate { text } else { "" },
@@ -384,6 +388,7 @@ fn compute_same_music(mf: SameMusic, entry_info: &Entry, text_view_errors: &Text
                         file_entry.modified_date,
                         &file_entry.track_title,
                         &file_entry.track_artist,
+                        &file_entry.track_album,
                         &file_entry.year,
                         file_entry.bitrate,
                         &format!("{} kbps", file_entry.bitrate),
@@ -1068,6 +1073,7 @@ fn same_music_add_to_list_store(
     modified_date: u64,
     track_title: &str,
     track_artist: &str,
+    track_album: &str,
     track_year: &str,
     track_bitrate: u32,
     bitrate_string: &str,
@@ -1076,7 +1082,7 @@ fn same_music_add_to_list_store(
     is_header: bool,
     is_reference_folder: bool,
 ) {
-    const COLUMNS_NUMBER: usize = 18;
+    const COLUMNS_NUMBER: usize = 19;
     let (size_str, string_date) = format_size_and_date(size, modified_date, is_header, is_reference_folder);
     let color = get_row_color(is_header);
 
@@ -1089,6 +1095,7 @@ fn same_music_add_to_list_store(
         (ColumnsSameMusic::Path as u32, &directory),
         (ColumnsSameMusic::Title as u32, &track_title),
         (ColumnsSameMusic::Artist as u32, &track_artist),
+        (ColumnsSameMusic::Album as u32, &track_album),
         (ColumnsSameMusic::Year as u32, &track_year),
         (ColumnsSameMusic::Genre as u32, &track_genre),
         (ColumnsSameMusic::Bitrate as u32, &bitrate_string),

--- a/czkawka_gui/src/connect_things/connect_button_search.rs
+++ b/czkawka_gui/src/connect_things/connect_button_search.rs
@@ -397,6 +397,7 @@ fn same_music_search(
 
     let check_button_music_artist: gtk4::CheckButton = gui_data.main_notebook.check_button_music_artist.clone();
     let check_button_music_title: gtk4::CheckButton = gui_data.main_notebook.check_button_music_title.clone();
+    let check_button_music_album: gtk4::CheckButton = gui_data.main_notebook.check_button_music_album.clone();
     let check_button_music_year: gtk4::CheckButton = gui_data.main_notebook.check_button_music_year.clone();
     let check_button_music_genre: gtk4::CheckButton = gui_data.main_notebook.check_button_music_genre.clone();
     let check_button_music_length: gtk4::CheckButton = gui_data.main_notebook.check_button_music_length.clone();
@@ -419,6 +420,9 @@ fn same_music_search(
     }
     if check_button_music_artist.is_active() {
         music_similarity |= MusicSimilarity::TRACK_ARTIST;
+    }
+    if check_button_music_album.is_active() {
+        music_similarity |= MusicSimilarity::TRACK_ALBUM;
     }
     if check_button_music_year.is_active() {
         music_similarity |= MusicSimilarity::YEAR;

--- a/czkawka_gui/src/gui_structs/gui_main_notebook.rs
+++ b/czkawka_gui/src/gui_structs/gui_main_notebook.rs
@@ -79,6 +79,7 @@ pub struct GuiMainNotebook {
     // Music
     pub check_button_music_title: CheckButton,
     pub check_button_music_artist: CheckButton,
+    pub check_button_music_album: CheckButton,
     pub check_button_music_year: CheckButton,
     pub check_button_music_bitrate: CheckButton,
     pub check_button_music_genre: CheckButton,
@@ -109,6 +110,7 @@ impl GuiMainNotebook {
         let check_button_duplicate_case_sensitive_name: CheckButton = builder.object("check_button_duplicate_case_sensitive_name").expect("Cambalache");
         let check_button_music_title: CheckButton = builder.object("check_button_music_title").expect("Cambalache");
         let check_button_music_artist: CheckButton = builder.object("check_button_music_artist").expect("Cambalache");
+        let check_button_music_album: CheckButton = builder.object("check_button_music_album").expect("Cambalache");
         let check_button_music_year: CheckButton = builder.object("check_button_music_year").expect("Cambalache");
         let check_button_music_bitrate: CheckButton = builder.object("check_button_music_bitrate").expect("Cambalache");
         let check_button_music_genre: CheckButton = builder.object("check_button_music_genre").expect("Cambalache");
@@ -221,6 +223,7 @@ impl GuiMainNotebook {
             check_button_broken_files_video,
             check_button_music_title,
             check_button_music_artist,
+            check_button_music_album,
             check_button_music_year,
             check_button_music_bitrate,
             check_button_music_genre,
@@ -245,6 +248,7 @@ impl GuiMainNotebook {
         self.check_button_duplicate_case_sensitive_name.set_label(Some(&flg!("duplicate_case_sensitive_name")));
         self.check_button_music_title.set_label(Some(&flg!("music_title_checkbox")));
         self.check_button_music_artist.set_label(Some(&flg!("music_artist_checkbox")));
+        self.check_button_music_album.set_label(Some(&flg!("music_album_checkbox")));
         self.check_button_music_year.set_label(Some(&flg!("music_year_checkbox")));
         self.check_button_music_bitrate.set_label(Some(&flg!("music_bitrate_checkbox")));
         self.check_button_music_genre.set_label(Some(&flg!("music_genre_checkbox")));

--- a/czkawka_gui/src/helpers/enums.rs
+++ b/czkawka_gui/src/helpers/enums.rs
@@ -181,6 +181,7 @@ pub enum ColumnsSameMusic {
     Path,
     Title,
     Artist,
+    Album,
     Year,
     Bitrate,
     BitrateAsNumber,

--- a/krokiet/i18n/en/krokiet.ftl
+++ b/krokiet/i18n/en/krokiet.ftl
@@ -107,6 +107,7 @@ column_dimensions = Dimensions
 column_new_dimensions = New Dimensions
 column_title = Title
 column_artist = Artist
+column_album = Album
 column_year = Year
 column_bitrate = Bitrate
 column_length = Length

--- a/krokiet/src/common.rs
+++ b/krokiet/src/common.rs
@@ -188,6 +188,7 @@ pub enum StrDataSimilarMusic {
     Name,
     Title,
     Artist,
+    Album,
     Year,
     Bitrate,
     Length,
@@ -407,6 +408,7 @@ impl ActiveTab {
                 | StrDataSimilarMusic::Path
                 | StrDataSimilarMusic::Title
                 | StrDataSimilarMusic::Artist
+                | StrDataSimilarMusic::Album
                 | StrDataSimilarMusic::Year
                 | StrDataSimilarMusic::Bitrate
                 | StrDataSimilarMusic::Length

--- a/krokiet/src/connect_scan/same_music.rs
+++ b/krokiet/src/connect_scan/same_music.rs
@@ -26,6 +26,9 @@ pub(crate) fn scan_similar_music(a: Weak<MainWindow>, sd: ScanData) {
             if sd.custom_settings.similar_music_sub_artist {
                 music_similarity |= MusicSimilarity::TRACK_ARTIST;
             }
+            if sd.custom_settings.similar_music_sub_album {
+                music_similarity |= MusicSimilarity::TRACK_ALBUM;
+            }
             if sd.custom_settings.similar_music_sub_bitrate {
                 music_similarity |= MusicSimilarity::BITRATE;
             }
@@ -132,6 +135,7 @@ fn prepare_data_model_similar_music(fe: MusicEntry) -> (ModelRc<SharedString>, M
         file.into(),
         fe.track_title.clone().into(),
         fe.track_artist.clone().into(),
+        fe.track_album.clone().into(),
         fe.year.clone().into(),
         fe.bitrate.to_string().into(),
         format_audio_duration(fe.length).into(),

--- a/krokiet/src/connect_select/custom_select.rs
+++ b/krokiet/src/connect_select/custom_select.rs
@@ -82,6 +82,7 @@ pub(super) fn build_custom_select_columns(active_tab: ActiveTab) -> Vec<CustomSe
     let dimensions = flk!("column_dimensions");
     let title = flk!("column_title");
     let artist = flk!("column_artist");
+    let album = flk!("column_album");
     let year = flk!("column_year");
     let bitrate = flk!("column_bitrate");
     let length = flk!("column_length");
@@ -159,6 +160,7 @@ pub(super) fn build_custom_select_columns(active_tab: ActiveTab) -> Vec<CustomSe
             col_str!(&path, StrDataSimilarMusic::Path),
             col_str!(&title, StrDataSimilarMusic::Title),
             col_str!(&artist, StrDataSimilarMusic::Artist),
+            col_str!(&album, StrDataSimilarMusic::Album),
             col_str!(&year, StrDataSimilarMusic::Year),
             col_str!(&genre, StrDataSimilarMusic::Genre),
             col_int_pair!(format!("{} [KB]", size), IntDataSimilarMusic::SizePart1),

--- a/krokiet/src/connect_translation.rs
+++ b/krokiet/src/connect_translation.rs
@@ -487,6 +487,7 @@ fn translate_items(app: &MainWindow) {
     let dimensions = flk!("column_dimensions");
     let title = flk!("column_title");
     let artist = flk!("column_artist");
+    let album = flk!("column_album");
     let year = flk!("column_year");
     let bitrate = flk!("column_bitrate");
     let length = flk!("column_length");
@@ -516,7 +517,9 @@ fn translate_items(app: &MainWindow) {
     settings.set_big_files_column_name(fnm(&[&selection, &size, &file_name, &path, &mod_date]));
     settings.set_similar_images_column_name(fnm(&[&selection, &similarity, &size, &dimensions, &file_name, &path, &mod_date]));
     settings.set_similar_videos_column_name(fnm(&[&selection, &size, &file_name, &path, &dimensions, &duration, &bitrate, &fps, &codec, &mod_date]));
-    settings.set_similar_music_column_name(fnm(&[&selection, &size, &file_name, &title, &artist, &year, &bitrate, &length, &genre, &path, &mod_date]));
+    settings.set_similar_music_column_name(fnm(&[
+        &selection, &size, &file_name, &title, &artist, &album, &year, &bitrate, &length, &genre, &path, &mod_date,
+    ]));
     settings.set_invalid_symlink_column_name(fnm(&[&selection, &symlink_name, &symlink_folder, &destination_path, &mod_date]));
     settings.set_broken_files_column_name(fnm(&[&selection, &file_name, &path, &type_of_error, &size, &mod_date]));
     settings.set_bad_extensions_column_name(fnm(&[&selection, &file_name, &path, &current_extension, &proper_extension]));

--- a/krokiet/src/settings/mod.rs
+++ b/krokiet/src/settings/mod.rs
@@ -533,6 +533,7 @@ pub(crate) fn set_settings_to_gui(app: &MainWindow, custom_settings: &SettingsCu
     settings.set_similar_music_sub_approximate_comparison(custom_settings.similar_music_sub_approximate_comparison);
     settings.set_similar_music_sub_title(custom_settings.similar_music_sub_title);
     settings.set_similar_music_sub_artist(custom_settings.similar_music_sub_artist);
+    settings.set_similar_music_sub_album(custom_settings.similar_music_sub_album);
     settings.set_similar_music_sub_year(custom_settings.similar_music_sub_year);
     settings.set_similar_music_sub_bitrate(custom_settings.similar_music_sub_bitrate);
     settings.set_similar_music_sub_genre(custom_settings.similar_music_sub_genre);
@@ -619,7 +620,7 @@ pub(crate) fn set_settings_to_gui(app: &MainWindow, custom_settings: &SettingsCu
         settings.set_big_files_column_size(fnm(&[sel_px, size_px, name_px, path_px, mod_px], "big_files"));
         settings.set_similar_images_column_size(fnm(&[sel_px, 80.0, 80.0, 80.0, name_px, path_px, mod_px], "similar_images"));
         settings.set_similar_videos_column_size(fnm(&[sel_px, size_px, name_px, path_px, 80.0, 80.0, 80.0, 80.0, 80.0, mod_px], "similar_videos"));
-        settings.set_similar_music_column_size(fnm(&[sel_px, size_px, name_px, 80.0, 80.0, 80.0, 80.0, 80.0, 80.0, path_px, mod_px], "similar_music"));
+        settings.set_similar_music_column_size(fnm(&[sel_px, size_px, name_px, 80.0, 80.0, 80.0, 80.0, 80.0, 80.0, 80.0, path_px, mod_px], "similar_music"));
         settings.set_invalid_symlink_column_size(fnm(&[sel_px, name_px, path_px, path_px, mod_px], "invalid_symlink"));
         settings.set_broken_files_column_size(fnm(&[sel_px, name_px, path_px, 200.0, size_px, mod_px], "broken_files"));
         settings.set_bad_extensions_column_size(fnm(&[sel_px, name_px, path_px, 40.0, 200.0], "bad_extensions"));
@@ -718,6 +719,7 @@ pub(crate) fn collect_settings(app: &MainWindow) -> SettingsCustom {
     let similar_music_sub_approximate_comparison = settings.get_similar_music_sub_approximate_comparison();
     let similar_music_sub_title = settings.get_similar_music_sub_title();
     let similar_music_sub_artist = settings.get_similar_music_sub_artist();
+    let similar_music_sub_album = settings.get_similar_music_sub_album();
     let similar_music_sub_year = settings.get_similar_music_sub_year();
     let similar_music_sub_bitrate = settings.get_similar_music_sub_bitrate();
     let similar_music_sub_genre = settings.get_similar_music_sub_genre();
@@ -855,6 +857,7 @@ pub(crate) fn collect_settings(app: &MainWindow) -> SettingsCustom {
         similar_music_compare_fingerprints_only_with_similar_titles,
         similar_music_sub_title,
         similar_music_sub_artist,
+        similar_music_sub_album,
         similar_music_sub_year,
         similar_music_sub_bitrate,
         similar_music_sub_genre,

--- a/krokiet/src/settings/model.rs
+++ b/krokiet/src/settings/model.rs
@@ -128,6 +128,8 @@ pub struct SettingsCustom {
     pub similar_music_sub_title: bool,
     #[serde(default = "ttrue")]
     pub similar_music_sub_artist: bool,
+    #[serde(default = "ttrue")]
+    pub similar_music_sub_album: bool,
     #[serde(default)]
     pub similar_music_sub_year: bool,
     #[serde(default)]

--- a/krokiet/ui/globals/settings.slint
+++ b/krokiet/ui/globals/settings.slint
@@ -148,6 +148,7 @@ export global Settings {
     in-out property <bool> similar_music_sub_approximate_comparison;
     in-out property <bool> similar_music_sub_title: true;
     in-out property <bool> similar_music_sub_artist: true;
+    in-out property <bool> similar_music_sub_album: true;
     in-out property <bool> similar_music_sub_year: false;
     in-out property <bool> similar_music_sub_bitrate: false;
     in-out property <bool> similar_music_sub_genre: false;
@@ -305,8 +306,8 @@ export global Settings {
     in-out property <[length]> similar_images_column_size: [35px, 80px, 80px, 80px, name_px, path_px, mod_px];
     in-out property <[string]> similar_videos_column_name: ["Selection", "Size", "File Name", "Path", "Dimensions", "Duration", "Bitrate", "Fps", "Codec", "Modification Date"];
     in-out property <[length]> similar_videos_column_size: [35px, size_px, name_px, path_px, 80px, 30px, 30px, 80px, 80px, mod_px];
-    in-out property <[string]> similar_music_column_name: ["Selection", "Size", "File Name", "Title", "Artist", "Year", "Bitrate", "Length", "Genre", "Path", "Modification Date"];
-    in-out property <[length]> similar_music_column_size: [35px, size_px, name_px, 80px, 80px, 80px, 80px, 80px, 80px, path_px, mod_px];
+    in-out property <[string]> similar_music_column_name: ["Selection", "Size", "File Name", "Title", "Artist", "Album", "Year", "Bitrate", "Length", "Genre", "Path", "Modification Date"];
+    in-out property <[length]> similar_music_column_size: [35px, size_px, name_px, 80px, 80px, 80px, 80px, 80px, 80px, 80px, path_px, mod_px];
     in-out property <[string]> invalid_symlink_column_name: ["Selection", "Symlink Name", "Symlink Folder", "Destination Path", "Modification Date"];
     in-out property <[length]> invalid_symlink_column_size: [35px, name_px, path_px, path_px, mod_px];
     in-out property <[string]> broken_files_column_name: ["Selection", "File Name", "Path", "Type of Error", "Size", "Modification Date"];

--- a/krokiet/ui/globals/translations.slint
+++ b/krokiet/ui/globals/translations.slint
@@ -138,6 +138,7 @@ export global Translations {
     in-out property <string> subsettings_music_compared_tags_text: "Compared tags";
     in-out property <string> subsettings_music_title_text: "Title";
     in-out property <string> subsettings_music_artist_text: "Artist";
+    in-out property <string> subsettings_music_album_text: "Album";
     in-out property <string> subsettings_music_bitrate_text: "Bitrate";
     in-out property <string> subsettings_music_genre_text: "Genre";
     in-out property <string> subsettings_music_year_text: "Year";

--- a/krokiet/ui/screens/tool_settings.slint
+++ b/krokiet/ui/screens/tool_settings.slint
@@ -434,6 +434,11 @@ export component ToolSettings {
                 }
 
                 CheckBoxWrapper {
+                    text: Translations.subsettings_music_album_text;
+                    checked <=> Settings.similar_music_sub_album;
+                }
+
+                CheckBoxWrapper {
                     text: Translations.subsettings_music_bitrate_text;
                     checked <=> Settings.similar_music_sub_bitrate;
                 }


### PR DESCRIPTION
This feature allows czkawka to distinguish between songs with the same name but released on different albums, ensuring more precise track grouping and preventing incorrect associations. For example, you might have a collection of music from a band that also has a live album. Using album matching will help prevent erroneous groupings being made for songs that are technically different from one another.

This follows the same "approximate" logic of the other string-based tag options like `TRACK_ARTIST` and `TRACK_TITLE`. This means there's still some chance of false-postives in duplicate detect for audiophiles. For example, `Goodbye Yellow Brick Road` and `Goodbye Yellow Brick Road (20XX Remaster)` can be detected to be the "same" even if they're not technically the same. Edit: To clarify, it will still do exact matching on album name if you desire it. But all three tags share the same setting toggle. 

It might be nice long term if we could select the matching algorithm to either be exact or approximate on a per-tag basis.  