### PR TITLE
Fix popup OK/Close button truncation if the text is too long (#2028)

### DIFF
--- a/krokiet/ui/components/popup_base.slint
+++ b/krokiet/ui/components/popup_base.slint
@@ -9,20 +9,22 @@ export component PopupBase inherits PopupWindow {
     in-out property <string> cancel_text <=> Translations.cancel_button_text;
     in-out property <bool> enabled_ok_button: true;
     in-out property <bool> show_cancel_button: true;
+    in property <length> popup_min_height: 0px;
 
     callback ok_clicked();
     callback cancel_clicked();
 
+    height: max(popup_min_height, vlayout.preferred-height);
     close-policy: PopupClosePolicy.no-auto-close;
     rect := Rectangle {
-        width: parent.width;
-        height: parent.height;
+        width: 100%;
+        height: 100%;
         border-radius: 10px;
         border-color: ColorPalette.popup_border_color;
         border-width: 2px;
         background: ColorPalette.popup_background;
         clip: true;
-        VerticalLayout {
+        vlayout := VerticalLayout {
             Rectangle {
                 background: ColorPalette.popup_background_title_line;
 

--- a/krokiet/ui/main_window.slint
+++ b/krokiet/ui/main_window.slint
@@ -238,9 +238,7 @@ export component MainWindow inherits Window {
     new_directory_popup_window := PopupNewDirectories {
         height: root.height;
         width: root.width;
-
-        x: parent.x + (root.width - self.popup_width) / 2.0;
-        y: parent.y + (parent.height - self.popup_height) / 2.0;
+        x: 0.0; y: 0.0;
     }
 
     select_popup_window := PopupSelectResults {
@@ -258,72 +256,55 @@ export component MainWindow inherits Window {
     custom_select_popup_window := PopupCustomSelect {
         height: root.height;
         width: root.width;
-        x: parent.x + (root.width - self.popup_width) / 2.0;
-        y: parent.y + (parent.height - self.popup_height) / 2.0;
+        x: 0.0; y: 0.0;
     }
 
     delete_popup_window := PopupDelete {
         height: root.height;
         width: root.width;
-
-        x: parent.x + (root.width - self.popup_width) / 2.0;
-        y: parent.y + (parent.height - self.popup_height) / 2.0;
+        x: 0.0; y: 0.0;
     }
 
     trash_popup_window := PopupTrash {
         height: root.height;
         width: root.width;
-
-        x: parent.x + (root.width - self.popup_width) / 2.0;
-        y: parent.y + (parent.height - self.popup_height) / 2.0;
+        x: 0.0; y: 0.0;
     }
 
     move_popup_window := PopupMoveFolders {
         height: root.height;
         width: root.width;
-
-        x: parent.x + (root.width - self.popup_width) / 2.0;
-        y: parent.y + (parent.height - self.popup_height) / 2.0;
+        x: 0.0; y: 0.0;
     }
 
     rename_extension_popup_window := PopupRenameBadExtensions {
         height: root.height;
         width: root.width;
-
-        x: parent.x + (root.width - self.popup_width) / 2.0;
-        y: parent.y + (parent.height - self.popup_height) / 2.0;
+        x: 0.0; y: 0.0;
     }
 
     rename_bad_file_name_popup_window := PopupRenameBadFileNames {
         height: root.height;
         width: root.width;
-
-        x: parent.x + (root.width - self.popup_width) / 2.0;
-        y: parent.y + (parent.height - self.popup_height) / 2.0;
+        x: 0.0; y: 0.0;
     }
 
     rename_file_popup_window := PopupRenameFile {
         height: root.height;
         width: root.width;
-
-        x: parent.x + (root.width - self.popup_width) / 2.0;
-        y: parent.y + (parent.height - self.popup_height) / 2.0;
+        x: 0.0; y: 0.0;
     }
 
     error_popup_window := PopupError {
         height: root.height;
         width: root.width;
-
-        x: parent.x + (root.width - self.popup_width) / 2.0;
-        y: parent.y + (parent.height - self.popup_height) / 2.0;
+        x: 0.0; y: 0.0;
     }
 
     save_popup_window := PopupSave {
         height: root.height;
         width: root.width;
-
-        x: parent.x + (root.width - self.popup_width) / 2.0;
-        y: parent.y + (parent.height - self.popup_height) / 2.0;
+        x: 0.0; y: 0.0;
     }
 
     sort_popup_window := PopupSortResults {
@@ -338,10 +319,8 @@ export component MainWindow inherits Window {
     clean_popup_window := PopupCleanExif {
         height: root.height;
         width: root.width;
+        x: 0.0; y: 0.0;
         title_text: Translations.clean_text;
-
-        x: parent.x + (root.width - self.popup_width) / 2.0;
-        y: parent.y + (parent.height - self.popup_height) / 2.0;
 
         action_confirmed() => {
             Callabler.clean_exif_items();
@@ -351,9 +330,7 @@ export component MainWindow inherits Window {
     clean_cache_popup_window := PopupCleanCache {
         height: root.height;
         width: root.width;
-
-        x: parent.x + (root.width - self.popup_width) / 2.0;
-        y: parent.y + (parent.height - self.popup_height) / 2.0;
+        x: 0.0; y: 0.0;
 
         start_cleaning() => {
             Callabler.start_cache_cleaning();
@@ -367,18 +344,14 @@ export component MainWindow inherits Window {
     other_apps_popup_window := PopupOtherApps {
         height: root.height;
         width: root.width;
-
-        x: parent.x + (root.width - self.popup_width) / 2.0;
-        y: parent.y + (parent.height - self.popup_height) / 2.0;
+        x: 0.0; y: 0.0;
     }
 
     crop_video_popup_window := PopupCropVideo {
         height: root.height;
         width: root.width;
+        x: 0.0; y: 0.0;
         title_text: Translations.crop_videos_text;
-
-        x: parent.x + (root.width - self.popup_width) / 2.0;
-        y: parent.y + (parent.height - self.popup_height) / 2.0;
 
         action_confirmed() => {
             Callabler.crop_video_items();
@@ -388,10 +361,8 @@ export component MainWindow inherits Window {
     reencode_video_popup_window := PopupReencodeVideo {
         height: root.height;
         width: root.width;
+        x: 0.0; y: 0.0;
         title_text: Translations.reencode_videos_text;
-
-        x: parent.x + (root.width - self.popup_width) / 2.0;
-        y: parent.y + (parent.height - self.popup_height) / 2.0;
 
         action_confirmed() => {
             Callabler.reencode_video_items();
@@ -401,11 +372,9 @@ export component MainWindow inherits Window {
     hardlink_popup_window := PopupActionConfirm {
         height: root.height;
         width: root.width;
+        x: 0.0; y: 0.0;
         title_text: Translations.hardlink_text;
         confirmation_text: Translations.hardlink_confirmation_text;
-
-        x: parent.x + (root.width - self.popup_width) / 2.0;
-        y: parent.y + (parent.height - self.popup_height) / 2.0;
 
         action_confirmed => {
             Callabler.hardlink_items();
@@ -415,11 +384,9 @@ export component MainWindow inherits Window {
     softlink_popup_window := PopupActionConfirm {
         height: root.height;
         width: root.width;
+        x: 0.0; y: 0.0;
         title_text: Translations.softlink_text;
         confirmation_text: Translations.softlink_confirmation_text;
-
-        x: parent.x + (root.width - self.popup_width) / 2.0;
-        y: parent.y + (parent.height - self.popup_height) / 2.0;
 
         action_confirmed => {
             Callabler.softlink_items();

--- a/krokiet/ui/popups/popup_action_confirm.slint
+++ b/krokiet/ui/popups/popup_action_confirm.slint
@@ -6,13 +6,15 @@ export component PopupActionConfirm inherits Rectangle {
     in-out property <string> confirmation_text;
     callback action_confirmed();
 
-    out property <length> popup_width: 350px;
-    out property <length> popup_height: 150px;
+    private property <length> popup_width: 350px;
+    private property <length> popup_min_height: 150px;
     callback show_popup();
 
     popup_window := PopupBase {
         width: popup_width;
-        height: popup_height;
+        popup_min_height: popup_min_height;
+        x: (parent.width - popup_width) / 2.0;
+        y: (parent.height - self.height) / 2.0;
         title_text <=> root.title_text;
 
         VerticalLayout {

--- a/krokiet/ui/popups/popup_clean_cache.slint
+++ b/krokiet/ui/popups/popup_clean_cache.slint
@@ -11,12 +11,14 @@ export component PopupCleanCache inherits Rectangle {
 
     in-out property <bool> stopped_by_user: false;
 
-    out property <length> popup_width: 500px;
-    out property <length> popup_height: 300px;
+    private property <length> popup_width: 500px;
+    private property <length> popup_height: 300px;
 
     popup_window := PopupWindow {
         width: popup_width;
         height: popup_height;
+        x: (parent.width - popup_width) / 2.0;
+        y: (parent.height - self.height) / 2.0;
         close-policy: PopupClosePolicy.no-auto-close;
 
         Rectangle {

--- a/krokiet/ui/popups/popup_clean_exif.slint
+++ b/krokiet/ui/popups/popup_clean_exif.slint
@@ -9,13 +9,15 @@ export component PopupCleanExif inherits Rectangle {
 
     callback action_confirmed();
 
-    out property <length> popup_width: 420px;
-    out property <length> popup_height: 200px;
+    private property <length> popup_width: 420px;
+    private property <length> popup_min_height: 200px;
     callback show_popup();
 
     popup_window := PopupBase {
         width: popup_width;
-        height: popup_height;
+        popup_min_height: popup_min_height;
+        x: (parent.width - popup_width) / 2.0;
+        y: (parent.height - self.height) / 2.0;
         title_text <=> root.title_text;
 
         VerticalLayout {

--- a/krokiet/ui/popups/popup_crop_video.slint
+++ b/krokiet/ui/popups/popup_crop_video.slint
@@ -10,13 +10,15 @@ export component PopupCropVideo inherits Rectangle {
 
     callback action_confirmed();
 
-    out property <length> popup_width: 440px;
-    out property <length> popup_height: 320px;
+    private property <length> popup_width: 440px;
+    private property <length> popup_min_height: 320px;
     callback show_popup();
 
     popup_window := PopupBase {
         width: popup_width;
-        height: popup_height;
+        popup_min_height: popup_min_height;
+        x: (parent.width - popup_width) / 2.0;
+        y: (parent.height - self.height) / 2.0;
         title_text <=> root.title_text;
 
         VerticalLayout {

--- a/krokiet/ui/popups/popup_custom_select.slint
+++ b/krokiet/ui/popups/popup_custom_select.slint
@@ -8,8 +8,8 @@ import { GuiState } from "../globals/gui_state.slint";
 import { Settings } from "../globals/settings.slint";
 
 export component PopupCustomSelect inherits Rectangle {
-    out property <length> popup_width: 620px;
-    out property <length> popup_height: 540px;
+    private property <length> popup_width: 620px;
+    private property <length> popup_height: 540px;
     callback show_popup();
     private property <bool> case_sensitive: false;
     private property <bool> leave_one_in_group: true;
@@ -26,6 +26,8 @@ export component PopupCustomSelect inherits Rectangle {
     popup_window := PopupWindow {
         width: popup_width;
         height: popup_height;
+        x: (parent.width - popup_width) / 2.0;
+        y: (parent.height - self.height) / 2.0;
         close-policy: PopupClosePolicy.no-auto-close;
         Rectangle {
             width: parent.width;

--- a/krokiet/ui/popups/popup_delete.slint
+++ b/krokiet/ui/popups/popup_delete.slint
@@ -4,13 +4,15 @@ import { PopupBase } from "../components/popup_base.slint";
 import { PopupCenteredText } from "../components/popup_centered_text.slint";
 
 export component PopupDelete inherits Rectangle {
-    out property <length> popup_width: 350px;
-    out property <length> popup_height: 150px;
+    private property <length> popup_width: 350px;
+    private property <length> popup_min_height: 150px;
     callback show_popup();
 
     popup_window := PopupBase {
         width: popup_width;
-        height: popup_height;
+        popup_min_height: popup_min_height;
+        x: (parent.width - popup_width) / 2.0;
+        y: (parent.height - self.height) / 2.0;
         title_text <=> Translations.delete_text;
 
         VerticalLayout {

--- a/krokiet/ui/popups/popup_error.slint
+++ b/krokiet/ui/popups/popup_error.slint
@@ -6,14 +6,16 @@ import { PopupCenteredText } from "../components/popup_centered_text.slint";
 // Used to make failed actions (e.g. a rename that could not be completed) visible to the user,
 // instead of only logging them to the console / hidden bottom panel.
 export component PopupError inherits Rectangle {
-    out property <length> popup_width: 450px;
-    out property <length> popup_height: 190px;
+    private property <length> popup_width: 450px;
+    private property <length> popup_min_height: 190px;
     private property <string> message_text;
     callback show_popup(string);
 
     popup_window := PopupBase {
         width: popup_width;
-        height: popup_height;
+        popup_min_height: popup_min_height;
+        x: (parent.width - popup_width) / 2.0;
+        y: (parent.height - self.height) / 2.0;
         title_text <=> Translations.popup_error_title_text;
         show_cancel_button: false;
 

--- a/krokiet/ui/popups/popup_move_folders.slint
+++ b/krokiet/ui/popups/popup_move_folders.slint
@@ -6,14 +6,16 @@ import { PopupCenteredText } from "../components/popup_centered_text.slint";
 import { Settings } from "../globals/settings.slint";
 
 export component PopupMoveFolders inherits Rectangle {
-    out property <length> popup_width: 500px;
-    out property <length> popup_height: 190px;
+    private property <length> popup_width: 500px;
+    private property <length> popup_min_height: 190px;
     in-out property <string> folder_name: "";
     callback show_popup();
 
     popup_window := PopupBase {
         width: popup_width;
-        height: popup_height;
+        popup_min_height: popup_min_height;
+        x: (parent.width - popup_width) / 2.0;
+        y: (parent.height - self.height) / 2.0;
         title_text <=> Translations.popup_move_title_text;
 
         VerticalLayout {

--- a/krokiet/ui/popups/popup_new_directories.slint
+++ b/krokiet/ui/popups/popup_new_directories.slint
@@ -5,8 +5,8 @@ import { PopupBase } from "../components/popup_base.slint";
 import { GuiState } from "../globals/gui_state.slint";
 
 export component PopupNewDirectories inherits Rectangle {
-    out property <length> popup_width: 350px;
-    out property <length> popup_height: 200px;
+    private property <length> popup_width: 350px;
+    private property <length> popup_min_height: 200px;
     callback show_popup();
 
     property <bool> included_paths;
@@ -14,7 +14,9 @@ export component PopupNewDirectories inherits Rectangle {
 
     popup_window := PopupBase {
         width: popup_width;
-        height: popup_height;
+        popup_min_height: popup_min_height;
+        x: (parent.width - popup_width) / 2.0;
+        y: (parent.height - self.height) / 2.0;
         title_text <=> Translations.popup_new_directories_title_text;
         enabled_ok_button: text_data != "";
 

--- a/krokiet/ui/popups/popup_optimize.slint
+++ b/krokiet/ui/popups/popup_optimize.slint
@@ -13,13 +13,15 @@ export component PopupReencodeVideo inherits Rectangle {
 
     callback action_confirmed();
 
-    out property <length> popup_width: 460px;
-    out property <length> popup_height: 600px;
+    private property <length> popup_width: 460px;
+    private property <length> popup_min_height: 600px;
     callback show_popup();
 
     popup_window := PopupBase {
         width: popup_width;
-        height: popup_height;
+        popup_min_height: popup_min_height;
+        x: (parent.width - popup_width) / 2.0;
+        y: (parent.height - self.height) / 2.0;
         title_text <=> root.title_text;
 
         VerticalLayout {

--- a/krokiet/ui/popups/popup_other_apps.slint
+++ b/krokiet/ui/popups/popup_other_apps.slint
@@ -52,8 +52,8 @@ component AppRow inherits Rectangle {
 export component PopupOtherApps inherits Rectangle {
     callback show_popup();
 
-    out property <length> popup_width: 520px;
-    out property <length> popup_height: 420px;
+    private property <length> popup_width: 520px;
+    private property <length> popup_height: 420px;
 
     property <[OtherApp]> apps: [
         { name: "Szyszka",               url: "https://github.com/qarmin/szyszka" },
@@ -67,6 +67,8 @@ export component PopupOtherApps inherits Rectangle {
     popup_window := PopupWindow {
         width: popup_width;
         height: popup_height;
+        x: (parent.width - popup_width) / 2.0;
+        y: (parent.height - self.height) / 2.0;
         close-policy: PopupClosePolicy.no-auto-close;
 
         Rectangle {

--- a/krokiet/ui/popups/popup_rename_bad_extensions.slint
+++ b/krokiet/ui/popups/popup_rename_bad_extensions.slint
@@ -4,13 +4,15 @@ import { PopupBase } from "../components/popup_base.slint";
 import { PopupCenteredText } from "../components/popup_centered_text.slint";
 
 export component PopupRenameBadExtensions inherits Rectangle {
-    out property <length> popup_width: 500px;
-    out property <length> popup_height: 150px;
+    private property <length> popup_width: 500px;
+    private property <length> popup_min_height: 150px;
     callback show_popup();
 
     popup_window := PopupBase {
         width: popup_width;
-        height: popup_height;
+        popup_min_height: popup_min_height;
+        x: (parent.width - popup_width) / 2.0;
+        y: (parent.height - self.height) / 2.0;
         title_text <=> Translations.popup_rename_title_text;
 
         VerticalLayout {

--- a/krokiet/ui/popups/popup_rename_bad_file_names.slint
+++ b/krokiet/ui/popups/popup_rename_bad_file_names.slint
@@ -4,13 +4,15 @@ import { PopupBase } from "../components/popup_base.slint";
 import { PopupCenteredText } from "../components/popup_centered_text.slint";
 
 export component PopupRenameBadFileNames inherits Rectangle {
-    out property <length> popup_width: 500px;
-    out property <length> popup_height: 150px;
+    private property <length> popup_width: 500px;
+    private property <length> popup_min_height: 150px;
     callback show_popup();
 
     popup_window := PopupBase {
         width: popup_width;
-        height: popup_height;
+        popup_min_height: popup_min_height;
+        x: (parent.width - popup_width) / 2.0;
+        y: (parent.height - self.height) / 2.0;
         title_text <=> Translations.popup_rename_title_text;
 
         VerticalLayout {

--- a/krokiet/ui/popups/popup_rename_file.slint
+++ b/krokiet/ui/popups/popup_rename_file.slint
@@ -6,8 +6,8 @@ import { ColorPalette } from "../globals/color_palette.slint";
 import { PopupBase } from "../components/popup_base.slint";
 
 export component PopupRenameFile inherits Rectangle {
-    out property <length> popup_width: 500px;
-    out property <length> popup_height: 185px;
+    private property <length> popup_width: 500px;
+    private property <length> popup_min_height: 185px;
     in-out property <int> row_idx: -1;
     private property <string> original_name;
     private property <string> text_data;
@@ -26,7 +26,9 @@ export component PopupRenameFile inherits Rectangle {
 
     popup_window := PopupBase {
         width: popup_width;
-        height: popup_height;
+        popup_min_height: popup_min_height;
+        x: (parent.width - popup_width) / 2.0;
+        y: (parent.height - self.height) / 2.0;
         title_text <=> Translations.popup_rename_single_title_text;
         enabled_ok_button: !name_empty && !name_unchanged && !target_exists;
 

--- a/krokiet/ui/popups/popup_save.slint
+++ b/krokiet/ui/popups/popup_save.slint
@@ -4,13 +4,15 @@ import { PopupBase } from "../components/popup_base.slint";
 import { PopupCenteredText } from "../components/popup_centered_text.slint";
 
 export component PopupSave inherits Rectangle {
-    out property <length> popup_width: 500px;
-    out property <length> popup_height: 150px;
+    private property <length> popup_width: 500px;
+    private property <length> popup_min_height: 150px;
     callback show_popup();
 
     popup_window := PopupBase {
         width: popup_width;
-        height: popup_height;
+        popup_min_height: popup_min_height;
+        x: (parent.width - popup_width) / 2.0;
+        y: (parent.height - self.height) / 2.0;
         title_text <=> Translations.popup_save_title_text;
 
         VerticalLayout {

--- a/krokiet/ui/popups/popup_trash.slint
+++ b/krokiet/ui/popups/popup_trash.slint
@@ -4,13 +4,15 @@ import { PopupBase } from "../components/popup_base.slint";
 import { PopupCenteredText } from "../components/popup_centered_text.slint";
 
 export component PopupTrash inherits Rectangle {
-    out property <length> popup_width: 400px;
-    out property <length> popup_height: 200px;
+    private property <length> popup_width: 400px;
+    private property <length> popup_min_height: 200px;
     callback show_popup();
 
     popup_window := PopupBase {
         width: popup_width;
-        height: popup_height;
+        popup_min_height: popup_min_height;
+        x: (parent.width - popup_width) / 2.0;
+        y: (parent.height - self.height) / 2.0;
         title_text <=> Translations.trash_text;
 
         VerticalLayout {


### PR DESCRIPTION
## Issue fix
`PopupTrash` had a hardcoded `popup_height` which is not enough to fit long translations. To fix it we can pass the minimum height into `PopupBase` and it will choose the maximum of `popup_min_height` and its text's preferred height.
This change was applied to all popups that use `PopupBase`.

## Popup centering
Types like `PopupTrash` have the size of the main window and contain a smaller popup window. Previously, the popup was placed in container's top-left corner and we were centering the container itself.
I placed most of the popup containers that use `PopupBase` or `PopupWindow` at (0, 0) and applied the centering to the popup inside.

Fixes #2028 
