### PR TITLE
Reject perceptual hashes that encode no spatial content

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+## Version 12.0.2 - 03.09.2026r
+
+### Core
+- Fixed unrelated images that consist of one light and one dark region being grouped as identical - such images produced a perceptual hash encoding only the position of the split, so they collided at distance 0 regardless of hash size - [#2059](https://github.com/qarmin/czkawka/pull/2059)
+
 ## Version 12.0.1 - 29.07.2026r
 
 ### Core

--- a/czkawka_core/src/tools/similar_images/core.rs
+++ b/czkawka_core/src/tools/similar_images/core.rs
@@ -21,7 +21,10 @@ use crate::common::progress_data::{ProgressData, SimilarImagesStage, ToolStage};
 use crate::common::progress_stop_handler::{check_if_stop_received, prepare_thread_handler_common};
 use crate::common::tool_data::{CommonData, CommonToolData};
 use crate::flc;
-use crate::tools::similar_images::{GeometricInvariance, Hamming, ImHash, ImagesEntry, SIMILAR_VALUES, SimilarImages, SimilarImagesParameters, SimilarityPreset};
+use crate::tools::similar_images::{
+    GeometricInvariance, Hamming, ImHash, ImagesEntry, MIN_DISTINCT_HASH_LINES, MIN_HASH_SIZE_FOR_STRUCTURE_CHECK, SIMILAR_VALUES, SimilarImages, SimilarImagesParameters,
+    SimilarityPreset,
+};
 
 impl SimilarImages {
     pub fn new(params: SimilarImagesParameters) -> Self {
@@ -205,7 +208,7 @@ impl SimilarImages {
         let entry_for_map = ImagesEntry { hashes: Vec::new(), ..file_entry };
 
         for hash in hashes {
-            if !Self::is_hash_valid(&hash) {
+            if !Self::is_hash_valid(&hash, self.get_params().hash_size) {
                 continue;
             }
             let vec_entry = self.image_hashes.entry(hash).or_default();
@@ -249,8 +252,11 @@ impl SimilarImages {
         hashes.into_iter().collect()
     }
 
-    fn is_hash_valid(hash: &ImHash) -> bool {
-        !(hash.is_empty() || hash.iter().all(|e| *e == 0) || hash.iter().all(|e| *e == 255))
+    pub(crate) fn is_hash_valid(hash: &ImHash, hash_size: u8) -> bool {
+        if hash.is_empty() || hash.iter().all(|e| *e == 0) || hash.iter().all(|e| *e == 255) {
+            return false;
+        }
+        hash_has_spatial_structure(hash, hash_size)
     }
 
     // Split hashes at 2 parts, base hashes and hashes to compare, 3 argument is set of hashes with multiple images
@@ -758,6 +764,44 @@ impl DisjointSet {
 
 fn is_in_reference_folder(reference_directories: &[PathBuf], path: &Path) -> bool {
     reference_directories.iter().any(|e| path.starts_with(e))
+}
+
+/// Rejects hashes that encode no spatial content.
+///
+/// An image made of one light and one dark region hashes to a bit matrix whose rows (or
+/// columns) are all identical, because every block on one side of the split lands on the
+/// same side of the algorithm's threshold and the actual content never crosses it. Such a
+/// hash records only where the split is, so unrelated images collide at distance 0.
+///
+/// Only square `hash_size x hash_size` layouts can be inspected this way, and only from
+/// hash size 16 up - an 8x8 matrix has too few lines to tell a degenerate hash from a
+/// legitimately simple image.
+fn hash_has_spatial_structure(hash: &ImHash, hash_size: u8) -> bool {
+    let side = hash_size as usize;
+    if hash_size < MIN_HASH_SIZE_FOR_STRUCTURE_CHECK || side > u64::BITS as usize || hash.len() * 8 != side * side {
+        return true;
+    }
+
+    let mut rows: Vec<u64> = Vec::with_capacity(side);
+    let mut columns: Vec<u64> = vec![0; side];
+    for row_idx in 0..side {
+        let mut row = 0;
+        for (col_idx, column) in columns.iter_mut().enumerate() {
+            let bit_idx = row_idx * side + col_idx;
+            let byte = hash.get(bit_idx / 8).copied().unwrap_or_default();
+            let bit = u64::from((byte >> (7 - (bit_idx % 8))) & 1);
+            row = (row << 1) | bit;
+            *column = (*column << 1) | bit;
+        }
+        rows.push(row);
+    }
+
+    rows.sort_unstable();
+    rows.dedup();
+    columns.sort_unstable();
+    columns.dedup();
+
+    rows.len() >= MIN_DISTINCT_HASH_LINES && columns.len() >= MIN_DISTINCT_HASH_LINES
 }
 
 #[expect(clippy::indexing_slicing)] // Because hash size is validated before

--- a/czkawka_core/src/tools/similar_images/mod.rs
+++ b/czkawka_core/src/tools/similar_images/mod.rs
@@ -23,6 +23,12 @@ use crate::common::traits::ResultEntry;
 type ImHash = Vec<u8>;
 
 // 40 is a little useless in 8 similarity - but this value is kept to simplify harder Krokiet max value calculations
+// Hash sizes below this have too few rows/columns for the structure check in
+// `hash_has_spatial_structure` to separate a degenerate hash from a simple image.
+pub(crate) const MIN_HASH_SIZE_FOR_STRUCTURE_CHECK: u8 = 16;
+// Distinct rows and columns a square hash must have to be considered to carry content.
+pub(crate) const MIN_DISTINCT_HASH_LINES: usize = 4;
+
 pub const SIMILAR_VALUES: [[u32; 6]; 4] = [
     [1, 2, 5, 7, 14, 40],    // 8
     [2, 5, 15, 30, 40, 40],  // 16

--- a/czkawka_core/src/tools/similar_images/tests.rs
+++ b/czkawka_core/src/tools/similar_images/tests.rs
@@ -328,3 +328,112 @@ fn test_similar_images_avif_solid_colors_are_all_similar_under_gradient_hash() {
     assert_eq!(info.number_of_groups, 1, "All solid-color AVIFs should be one group under gradient hash");
     assert_eq!(info.number_of_duplicates, 2);
 }
+
+#[cfg(test)]
+mod structureless_hash_tests {
+    use image::{DynamicImage, ImageBuffer, Rgb};
+    use image_hasher::{FilterType, HashAlg, HasherConfig};
+
+    use crate::tools::similar_images::SimilarImages;
+
+    // Two unrelated pictures that share only a hard light/dark vertical split. Blockhash
+    // thresholds every block against the median, so the low contrast detail inside each half
+    // never crosses it and both images hash to the same "one vertical edge" pattern.
+    fn split_tone_image(seed: u32) -> DynamicImage {
+        let buf = ImageBuffer::from_fn(256, 256, |x, y| {
+            let base = if x < 128 { 242 } else { 38 };
+            let detail = ((x * seed + y * (seed + 3)) % 11) as i32;
+            let v = (base + detail).clamp(0, 255) as u8;
+            Rgb([v, v, v])
+        });
+        DynamicImage::ImageRgb8(buf)
+    }
+
+    // Broad shapes plus fine detail and grain, so the hash varies from row to row the way it
+    // does for real pictures. A plain smooth gradient is deliberately not used here: it is
+    // itself close to structureless and would be rejected.
+    fn detailed_image(seed: u32) -> DynamicImage {
+        let buf = ImageBuffer::from_fn(256, 256, |x, y| {
+            let fx = x as f32 / 256.0;
+            let fy = y as f32 / 256.0;
+            let broad = (fx * 3.0 * seed as f32).sin() * (fy * 4.0).cos() * 60.0;
+            let fine = (fx * 37.0).sin() * (fy * 41.0 + seed as f32).cos() * 45.0;
+            let grain = f32::from(u8::try_from((x.wrapping_mul(2_654_435_761_u32.wrapping_add(seed)) ^ y.wrapping_mul(40_503)) % 64).unwrap_or_default()) - 32.0;
+            let v = (broad + fine + grain + 128.0).clamp(0.0, 255.0) as u8;
+            Rgb([v, v, v])
+        });
+        DynamicImage::ImageRgb8(buf)
+    }
+
+    fn hash_of(image: &DynamicImage, hash_size: u32) -> Vec<u8> {
+        HasherConfig::new()
+            .hash_size(hash_size, hash_size)
+            .hash_alg(HashAlg::Blockhash)
+            .resize_filter(FilterType::Lanczos3)
+            .to_hasher()
+            .hash_image(image)
+            .as_bytes()
+            .to_vec()
+    }
+
+    #[test]
+    fn unrelated_split_tone_images_collide_and_are_rejected() {
+        for hash_size in [16_u32, 32, 64] {
+            let first = hash_of(&split_tone_image(1), hash_size);
+            let second = hash_of(&split_tone_image(5), hash_size);
+
+            let distance: u32 = first.iter().zip(&second).map(|(a, b)| (a ^ b).count_ones()).sum();
+            assert_eq!(distance, 0, "unrelated split tone images should collide at hash size {hash_size}");
+
+            assert!(
+                !SimilarImages::is_hash_valid(&first, hash_size as u8),
+                "structureless hash should be rejected at hash size {hash_size}"
+            );
+        }
+    }
+
+    #[test]
+    fn detailed_images_are_kept() {
+        for hash_size in [16_u32, 32, 64] {
+            for seed in 1..=3 {
+                let hash = hash_of(&detailed_image(seed), hash_size);
+                assert!(
+                    SimilarImages::is_hash_valid(&hash, hash_size as u8),
+                    "detailed image should be kept at hash size {hash_size}, seed {seed}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn structure_check_is_skipped_for_small_hashes() {
+        // An 8x8 matrix has too few lines to distinguish a degenerate hash from a simple
+        // image, so the check must not run and must not reject anything there.
+        let hash = hash_of(&split_tone_image(1), 8);
+        assert!(SimilarImages::is_hash_valid(&hash, 8));
+    }
+
+    #[test]
+    fn uniform_hashes_are_still_rejected() {
+        assert!(!SimilarImages::is_hash_valid(&vec![0_u8; 128], 32));
+        assert!(!SimilarImages::is_hash_valid(&vec![255_u8; 128], 32));
+        assert!(!SimilarImages::is_hash_valid(&Vec::new(), 32));
+    }
+
+    #[test]
+    fn non_square_hash_layout_is_left_alone() {
+        // DoubleGradient does not produce a hash_size x hash_size matrix, so the structural
+        // check cannot interpret it and must pass it through.
+        let image = split_tone_image(1);
+        let hash = HasherConfig::new()
+            .hash_size(32, 32)
+            .hash_alg(HashAlg::DoubleGradient)
+            .resize_filter(FilterType::Lanczos3)
+            .to_hasher()
+            .hash_image(&image)
+            .as_bytes()
+            .to_vec();
+        assert_ne!(hash.len() * 8, 32 * 32, "DoubleGradient is expected to use a different layout");
+        assert!(SimilarImages::is_hash_valid(&hash, 32));
+    }
+}


### PR DESCRIPTION
Similar Images can group completely unrelated pictures as `Original`, and no setting avoids it: the images collide at Hamming distance 0, so raising the hash size or lowering Max difference does not help.

## What happens

An image made of one light region and one dark region (a sketch beside its finished version, a light and a dark colourway of the same pattern, and so on) hashes to a bit matrix whose rows are all identical.

Blockhash and Mean set each block's bit by comparing it against the median of all blocks. On a strongly bimodal image every block on the light side lands above the median and every block on the dark side below it, so the picture's own detail never crosses the threshold and contributes no bits at all. What is left encodes only the position of the split, and any two images sharing that split are identical to the hasher.

Measured on 7 such files reported by a user, hashed exactly as `SimilarImages` does (Blockhash, Lanczos3):

| hash size | max pairwise distance between the 7 unrelated images |
|---|---|
| 16 | 0 |
| 32 | 2 |
| 64 | 80 |

At 16 and 32 they are indistinguishable. At 64 they separate on their own, which is why the fix below does not need to catch them all there.

`is_hash_valid` did not stop this. It rejects a hash that is entirely `0x00` or entirely `0xFF`, but a split hash is exactly 50% ones and passes.

## The fix

Reject a hash whose bit matrix has fewer than 4 distinct rows or fewer than 4 distinct columns. A hash that degenerate carries no usable content, in the same spirit as the existing all-black / all-white check.

Two deliberate limits:

- **Only from hash size 16 up.** An 8x8 matrix has too few lines to tell a degenerate hash from a legitimately simple picture; applying the rule there rejected 0.2 to 1.7 percent of a real sample, so it is skipped.
- **Only for square layouts.** `DoubleGradient` does not produce a `hash_size x hash_size` matrix, so the check cannot interpret its bits and passes it through untouched.

## Evidence

4000 images from a personal photo and artwork library, against the 7 reported files:

| | reported files score | library minimum | caught | false rejects |
|---|---|---|---|---|
| Blockhash 16 | 1 | 7 | 7/7 | 0 / 4000 |
| Blockhash 32 | 1 to 3 | 12 | 7/7 | 0 / 4000 |
| Blockhash 64 | 1 to 18 | 25 | 3/7 | 0 / 4000 |

The library minimum stays far above the threshold of 4 at every applicable size, and nothing in the sample was rejected.

I first tried a bit-transition ratio instead. It looked convincing on 596 images but degraded to a 1.3x margin at 3928 with false rejections that grew as the sample grew, so it was dropped in favour of the structural measure above, which separates by roughly an order of magnitude.

The gradient algorithms are unaffected by the underlying problem: they compare adjacent pixels rather than a global median, so the same 7 files score 18 to 32 and never collided. Switching the hash algorithm is a usable workaround for anyone hitting this today.

Worth noting: a perfectly smooth synthetic gradient is itself close to structureless and would be rejected. That is arguably correct, since its hash carries almost nothing, but it is a behaviour change and I would rather flag it than hide it.

## Tests

Five new tests in `similar_images/tests.rs`: unrelated split-tone images collide *and* are rejected at 16/32/64; detailed images are kept; the check is skipped at hash size 8; uniform hashes are still rejected; a non-square `DoubleGradient` layout is passed through.

## Checks run locally

- `cargo fmt --all -- --check` clean
- `cargo clippy --all-targets --all-features -- -D warnings` and `cargo clippy --all-targets -- -D warnings` both clean
- `cargo test -p czkawka_core` - 241 passed, 0 failed

Local toolchain is 1.92 rather than the pinned 1.94.1, so clippy there may still see something mine did not.

Note this changes hashing behaviour but not the hash values themselves, so existing caches stay valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
