### PR TITLE
Add option to hide similar-image groups confined to one directory

### DIFF
--- a/cedinia/i18n/en/cedinia.ftl
+++ b/cedinia/i18n/en/cedinia.ftl
@@ -165,6 +165,8 @@ settings_bad_names_space = Spaces at start/end
 settings_bad_names_non_ascii = Non-ASCII characters
 settings_bad_names_duplicated = Repeated characters
 settings_ignore_same_resolution = Ignore images with the same resolution
+settings_ignore_same_directory = Hide groups found only in one directory
+settings_ignore_same_directory_desc = Groups whose images all live in the same folder (e.g. burst shots) are hidden entirely
 
 # Settings - Appearance section
 settings_appearance_label = APPEARANCE

--- a/cedinia/src/callbacks/scan.rs
+++ b/cedinia/src/callbacks/scan.rs
@@ -166,6 +166,7 @@ fn build_scan_request(win: &MainWindow, tool: ActiveTool, dirs: Vec<PathBuf>, ex
                 geometric_invariance: StringComboBoxItems::value_from_idx(&items.image_geometric_invariance, s.get_geometric_invariance_idx(), GeometricInvariance::Off),
                 ignore_same_size: s.get_ignore_same_size(),
                 ignore_same_resolution: s.get_ignore_same_resolution(),
+                ignore_same_directory: s.get_ignore_same_directory(),
                 filters,
             }
         }

--- a/cedinia/src/scan_runner.rs
+++ b/cedinia/src/scan_runner.rs
@@ -82,6 +82,7 @@ pub enum ScanRequest {
         geometric_invariance: GeometricInvariance,
         ignore_same_size: bool,
         ignore_same_resolution: bool,
+        ignore_same_directory: bool,
         filters: CommonFilters,
     },
     EmptyFiles {
@@ -244,6 +245,7 @@ fn worker_loop<H: ScanResultHandler + Sync>(req_rx: &Receiver<ScanRequest>, hand
                 geometric_invariance,
                 ignore_same_size,
                 ignore_same_resolution,
+                ignore_same_directory,
                 filters,
             } => {
                 let items = scan_similar_images(
@@ -255,6 +257,7 @@ fn worker_loop<H: ScanResultHandler + Sync>(req_rx: &Receiver<ScanRequest>, hand
                     geometric_invariance,
                     ignore_same_size,
                     ignore_same_resolution,
+                    ignore_same_directory,
                     &filters,
                     stop_flag,
                     &handler,

--- a/cedinia/src/scanners.rs
+++ b/cedinia/src/scanners.rs
@@ -189,6 +189,7 @@ pub(crate) fn scan_similar_images<H: ScanResultHandler>(
     geometric_invariance: czkawka_core::tools::similar_images::GeometricInvariance,
     ignore_same_size: bool,
     ignore_same_resolution: bool,
+    ignore_same_directory: bool,
     filters: &CommonFilters,
     stop: &Arc<AtomicBool>,
     handler: &Arc<H>,
@@ -197,7 +198,16 @@ pub(crate) fn scan_similar_images<H: ScanResultHandler>(
     use czkawka_core::tools::similar_images::{ImagesEntry, SimilarImages, SimilarImagesParameters, return_similarity_from_similarity_preset};
     let max_diff = return_similarity_from_similarity_preset(similarity_preset, hash_size);
     let (ptx, fwd) = spawn_progress_forwarder(Arc::clone(handler), scan_id);
-    let params = SimilarImagesParameters::new(max_diff, hash_size, hash_alg, image_filter, ignore_same_size, ignore_same_resolution, geometric_invariance);
+    let params = SimilarImagesParameters::new(
+        max_diff,
+        hash_size,
+        hash_alg,
+        image_filter,
+        ignore_same_size,
+        ignore_same_resolution,
+        ignore_same_directory,
+        geometric_invariance,
+    );
     let mut tool = SimilarImages::new(params);
     tool.set_included_paths(dirs);
     apply_filters(&mut tool, filters);

--- a/cedinia/src/settings/mod.rs
+++ b/cedinia/src/settings/mod.rs
@@ -109,6 +109,8 @@ pub struct CediniaSettings {
     #[serde(default)]
     pub similar_images_ignore_same_resolution: bool,
     #[serde(default)]
+    pub similar_images_ignore_same_directory: bool,
+    #[serde(default)]
     pub gallery_image_fit_cover: bool,
 
     #[serde(default = "default_search_mode")]
@@ -353,6 +355,7 @@ pub fn apply_settings_to_gui(win: &MainWindow, s: &CediniaSettings) {
 
     win.global::<SimilarImagesSettings>().set_ignore_same_size(s.similar_images_ignore_same_size);
     win.global::<SimilarImagesSettings>().set_ignore_same_resolution(s.similar_images_ignore_same_resolution);
+    win.global::<SimilarImagesSettings>().set_ignore_same_directory(s.similar_images_ignore_same_directory);
     win.global::<SimilarImagesSettings>().set_gallery_image_fit_cover(s.gallery_image_fit_cover);
 
     let sm_idx = StringComboBoxItems::idx_from_config_name(&s.big_files_search_mode, &items.biggest_files_method);
@@ -450,6 +453,7 @@ pub fn collect_settings_from_gui(win: &MainWindow) -> CediniaSettings {
         ),
         similar_images_ignore_same_size: si.get_ignore_same_size(),
         similar_images_ignore_same_resolution: si.get_ignore_same_resolution(),
+        similar_images_ignore_same_directory: si.get_ignore_same_directory(),
         gallery_image_fit_cover: si.get_gallery_image_fit_cover(),
         big_files_search_mode: items
             .biggest_files_method

--- a/cedinia/src/translations.rs
+++ b/cedinia/src/translations.rs
@@ -264,6 +264,8 @@ pub(crate) fn translate_items(app: &MainWindow) {
     t.set_ctx_open_file_text(flc!("ctx_open_file").into());
     t.set_ctx_open_folder_text(flc!("ctx_open_folder").into());
     t.set_settings_ignore_same_resolution_text(flc!("settings_ignore_same_resolution").into());
+    t.set_settings_ignore_same_directory_text(flc!("settings_ignore_same_directory").into());
+    t.set_settings_ignore_same_directory_desc_text(flc!("settings_ignore_same_directory_desc").into());
     t.set_settings_appearance_label_text(flc!("settings_appearance_label").into());
     t.set_settings_dark_theme_text(flc!("settings_dark_theme").into());
     t.set_settings_dark_theme_desc_text(flc!("settings_dark_theme_desc").into());

--- a/cedinia/ui/globals/app_state.slint
+++ b/cedinia/ui/globals/app_state.slint
@@ -58,6 +58,7 @@ export global SimilarImagesSettings {
 
     in-out property <bool>   ignore_same_size:        false;
     in-out property <bool>   ignore_same_resolution:  false;
+    in-out property <bool>   ignore_same_directory:   false;
     in-out property <bool>   gallery_image_fit_cover: true;
 }
 

--- a/cedinia/ui/globals/translations.slint
+++ b/cedinia/ui/globals/translations.slint
@@ -117,6 +117,8 @@ export global Translations {
     in-out property <string> settings_geometric_invariance_text: "Geometric invariance";
     in-out property <string> settings_ignore_same_size_text:  "Ignore images with the same dimensions";
     in-out property <string> settings_ignore_same_resolution_text: "Ignore images with the same resolution";
+    in-out property <string> settings_ignore_same_directory_text: "Hide groups found only in one directory";
+    in-out property <string> settings_ignore_same_directory_desc_text: "Groups whose images all live in the same folder (e.g. burst shots) are hidden entirely";
     in-out property <string> settings_gallery_image_fit_cover_text: "Gallery: crop to square";
     in-out property <string> settings_gallery_image_fit_cover_desc_text: "Fill the tile; disable to keep original aspect ratio";
     in-out property <string> settings_appearance_label_text:       "APPEARANCE";

--- a/cedinia/ui/screens/settings_screen.slint
+++ b/cedinia/ui/screens/settings_screen.slint
@@ -423,6 +423,13 @@ export component SettingsScreen {
                     Divider {}
 
                     ToggleRow {
+                        label: Translations.settings_ignore_same_directory_text;
+                        description: Translations.settings_ignore_same_directory_desc_text;
+                        value <=> SimilarImagesSettings.ignore_same_directory;
+                    }
+                    Divider {}
+
+                    ToggleRow {
                         label: Translations.settings_gallery_image_fit_cover_text;
                         description: Translations.settings_gallery_image_fit_cover_desc_text;
                         value <=> SimilarImagesSettings.gallery_image_fit_cover;

--- a/czkawka_cli/src/commands.rs
+++ b/czkawka_cli/src/commands.rs
@@ -323,6 +323,8 @@ pub struct SimilarImagesArgs {
     pub ignore_same_size: IgnoreSameSize,
     #[clap(flatten)]
     pub ignore_same_resolution: IgnoreSameResolution,
+    #[clap(flatten)]
+    pub ignore_same_directory: IgnoreSameDirectory,
     #[clap(
         short = 'g',
         long,
@@ -1157,6 +1159,17 @@ pub struct IgnoreSameResolution {
         long_help = "Within each similar-file group, removes entries that share a resolution (WxH) with another entry in the same group. Groups that shrink to a single entry are discarded."
     )]
     pub ignore_same_resolution: bool,
+}
+
+#[derive(Debug, clap::Args)]
+pub struct IgnoreSameDirectory {
+    #[clap(
+        short = 'Y',
+        long,
+        help = "Hide groups confined to a single directory",
+        long_help = "Discards similar-file groups whose members all live in the same directory (e.g. sequential burst-shot photos). Groups whose members span two or more directories are kept unchanged."
+    )]
+    pub ignore_same_directory: bool,
 }
 
 impl FileToSave {

--- a/czkawka_cli/src/main.rs
+++ b/czkawka_cli/src/main.rs
@@ -247,6 +247,7 @@ fn similar_images(similar_images: SimilarImagesArgs, stop_flag: &Arc<AtomicBool>
         allow_hard_links,
         ignore_same_size,
         ignore_same_resolution,
+        ignore_same_directory,
     } = similar_images;
 
     validate_file_sizes(minimal_file_size, maximal_file_size);
@@ -258,6 +259,7 @@ fn similar_images(similar_images: SimilarImagesArgs, stop_flag: &Arc<AtomicBool>
         image_filter,
         ignore_same_size.ignore_same_size,
         ignore_same_resolution.ignore_same_resolution,
+        ignore_same_directory.ignore_same_directory,
         geometric_invariance,
     );
     let mut tool = SimilarImages::new(params);

--- a/czkawka_core/src/tools/similar_images/core.rs
+++ b/czkawka_core/src/tools/similar_images/core.rs
@@ -526,6 +526,7 @@ impl SimilarImages {
 
         self.exclude_items_with_same_size();
         self.exclude_items_with_same_resolution();
+        self.exclude_items_with_same_directory();
 
         self.remove_multiple_records_from_reference_folders();
 
@@ -582,6 +583,20 @@ impl SimilarImages {
                     self.similar_vectors.push(vec_values);
                 }
             }
+        }
+    }
+
+    // Drops entire groups whose members all live in the same directory (e.g. burst-shot
+    // sequences), instead of deduplicating individual entries like the size/resolution filters
+    // above - a group is only useful here if it points across directories.
+    #[fun_time(message = "exclude_items_with_same_directory", level = "debug")]
+    fn exclude_items_with_same_directory(&mut self) {
+        if self.get_params().exclude_images_with_same_directory {
+            self.similar_vectors.retain(|vec_file_entry| {
+                let mut directories = vec_file_entry.iter().map(|file_entry| file_entry.path.parent().unwrap_or(Path::new("")));
+                let first_directory = directories.next();
+                directories.any(|directory| Some(directory) != first_directory)
+            });
         }
     }
 
@@ -934,6 +949,7 @@ mod tests {
             image_filter: FilterType::Lanczos3,
             exclude_images_with_same_size: false,
             exclude_images_with_same_resolution: false,
+            exclude_images_with_same_directory: false,
             geometric_invariance: GeometricInvariance::Off,
         }
     }
@@ -1577,7 +1593,7 @@ mod connect_results_tests {
 
     #[test]
     fn test_connect_results_real_case() {
-        let params = SimilarImagesParameters::new(10, 8, HashAlg::Gradient, FilterType::Lanczos3, false, false, GeometricInvariance::Off);
+        let params = SimilarImagesParameters::new(10, 8, HashAlg::Gradient, FilterType::Lanczos3, false, false, false, GeometricInvariance::Off);
         let _finder = SimilarImages::new(params);
 
         let hash1: ImHash = vec![59, 41, 53, 27, 19, 143, 228, 228];

--- a/czkawka_core/src/tools/similar_images/core.rs
+++ b/czkawka_core/src/tools/similar_images/core.rs
@@ -586,9 +586,6 @@ impl SimilarImages {
         }
     }
 
-    // Drops entire groups whose members all live in the same directory (e.g. burst-shot
-    // sequences), instead of deduplicating individual entries like the size/resolution filters
-    // above - a group is only useful here if it points across directories.
     #[fun_time(message = "exclude_items_with_same_directory", level = "debug")]
     fn exclude_items_with_same_directory(&mut self) {
         if self.get_params().exclude_images_with_same_directory {

--- a/czkawka_core/src/tools/similar_images/mod.rs
+++ b/czkawka_core/src/tools/similar_images/mod.rs
@@ -121,6 +121,7 @@ pub struct SimilarImagesParameters {
     pub image_filter: FilterType,
     pub exclude_images_with_same_size: bool,
     pub exclude_images_with_same_resolution: bool,
+    pub exclude_images_with_same_directory: bool,
     pub geometric_invariance: GeometricInvariance,
 }
 
@@ -132,6 +133,7 @@ impl SimilarImagesParameters {
         image_filter: FilterType,
         exclude_images_with_same_size: bool,
         exclude_images_with_same_resolution: bool,
+        exclude_images_with_same_directory: bool,
         geometric_invariance: GeometricInvariance,
     ) -> Self {
         assert!([8, 16, 32, 64].contains(&hash_size));
@@ -142,6 +144,7 @@ impl SimilarImagesParameters {
             image_filter,
             exclude_images_with_same_size,
             exclude_images_with_same_resolution,
+            exclude_images_with_same_directory,
             geometric_invariance,
         }
     }

--- a/czkawka_core/src/tools/similar_images/tests.rs
+++ b/czkawka_core/src/tools/similar_images/tests.rs
@@ -57,7 +57,7 @@ fn test_similar_images() {
     ];
 
     for (idx, (hash_alg, filter_type, hash_size, similarity, duplicates, groups, all_in_similar)) in algo_filter_hash_sim_found.into_iter().enumerate() {
-        let params = SimilarImagesParameters::new(similarity, hash_size, hash_alg, filter_type, false, false, GeometricInvariance::Off);
+        let params = SimilarImagesParameters::new(similarity, hash_size, hash_alg, filter_type, false, false, false, GeometricInvariance::Off);
 
         let mut finder = SimilarImages::new(params);
         finder.set_included_paths(vec![test_path.clone()]);
@@ -84,7 +84,7 @@ fn test_similar_images() {
 fn test_similar_images_exclude_same_size() {
     let test_path = get_test_resources_path();
 
-    let params = SimilarImagesParameters::new(10, 8, HashAlg::Gradient, FilterType::Lanczos3, true, false, GeometricInvariance::Off);
+    let params = SimilarImagesParameters::new(10, 8, HashAlg::Gradient, FilterType::Lanczos3, true, false, false, GeometricInvariance::Off);
 
     let mut finder = SimilarImages::new(params);
     finder.set_included_paths(vec![test_path]);
@@ -108,11 +108,51 @@ fn test_similar_images_exclude_same_size() {
 }
 
 #[test]
+fn test_similar_images_exclude_same_directory() {
+    let temp_dir = TempDir::new().unwrap();
+    let dir_a = temp_dir.path().join("dir_a");
+    let dir_b = temp_dir.path().join("dir_b");
+    let dir_c = temp_dir.path().join("dir_c");
+    std::fs::create_dir(&dir_a).unwrap();
+    std::fs::create_dir(&dir_b).unwrap();
+    std::fs::create_dir(&dir_c).unwrap();
+
+    // Group fully contained in dir_a - should be dropped entirely when the filter is on.
+    let base = create_asymmetric_test_image(&dir_a.join("image1.png"));
+    base.save(dir_a.join("image2.png")).expect("Failed to save second copy in dir_a");
+
+    // Group spanning dir_b and dir_c - should survive untouched (both entries kept).
+    let flipped = base.fliph();
+    flipped.save(dir_b.join("image3.png")).expect("Failed to save copy in dir_b");
+    flipped.save(dir_c.join("image4.png")).expect("Failed to save copy in dir_c");
+
+    let params = SimilarImagesParameters::new(0, 8, HashAlg::Gradient, FilterType::Lanczos3, false, false, true, GeometricInvariance::Off);
+
+    let mut finder = SimilarImages::new(params);
+    finder.set_included_paths(vec![temp_dir.path().to_path_buf()]);
+    finder.set_recursive_search(true);
+    finder.set_use_cache(false);
+
+    let stop_flag = Arc::new(AtomicBool::new(false));
+    finder.search(&stop_flag, None);
+
+    let similar_images = finder.get_similar_images();
+    let info = finder.get_information();
+
+    assert_eq!(info.number_of_groups, 1, "the dir_a-only group should have been dropped");
+    assert_eq!(similar_images.len(), 1);
+    let group = &similar_images[0];
+    assert_eq!(group.len(), 2, "the cross-directory group should be kept intact");
+    let unique_directories: std::collections::BTreeSet<_> = group.iter().map(|img| img.path.parent().unwrap().to_path_buf()).collect();
+    assert_eq!(unique_directories.len(), 2, "surviving group should span two directories");
+}
+
+#[test]
 fn test_similar_images_empty_directory() {
     let temp_dir = TempDir::new().unwrap();
     let path = temp_dir.path();
 
-    let params = SimilarImagesParameters::new(10, 8, HashAlg::Gradient, FilterType::Lanczos3, false, false, GeometricInvariance::Off);
+    let params = SimilarImagesParameters::new(10, 8, HashAlg::Gradient, FilterType::Lanczos3, false, false, false, GeometricInvariance::Off);
 
     let mut finder = SimilarImages::new(params);
     finder.set_included_paths(vec![path.to_path_buf()]);
@@ -139,7 +179,7 @@ fn test_similar_images_mirror_flip_invariance() {
     let base = create_asymmetric_test_image(&base_path);
     base.fliph().save(&flipped_path).expect("Failed to save flipped image");
 
-    let params = SimilarImagesParameters::new(0, 8, HashAlg::Gradient, FilterType::Lanczos3, false, false, GeometricInvariance::MirrorFlip);
+    let params = SimilarImagesParameters::new(0, 8, HashAlg::Gradient, FilterType::Lanczos3, false, false, false, GeometricInvariance::MirrorFlip);
     let mut finder = SimilarImages::new(params);
     finder.set_included_paths(vec![temp_dir.path().to_path_buf()]);
     finder.set_recursive_search(true);
@@ -166,7 +206,7 @@ fn test_similar_images_rotate_invariance() {
     let base = create_asymmetric_test_image(&base_path);
     base.rotate90().save(&rotated_path).expect("Failed to save rotated image");
 
-    let params = SimilarImagesParameters::new(0, 8, HashAlg::Gradient, FilterType::Lanczos3, false, false, GeometricInvariance::MirrorFlipRotate90);
+    let params = SimilarImagesParameters::new(0, 8, HashAlg::Gradient, FilterType::Lanczos3, false, false, false, GeometricInvariance::MirrorFlipRotate90);
     let mut finder = SimilarImages::new(params);
     finder.set_included_paths(vec![temp_dir.path().to_path_buf()]);
     finder.set_recursive_search(true);
@@ -209,7 +249,7 @@ fn test_similar_images_hide_hard_links() {
     }
 
     {
-        let params = SimilarImagesParameters::new(10, 8, HashAlg::Gradient, FilterType::Lanczos3, false, false, GeometricInvariance::Off);
+        let params = SimilarImagesParameters::new(10, 8, HashAlg::Gradient, FilterType::Lanczos3, false, false, false, GeometricInvariance::Off);
         let mut finder = SimilarImages::new(params);
         finder.set_hide_hard_links(true);
         finder.set_included_paths(vec![path.to_path_buf()]);
@@ -225,7 +265,7 @@ fn test_similar_images_hide_hard_links() {
     }
 
     {
-        let params = SimilarImagesParameters::new(10, 8, HashAlg::Gradient, FilterType::Lanczos3, false, false, GeometricInvariance::Off);
+        let params = SimilarImagesParameters::new(10, 8, HashAlg::Gradient, FilterType::Lanczos3, false, false, false, GeometricInvariance::Off);
         let mut finder = SimilarImages::new(params);
         finder.set_hide_hard_links(false);
         finder.set_included_paths(vec![path.to_path_buf()]);
@@ -268,7 +308,7 @@ fn test_similar_images_reference_mode_deletes_only_non_reference() {
         difference: 0,
     };
 
-    let params = SimilarImagesParameters::new(10, 8, HashAlg::Gradient, FilterType::Lanczos3, false, false, GeometricInvariance::Off);
+    let params = SimilarImagesParameters::new(10, 8, HashAlg::Gradient, FilterType::Lanczos3, false, false, false, GeometricInvariance::Off);
     let mut finder = SimilarImages::new(params);
     finder.set_delete_method(DeleteMethod::Delete);
     finder.set_move_to_trash(false);
@@ -294,7 +334,7 @@ fn get_heif_images_path() -> PathBuf {
 fn test_similar_images_avif_files_are_found() {
     let test_path = get_heif_images_path();
 
-    let params = SimilarImagesParameters::new(30, 8, HashAlg::Gradient, FilterType::Lanczos3, false, false, GeometricInvariance::Off);
+    let params = SimilarImagesParameters::new(30, 8, HashAlg::Gradient, FilterType::Lanczos3, false, false, false, GeometricInvariance::Off);
     let mut finder = SimilarImages::new(params);
     finder.set_included_paths(vec![test_path]);
     finder.set_recursive_search(false);
@@ -312,7 +352,7 @@ fn test_similar_images_avif_files_are_found() {
 fn test_similar_images_avif_striped_pattern_are_all_similar_under_gradient_hash() {
     let test_path = get_heif_images_path();
 
-    let params = SimilarImagesParameters::new(0, 8, HashAlg::Gradient, FilterType::Lanczos3, false, false, GeometricInvariance::Off);
+    let params = SimilarImagesParameters::new(0, 8, HashAlg::Gradient, FilterType::Lanczos3, false, false, false, GeometricInvariance::Off);
     let mut finder = SimilarImages::new(params);
     finder.set_included_paths(vec![test_path]);
     finder.set_recursive_search(false);

--- a/czkawka_core/src/tools/similar_images/tests.rs
+++ b/czkawka_core/src/tools/similar_images/tests.rs
@@ -117,11 +117,9 @@ fn test_similar_images_exclude_same_directory() {
     std::fs::create_dir(&dir_b).unwrap();
     std::fs::create_dir(&dir_c).unwrap();
 
-    // Group fully contained in dir_a - should be dropped entirely when the filter is on.
     let base = create_asymmetric_test_image(&dir_a.join("image1.png"));
     base.save(dir_a.join("image2.png")).expect("Failed to save second copy in dir_a");
 
-    // Group spanning dir_b and dir_c - should survive untouched (both entries kept).
     let flipped = base.fliph();
     flipped.save(dir_b.join("image3.png")).expect("Failed to save copy in dir_b");
     flipped.save(dir_c.join("image4.png")).expect("Failed to save copy in dir_c");

--- a/czkawka_gui/src/connect_things/connect_button_search.rs
+++ b/czkawka_gui/src/connect_things/connect_button_search.rs
@@ -610,6 +610,7 @@ fn similar_image_search(
                 image_filter,
                 ignore_same_size,
                 false, // Not implemented in gtk gui
+                false, // Not implemented in gtk gui
                 geometric_invariance,
             );
             let mut tool = SimilarImages::new(params);

--- a/instructions/Instruction_CLI.md
+++ b/instructions/Instruction_CLI.md
@@ -312,6 +312,7 @@ czkawka_cli image -d <dirs> [options]
 | `-i` / `--maximal-file-size` | (max) | Max size in bytes |
 | `-J` / `--ignore-same-size` | false | Skip images with identical byte size |
 | `-Z` / `--ignore-same-resolution` | false | Skip images with identical pixel dimensions |
+| `-Y` / `--ignore-same-directory` | false | Hide groups whose members all live in the same directory |
 | `-L` / `--allow-hard-links` | false | Treat hard links as separate files |
 | `-r` / `--reference-directories` | - | Reference directories |
 | `-D` / `-Q` / `-y` | | Delete method / dry-run / trash |

--- a/instructions/Instruction_Core.md
+++ b/instructions/Instruction_Core.md
@@ -292,6 +292,7 @@ let params = SimilarImagesParameters::new(
     FilterType::Nearest,
     false,                      // exclude_images_with_same_size
     false,                      // exclude_images_with_same_resolution
+    false,                      // exclude_images_with_same_directory
     GeometricInvariance::Off,   // Off | MirrorFlip | MirrorFlipRotate90
 );
 let mut tool = SimilarImages::new(params);

--- a/krokiet/i18n/en/krokiet.ftl
+++ b/krokiet/i18n/en/krokiet.ftl
@@ -214,6 +214,7 @@ subsettings_images_hash_size = Hash Size
 subsettings_images_resize_algorithm = Resize Algorithm
 subsettings_images_ignore_same_size = Ignore images with same size
 subsettings_images_ignore_same_resolution = Ignore images with same resolution
+subsettings_images_ignore_same_directory = Hide groups found only in one directory
 subsettings_images_max_difference = Max difference
 subsettings_images_geometric_invariance = Geometric invariance
 subsettings_images_duplicates_hash_type = Hash Type

--- a/krokiet/src/connect_scan/similar_images.rs
+++ b/krokiet/src/connect_scan/similar_images.rs
@@ -36,6 +36,7 @@ pub(crate) fn scan_similar_images(a: Weak<MainWindow>, sd: ScanData) {
                 resize_algorithm,
                 sd.custom_settings.similar_images_sub_ignore_same_size,
                 sd.custom_settings.similar_images_sub_ignore_same_resolution,
+                sd.custom_settings.similar_images_sub_ignore_same_directory,
                 geometric_invariance,
             );
             let mut tool = SimilarImages::new(params);

--- a/krokiet/src/connect_translation.rs
+++ b/krokiet/src/connect_translation.rs
@@ -141,6 +141,7 @@ fn translate_items(app: &MainWindow) {
     translation.set_subsettings_images_resize_algorithm_text(flk!("subsettings_images_resize_algorithm").into());
     translation.set_subsettings_images_ignore_same_size_text(flk!("subsettings_images_ignore_same_size").into());
     translation.set_subsettings_images_ignore_same_resolution_text(flk!("subsettings_images_ignore_same_resolution").into());
+    translation.set_subsettings_images_ignore_same_directory_text(flk!("subsettings_images_ignore_same_directory").into());
     translation.set_subsettings_images_max_difference_text(flk!("subsettings_images_max_difference").into());
     translation.set_subsettings_images_geometric_invariance_text(flk!("subsettings_images_geometric_invariance").into());
     translation.set_subsettings_images_duplicates_hash_type_text(flk!("subsettings_images_duplicates_hash_type").into());

--- a/krokiet/src/settings/mod.rs
+++ b/krokiet/src/settings/mod.rs
@@ -445,6 +445,7 @@ pub(crate) fn set_settings_to_gui(app: &MainWindow, custom_settings: &SettingsCu
 
     settings.set_similar_images_sub_ignore_same_size(custom_settings.similar_images_sub_ignore_same_size);
     settings.set_similar_images_sub_ignore_same_resolution(custom_settings.similar_images_sub_ignore_same_resolution);
+    settings.set_similar_images_sub_ignore_same_directory(custom_settings.similar_images_sub_ignore_same_directory);
     settings.set_similar_images_sub_max_similarity(MAX_HASH_SIZE);
     settings.set_similar_images_sub_current_similarity(custom_settings.similar_images_sub_similarity as f32);
 
@@ -684,6 +685,7 @@ pub(crate) fn collect_settings(app: &MainWindow) -> SettingsCustom {
     let similar_images_sub_geometric_invariance = combo_box_items.image_geometric_invariance.config_name.clone();
     let similar_images_sub_ignore_same_size = settings.get_similar_images_sub_ignore_same_size();
     let similar_images_sub_ignore_same_resolution = settings.get_similar_images_sub_ignore_same_resolution();
+    let similar_images_sub_ignore_same_directory = settings.get_similar_images_sub_ignore_same_directory();
     let similar_images_sub_similarity = settings.get_similar_images_sub_current_similarity().round() as i32;
 
     let duplicates_sub_check_method = combo_box_items.duplicates_check_method.config_name.clone();
@@ -835,6 +837,7 @@ pub(crate) fn collect_settings(app: &MainWindow) -> SettingsCustom {
         similar_images_sub_geometric_invariance,
         similar_images_sub_ignore_same_size,
         similar_images_sub_ignore_same_resolution,
+        similar_images_sub_ignore_same_directory,
         similar_images_sub_similarity,
         duplicates_sub_check_method,
         duplicates_sub_available_hash_type,

--- a/krokiet/src/settings/model.rs
+++ b/krokiet/src/settings/model.rs
@@ -100,6 +100,8 @@ pub struct SettingsCustom {
     pub similar_images_sub_ignore_same_size: bool,
     #[serde(default)]
     pub similar_images_sub_ignore_same_resolution: bool,
+    #[serde(default)]
+    pub similar_images_sub_ignore_same_directory: bool,
     #[serde(default = "default_image_similarity")]
     pub similar_images_sub_similarity: i32,
     #[serde(default = "default_duplicates_check_method")]

--- a/krokiet/ui/globals/settings.slint
+++ b/krokiet/ui/globals/settings.slint
@@ -72,6 +72,7 @@ export global Settings {
     in-out property <float> similar_images_sub_current_similarity: 20;
     in-out property <bool> similar_images_sub_ignore_same_size: false;
     in-out property <bool> similar_images_sub_ignore_same_resolution: false;
+    in-out property <bool> similar_images_sub_ignore_same_directory: false;
 
     // Duplicates
     in-out property <[string]> duplicates_sub_check_method: ["Hash", "Size", "Name", "Size and Name"];

--- a/krokiet/ui/globals/translations.slint
+++ b/krokiet/ui/globals/translations.slint
@@ -96,6 +96,7 @@ export global Translations {
     in-out property <string> subsettings_images_resize_algorithm_text: "Resize Algorithm";
     in-out property <string> subsettings_images_ignore_same_size_text: "Ignore images with same size";
     in-out property <string> subsettings_images_ignore_same_resolution_text: "Ignore images with same resolution";
+    in-out property <string> subsettings_images_ignore_same_directory_text: "Hide groups found only in one directory";
     in-out property <string> subsettings_images_max_difference_text: "Max difference";
     in-out property <string> subsettings_images_geometric_invariance_text: "Geometric invariance";
 

--- a/krokiet/ui/screens/tool_settings.slint
+++ b/krokiet/ui/screens/tool_settings.slint
@@ -139,6 +139,11 @@ export component ToolSettings {
                 checked <=> Settings.similar_images_sub_ignore_same_resolution;
             }
 
+            CheckBoxWrapper {
+                text: Translations.subsettings_images_ignore_same_directory_text;
+                checked <=> Settings.similar_images_sub_ignore_same_directory;
+            }
+
             Rectangle {
                 height: 4px;
             }


### PR DESCRIPTION
Similar Images search often floods results with burst-shot sequences that live entirely within a single folder. Add an opt-in filter (exclude_images_with_same_directory) that drops any result group whose members all share the same parent directory, while leaving groups that span multiple directories untouched. Wired up as a checkbox in Krokiet and Cedinia, and as -Y/--ignore-same-directory in the CLI.

Raised here but never got ack'd: https://github.com/qarmin/czkawka/issues/1361